### PR TITLE
Pointer and cursor improvements

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -566,20 +566,14 @@ MouseCursor::MouseCursor(_XDisplay *display)
 {
 }
 
-void MouseCursor::queryPositions(int &rootX, int &rootY, int &winX, int &winY)
+void MouseCursor::queryRelativePosition(int &winX, int &winY)
 {
 	Window window, child;
+	int rootX, rootY;
 	unsigned int mask;
 
 	XQueryPointer(m_display, DefaultRootWindow(m_display), &window, &child,
 				  &rootX, &rootY, &winX, &winY, &mask);
-
-}
-
-void MouseCursor::queryGlobalPosition(int &x, int &y)
-{
-	int winX, winY;
-	queryPositions(x, y, winX, winY);
 }
 
 void MouseCursor::queryButtonMask(unsigned int &mask)
@@ -669,9 +663,6 @@ void MouseCursor::constrainPosition()
 	m_scaledFocusBarriers[3] = barricade(window->a.x, root_height, window->a.x, 0);
 
 	// Make sure the cursor is somewhere in our jail
-//	int rootX, rootY;
-//	queryGlobalPosition(rootX, rootY);
-
 	if (pointerX >= window->a.width || pointerY >= window->a.height) {
 		warp(window->a.width / 2, window->a.height / 2);
 	}
@@ -685,7 +676,6 @@ void MouseCursor::move(int x, int y)
 	}
 	m_x = pointerX;
 	m_y = pointerY;
-//	fprintf (stderr, "XXX %d,%d -> %d,%d\n", x, y, pointerX, pointerY);
 
 	win *window = find_win(m_display, currentFocusWindow);
 
@@ -714,9 +704,7 @@ void MouseCursor::move(int x, int y)
 
 void MouseCursor::updatePosition()
 {
-	int x,y;
-	queryGlobalPosition(x, y);
-	move(x, y);
+	move(pointerX, pointerY);
 	checkSuspension();
 }
 
@@ -793,8 +781,8 @@ void MouseCursor::paint(win *window, struct Composite_t *pComposite,
 		return;
 	}
 
-	int rootX, rootY, winX, winY;
-	queryPositions(rootX, rootY, winX, winY);
+	int winX, winY;
+	queryRelativePosition(winX, winY);
 	move(pointerX, pointerY);
 
 	// Also need new texture

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -669,10 +669,10 @@ void MouseCursor::constrainPosition()
 	m_scaledFocusBarriers[3] = barricade(window->a.x, root_height, window->a.x, 0);
 
 	// Make sure the cursor is somewhere in our jail
-	int rootX, rootY;
-	queryGlobalPosition(rootX, rootY);
+//	int rootX, rootY;
+//	queryGlobalPosition(rootX, rootY);
 
-	if (rootX >= window->a.width || rootY >= window->a.height) {
+	if (pointerX >= window->a.width || pointerY >= window->a.height) {
 		warp(window->a.width / 2, window->a.height / 2);
 	}
 }
