### PR TITLE
Clean up layering loop

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -27,6 +27,7 @@ uint32_t g_nDRMFormat;
 bool g_bRotated;
 
 bool g_bUseLayers;
+bool g_bDebugLayers;
 
 static int s_drm_log = 0;
 
@@ -458,6 +459,10 @@ int init_drm(struct drm_t *drm, const char *device, const char *mode_str, unsign
 		g_nOutputWidth = drm->mode->vdisplay;
 		g_nOutputHeight = drm->mode->hdisplay;
 	}
+
+	if (g_bUseLayers) {
+		liftoff_log_init(g_bDebugLayers ? LIFTOFF_DEBUG : LIFTOFF_ERROR, NULL);
+	}
 	
 	drm->lo_device = liftoff_device_create( drm->fd );
 	drm->lo_output = liftoff_output_create( drm->lo_device, drm->crtc_id );
@@ -701,8 +706,8 @@ bool drm_can_avoid_composite( struct drm_t *drm, struct Composite_t *pComposite,
 				{
 					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_270);
 				}
-
-				if ( pPipeline->layerBindings[ i ].fbid == 0 )
+				
+				if ( pPipeline->layerBindings[ i ].fbid != 0 )
 				{
 					return false;
 				}

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -701,8 +701,8 @@ bool drm_can_avoid_composite( struct drm_t *drm, struct Composite_t *pComposite,
 				{
 					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_270);
 				}
-				
-				if ( pPipeline->layerBindings[ i ].fbid != 0 )
+
+				if ( pPipeline->layerBindings[ i ].fbid == 0 )
 				{
 					return false;
 				}

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -86,6 +86,7 @@ extern uint32_t g_nDRMFormat;
 
 extern bool g_bUseLayers;
 extern bool g_bRotated;
+extern bool g_bDebugLayers;
 
 int init_drm(struct drm_t *drm, const char *device, const char *mode_str, unsigned int vrefresh);
 int drm_atomic_commit(struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
 	
 	bool bSleepAtStartup = false;
 	
-	while ((o = getopt (argc, argv, ":R:T:w:h:W:H:r:NSvVecslnb")) != -1)
+	while ((o = getopt (argc, argv, ":R:T:w:h:W:H:r:NSvVecsdlnb")) != -1)
 	{
 		switch (o) {
 			case 'w':
@@ -82,6 +82,9 @@ int main(int argc, char **argv)
 				break;
 			case 'l':
 				g_bUseLayers = true;
+				break;
+			case 'd':
+				g_bDebugLayers = true;
 				break;
 			case 'n':
 				g_bFilterGameWindow = false;


### PR DESCRIPTION
When trying the layering I first failed on an assert. That's the second patch.

Then there was a second problem that as soon as I started a game (CS GO) the screen became black. I noticed that if I reset all values of layers that were used in the past but not anymore the game was shown after a certain amount of time.

The reason: as soon as the mouse cursor and the info message in right lower corner was hidden it showed. The cursor or the info message were on a second layer. Whenever there are more than one layer the layer below becomes black. This could be a bug in libliftoff or the kernel driver (tested with RX 5700 XT).

Resetting all values for now is part of the first patch, which does also overall tidy up the loop a bit and adds some verbose debug statements for the loop that can be activated via command line parameter.