### PR TITLE
Use build in glslangValidator functionally to generate shader include

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,13 +31,14 @@ wlroots_proj = subproject('wlroots')
 wlroots_static_dep = wlroots_proj.get_variable('wlroots_static_dep')
 
 shadercompiler = find_program('glslangValidator')
-extratool = find_program('xxd')
-shaderbuilder = find_program('src/shaderbuild.sh')
 
 spirv_shader = custom_target('shader_target',
   output : 'composite.h',
   input : 'src/composite.comp.hlsl',
-  command : [shaderbuilder, '@INPUT@', '@OUTPUT@'],
+  command : [
+    shadercompiler, '-V', '-e', 'main', '--vn',
+    'composite_spv', '@INPUT@', '-o', '@OUTPUT@'
+  ],
   install : false,
 )
 

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -520,7 +520,7 @@ int init_device()
 	
 	VkShaderModuleCreateInfo shaderModuleCreateInfo = {};
 	shaderModuleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-	shaderModuleCreateInfo.codeSize = composite_spv_len;
+	shaderModuleCreateInfo.codeSize = sizeof(composite_spv);
 	shaderModuleCreateInfo.pCode = (const uint32_t*)composite_spv;
 	
 	VkResult res = vkCreateShaderModule( device, &shaderModuleCreateInfo, nullptr, &shaderModule );

--- a/src/shaderbuild.sh
+++ b/src/shaderbuild.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-glslangValidator -e main -o composite.spv -V $1
-
-xxd -i composite.spv > $2


### PR DESCRIPTION
file.
This removes the xxd dependency.