@@ -680,11 +680,12 @@ void MouseCursor::constrainPosition()
 void MouseCursor::move(int x, int y)
 {
 	// Some stuff likes to warp in-place
-	if (m_x == x && m_y == y) {
+	if (m_x == pointerX && m_y == pointerY) {
 		return;
 	}
-	m_x = x;
-	m_y = y;
+	m_x = pointerX;
+	m_y = pointerY;
+//	fprintf (stderr, "XXX %d,%d -> %d,%d\n", x, y, pointerX, pointerY);
 
 	win *window = find_win(m_display, currentFocusWindow);
 
@@ -794,7 +795,7 @@ void MouseCursor::paint(win *window, struct Composite_t *pComposite,
 
 	int rootX, rootY, winX, winY;
 	queryPositions(rootX, rootY, winX, winY);
-	move(rootX, rootY);
+	move(pointerX, pointerY);
 
 	// Also need new texture
 	if (!getTexture()) {

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -566,16 +566,6 @@ MouseCursor::MouseCursor(_XDisplay *display)
 {
 }
 
-void MouseCursor::queryRelativePosition(int &winX, int &winY)
-{
-	Window window, child;
-	int rootX, rootY;
-	unsigned int mask;
-
-	XQueryPointer(m_display, DefaultRootWindow(m_display), &window, &child,
-				  &rootX, &rootY, &winX, &winY, &mask);
-}
-
 void MouseCursor::queryButtonMask(unsigned int &mask)
 {
 	Window window, child;
@@ -781,9 +771,9 @@ void MouseCursor::paint(win *window, struct Composite_t *pComposite,
 		return;
 	}
 
-	int winX, winY;
-	queryRelativePosition(winX, winY);
-	move(pointerX, pointerY);
+	// We assume 'window' is as a fullscreen window always positioned at (0,0).
+	const int winX = pointerX;
+	const int winY = pointerY;
 
 	// Also need new texture
 	if (!getTexture()) {

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -52,8 +52,7 @@ private:
 	void warp(int x, int y);
 	void checkSuspension();
 
-	void queryGlobalPosition(int &x, int &y);
-	void queryPositions(int &rootX, int &rootY, int &winX, int &winY);
+	void queryRelativePosition(int &winX, int &winY);
 	void queryButtonMask(unsigned int &mask);
 
 	bool getTexture();

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -52,7 +52,6 @@ private:
 	void warp(int x, int y);
 	void checkSuspension();
 
-	void queryRelativePosition(int &winX, int &winY);
 	void queryButtonMask(unsigned int &mask);
 
 	bool getTexture();

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -14,14 +14,66 @@ int steamcompmgr_main(int argc, char **argv);
 #ifndef C_SIDE
 }
 
+#include "rendervulkan.hpp"
+
 #include <mutex>
 #include <vector>
 
 #include <wlr/render/dmabuf.h>
 
+#include <X11/extensions/Xfixes.h>
+
 struct ResListEntry_t {
 	struct wlr_surface *surf;
 	struct wlr_dmabuf_attributes attribs;
+};
+
+struct _XDisplay;
+struct _win;
+
+class MouseCursor
+{
+public:
+	explicit MouseCursor(_XDisplay *display);
+
+	int x() const;
+	int y() const;
+
+	void move(int x, int y);
+	void updatePosition();
+	void constrainPosition();
+	void resetPosition();
+
+	void paint(struct _win *window, struct Composite_t *pComposite,
+			   struct VulkanPipeline_t *pPipeline);
+	void setDirty();
+
+private:
+	void warp(int x, int y);
+	void checkSuspension();
+
+	void queryGlobalPosition(int &x, int &y);
+	void queryPositions(int &rootX, int &rootY, int &winX, int &winY);
+	void queryButtonMask(unsigned int &mask);
+
+	bool getTexture();
+
+	int m_x, m_y;
+	int m_hotspotX, m_hotspotY;
+	int m_width, m_height;
+
+	VulkanTexture_t m_texture;
+	bool m_dirty;
+	bool m_imageEmpty;
+
+	unsigned int m_lastMovedTime;
+	bool m_hideForMovement;
+
+	PointerBarrier m_scaledFocusBarriers[4];
+
+	bool m_hasPlane;
+
+	_XDisplay *m_display;
 };
 
 extern std::mutex wayland_commit_lock;

--- a/src/wlserver.c
+++ b/src/wlserver.c
@@ -38,6 +38,8 @@ struct wlserver_t wlserver;
 Display *g_XWLDpy;
 
 bool run = true;
+int pointerX = 0;
+int pointerY = 0;
 
 void sig_handler(int signal)
 {
@@ -172,6 +174,8 @@ static void wlserver_handle_pointer_motion(struct wl_listener *listener, void *d
 	{
 		wlserver_movecursor( event->unaccel_dx, event->unaccel_dy );
 
+		pointerX = wlserver.mouse_surface_cursorx;
+		pointerY = wlserver.mouse_surface_cursory;
 		wlr_seat_pointer_notify_motion( wlserver.wlr.seat, event->time_msec, wlserver.mouse_surface_cursorx, wlserver.mouse_surface_cursory );
 		wlr_seat_pointer_notify_frame( wlserver.wlr.seat );
 	}
@@ -198,7 +202,7 @@ static void wlserver_handle_touch_down(struct wl_listener *listener, void *data)
 
 		wlserver.touchdown_x = x * wlserver.mouse_focus_surface->current.width;
 		wlserver.touchdown_y = y * wlserver.mouse_focus_surface->current.height;
-		
+
 		wlserver.mouse_surface_cursorx = x * wlserver.mouse_focus_surface->current.width;
 		wlserver.mouse_surface_cursory = y * wlserver.mouse_focus_surface->current.height;
 
@@ -529,6 +533,8 @@ void wlserver_mousefocus( struct wlr_surface *wlrsurface )
 
 void wlserver_mousemotion( int x, int y, uint32_t time )
 {
+	pointerX += x;
+	pointerY += y;
 	if ( g_XWLDpy != NULL )
 	{
 		XTestFakeRelativeMotionEvent( g_XWLDpy, x, y, CurrentTime );

--- a/src/wlserver.c
+++ b/src/wlserver.c
@@ -680,15 +680,15 @@ void wlserver_mousefocus( struct wlr_surface *wlrsurface )
 	wlr_seat_pointer_notify_enter( wlserver.wlr.seat, wlrsurface, wlserver.mouse_surface_cursorx, wlserver.mouse_surface_cursory );
 }
 
-void wlserver_mousemotion( int x, int y, uint32_t time )
+void wlserver_mousemotion( int dx, int dy, uint32_t time )
 {
-	pointerX += x;
-	pointerY += y;
-	if ( g_XWLDpy != NULL )
-	{
-		XTestFakeRelativeMotionEvent( g_XWLDpy, x, y, CurrentTime );
-		XFlush( g_XWLDpy );
+	if (!wlserver.mouse_focus_surface) {
+		return;
 	}
+	wlserver_movecursor(dx, dy, dx, dy, time);
+	wlr_seat_pointer_notify_motion(wlserver.wlr.seat, time, wlserver.mouse_surface_cursorx,
+								   wlserver.mouse_surface_cursory);
+	wlr_seat_pointer_notify_frame(wlserver.wlr.seat);
 }
 
 void wlserver_mousebutton( int button, bool press, uint32_t time )

--- a/src/wlserver.c
+++ b/src/wlserver.c
@@ -669,11 +669,15 @@ void wlserver_key( uint32_t key, bool press, uint32_t time )
 void wlserver_mousefocus( struct wlr_surface *wlrsurface )
 {
 	if (wlserver.mouse_focus_surface != wlrsurface) {
+		wlr_log(WLR_DEBUG, "focus: %p -> %p (was constraint: %d)",
+				wlserver.mouse_focus_surface, wlrsurface, (bool)wlserver.wlr.constraint.active);
+
 		if (wlserver.wlr.constraint.active && wlserver.wlr.constraint.active->surface == wlrsurface)
 			wlserver_constrain_pointer(wlserver.wlr.constraint.active);
 		else
 			wlserver_constrain_pointer(NULL);
 	}
+
 	wlserver.mouse_focus_surface = wlrsurface;
 	wlserver.mouse_surface_cursorx = wlrsurface->current.width / 2.0;
 	wlserver.mouse_surface_cursory = wlrsurface->current.height / 2.0;
@@ -730,7 +734,7 @@ struct wlr_surface *wlserver_get_surface( long surfaceID )
 	
 	if ( !wlr_surface_set_role(ret, &xwayland_surface_role, NULL, NULL, 0 ) )
 	{
-		fprintf (stderr, "Failed to set xwayland surface role");
+		fprintf (stderr, "Failed to set xwayland surface role.\n");
 		return NULL;
 	}
 	

--- a/src/wlserver.h
+++ b/src/wlserver.h
@@ -9,6 +9,8 @@
 #include <wlr/backend.h>
 #include <wlr/backend/session.h>
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_pointer_constraints_v1.h>
+#include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/xwayland.h>
 
 struct wlserver_t {
@@ -27,6 +29,18 @@ struct wlserver_t {
 		struct wlr_session *session;	
 		struct wlr_seat *seat;
 		struct wlr_output *output;
+
+		struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
+		struct wl_listener relative_pointer_listener;
+
+		struct wlr_pointer_constraints_v1 *pointer_constraints;
+		struct wl_listener pointer_constraints_listener;
+
+		struct {
+			struct wlr_pointer_constraint_v1 *active;
+			pixman_region32_t confine; // invalid if active == NULL
+			struct wl_listener commit;
+		} constraint;
 	} wlr;
 	
 	struct wlr_surface *mouse_focus_surface;

--- a/src/wlserver.h
+++ b/src/wlserver.h
@@ -71,6 +71,8 @@ extern "C" {
 #endif
 	
 extern bool run;
+extern int pointerX;
+extern int pointerY;
 
 void xwayland_surface_role_commit(struct wlr_surface *wlr_surface);
 

--- a/src/wlserver.h
+++ b/src/wlserver.h
@@ -103,7 +103,7 @@ void wlserver_keyboardfocus( struct wlr_surface *surface );
 void wlserver_key( uint32_t key, bool press, uint32_t time );
 
 void wlserver_mousefocus( struct wlr_surface *wlrsurface );
-void wlserver_mousemotion( int x, int y, uint32_t time );
+void wlserver_mousemotion( int dx, int dy, uint32_t time );
 void wlserver_mousebutton( int button, bool press, uint32_t time );
 void wlserver_mousewheel( int x, int y, uint32_t time );
 


### PR DESCRIPTION
The long-term goal is to make cursor painting independent of X11 protocol.

Larger objectives here:
* Introduce MouseCursor class, better encapsulation.
* No round trip through XWayland for getting cursor position, instead just get it from global variable.
* Introduce support for relative pointer and pointer constraints protocol extensions. Fixes #19.
* Unify pointer movement code paths in drm and nested mode, simplifies logic.

Note: To get it to build I needed to add the protocol directory to wlroots top-level meson.build file. I.e.: `wlr_inc = include_directories('.', 'include', 'protocol')`. Otherwise the pointer-constraints-unstable-v1-protocol.h header file is not found. That probably comes from the static linkage.