### PR TITLE
Support for cursor on cursor plane

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -359,6 +359,19 @@ int init_drm(struct drm_t *drm, const char *device, const char *mode_str, unsign
 		printf("could not find mode!\n");
 		return -1;
 	}
+
+	/* find preferred cursor width, height */
+	drm->cursor_width = 64;
+	drm->cursor_height = 64;
+	uint64_t cap;
+	if (drmGetCap(drm->fd, DRM_CAP_CURSOR_WIDTH, &cap) == 0) {
+		printf("Got drm cursor width: %lu\n", cap);
+		drm->cursor_width = cap;
+	}
+	if (drmGetCap(drm->fd, DRM_CAP_CURSOR_HEIGHT, &cap) == 0) {
+		printf("Got drm cursor height: %lu\n", cap);
+		drm->cursor_height = cap;
+	}
 	
 	/* find encoder: */
 	for (i = 0; i < resources->count_encoders; i++) {

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -474,7 +474,7 @@ int init_drm(struct drm_t *drm, const char *device, const char *mode_str, unsign
 		drm->lo_layers[ i ] = liftoff_layer_create( drm->lo_output );
 		assert( drm->lo_layers[ i ] );
 	}
-	
+	liftoff_output_set_composition_layer(drm->lo_output, drm->lo_layers[ 0 ]);
 	drm->flipcount = 0;
 	
 	return 0;

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -712,7 +712,10 @@ bool drm_can_avoid_composite( struct drm_t *drm, struct Composite_t *pComposite,
 				drm->fbids_in_req.push_back( pPipeline->layerBindings[ i ].fbid );
 
 				liftoff_layer_set_property( drm->lo_layers[ i ], "zpos", pPipeline->layerBindings[ i ].zpos );
-				liftoff_layer_set_property( drm->lo_layers[ i ], "alpha", pComposite->layers[ i ].flOpacity * 0xffff);
+
+				if (pComposite->layers[ i ].flOpacity < 1.) {
+					liftoff_layer_set_property( drm->lo_layers[ i ], "alpha", pComposite->layers[ i ].flOpacity * 0xffff);
+				}
 
 				if ( pPipeline->layerBindings[ i ].zpos == 0 )
 				{

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -56,6 +56,9 @@ struct drm_t {
 	
 	drmModeAtomicReq *req;
 	uint32_t flags;
+
+	uint64_t cursor_width;
+	uint64_t cursor_height;
 	
 	struct liftoff_device *lo_device;
 	struct liftoff_output *lo_output;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ uint32_t g_nOutputWidth = 1280;
 uint32_t g_nOutputHeight = 720;
 int g_nOutputRefresh = 60;
 
+bool g_bDumbDrmCursor = true;
 bool g_bIsNested = false;
 
 bool g_bFilterGameWindow = true;
@@ -59,7 +60,7 @@ int main(int argc, char **argv)
 	
 	bool bSleepAtStartup = false;
 	
-	while ((o = getopt (argc, argv, ":R:T:w:h:W:H:r:NSvVecsdlnb")) != -1)
+	while ((o = getopt (argc, argv, ":R:T:w:h:W:H:r:NSvVecsdlnbC")) != -1)
 	{
 		switch (o) {
 			case 'w':
@@ -91,6 +92,9 @@ int main(int argc, char **argv)
 				break;
 			case 'b':
 				g_bBorderlessOutputWindow = true;
+				break;
+			case 'C':
+				g_bDumbDrmCursor = false;
 				break;
 			default:
 				break;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -21,6 +21,8 @@ extern int g_nNestedWidth;
 extern int g_nNestedHeight;
 extern int g_nNestedRefresh;
 
+extern bool g_bDumbDrmCursor;
+
 extern uint32_t g_nOutputWidth;
 extern uint32_t g_nOutputHeight;
 extern int g_nOutputRefresh;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -61,7 +61,7 @@ class CVulkanTexture
 public:
 	bool BInit(uint32_t width, uint32_t height, VkFormat format, bool bFlippable, bool bTextureable, wlr_dmabuf_attributes *pDMA = nullptr );
 	
-	~CVulkanTexture( void );
+	virtual ~CVulkanTexture( void );
 	
 	bool m_bInitialized = false;
 
@@ -80,6 +80,17 @@ public:
 	VulkanTexture_t handle = 0;
 };
 
+class CVulkanCursorTexture : public CVulkanTexture
+{
+public:
+	~CVulkanCursorTexture( void ) override;
+
+	bool BInit(uint32_t width, uint32_t height, bool useDmabufForFlips);
+
+	uint64_t m_memorySize = 0;
+	void *m_memory = nullptr;
+};
+
 extern std::vector< const char * > g_vecSDLInstanceExts;
 
 #endif
@@ -88,6 +99,7 @@ int vulkan_init(void);
 
 VulkanTexture_t vulkan_create_texture_from_dmabuf( struct wlr_dmabuf_attributes *pDMA );
 VulkanTexture_t vulkan_create_texture_from_bits( uint32_t width, uint32_t height, VkFormat format, void *bits );
+VulkanTexture_t vulkan_create_cursor_texture(uint32_t width, uint32_t height, uint32_t *pixels , uint32_t *fbid);
 
 uint32_t vulkan_get_texture_fence( VulkanTexture_t vulkanTex );
 void vulkan_wait_for_fence( uint32_t );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -723,9 +723,6 @@ bool MouseCursor::getTexture()
 	m_hotspotX = image->xhot;
 	m_hotspotY = image->yhot;
 
-	m_width = image->width;
-	m_height = image->height;
-
 	if (m_texture) {
 		vulkan_free_texture(m_texture);
 		m_texture = 0;
@@ -734,12 +731,27 @@ bool MouseCursor::getTexture()
 	// Assume the cursor is fully translucent unless proven otherwise.
 	bool bNoCursor = true;
 
-	unsigned int cursorDataBuffer[m_width * m_height];
-	for (int i = 0; i < m_width * m_height; i++) {
-		cursorDataBuffer[i] = image->pixels[i];
+	m_width = image->width;
+	m_height = image->height;
 
-		if ( cursorDataBuffer[i] & 0x000000ff ) {
-			bNoCursor = false;
+	if ( BIsNested() == false && alwaysComposite == False )
+	{
+		m_width = g_DRM.cursor_width;
+		m_height = g_DRM.cursor_height;
+	}
+
+	uint32_t cursorDataBuffer[m_width * m_height] = {0};
+
+	for (int i = 0; i < image->height; i++)
+	{
+		for (int j = 0; j < image->width; j++)
+		{
+			cursorDataBuffer[i * m_width + j] = image->pixels[i * image->width + j];
+
+			if ( cursorDataBuffer[i * m_width + j] & 0x000000ff )
+			{
+				bNoCursor = false;
+			}
 		}
 	}
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -562,6 +562,7 @@ MouseCursor::MouseCursor(_XDisplay *display)
 	, m_imageEmpty(false)
 	, m_hideForMovement(true)
 	, m_hasPlane(false)
+	, m_fbId(0)
 	, m_display(display)
 {
 }
@@ -767,8 +768,8 @@ bool MouseCursor::getTexture()
 		return false;
 	}
 
-	m_texture = vulkan_create_texture_from_bits(m_width, m_height, VK_FORMAT_R8G8B8A8_UNORM,
-												cursorDataBuffer);
+	m_texture = vulkan_create_cursor_texture(m_width, m_height, cursorDataBuffer,
+											 g_bDumbDrmCursor ? &m_fbId : nullptr);
 	assert(m_texture);
 	XFree(image);
 	m_dirty = false;
@@ -834,7 +835,7 @@ void MouseCursor::paint(win *window, struct Composite_t *pComposite,
 
 	pPipeline->layerBindings[ curLayer ].tex = m_texture;
 	pPipeline->layerBindings[ curLayer ].fbid = BIsNested() ? 0 :
-															  vulkan_texture_get_fbid(m_texture);
+											m_fbId ? m_fbId : vulkan_texture_get_fbid(m_texture);
 
 	pPipeline->layerBindings[ curLayer ].bFilter = false;
 	pPipeline->layerBindings[ curLayer ].bBlackBorder = false;

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -70,6 +70,7 @@ private:
 	PointerBarrier m_scaledFocusBarriers[4];
 
 	bool m_hasPlane;
+	uint32_t m_fbId;
 
 	_XDisplay *m_display;
 };


### PR DESCRIPTION
This adds fixes to put the cursor reliable on a cursor plane.

In the past the cursor was always put on overlay plane because the alpha property was indiscriminately set forcing it to an overlay plane.

When actually putting the cursor on the cursor plane the image is scrambled. The issue was identified to originate from the Vulkan texture via dmabuf to DRM pipeline.

A solution for that must yet be found if such a solution appears desirable but this PR for now adds a robust second path to the currently broken dmabuf based cursor buffers on cursor plane one: dumb DRM cursor buffers on cursor plane.

Both paths are still available and can be selected via command line option such that In the future it can still be tried to repair the dmabuf based path or if it is decided to just only use the dumb DRM buffer path, the switch can be removed.

I tested this series with a Konsole window opened where it works without any issues. It also works in general in a Steam session but there are still issues with overlay planes when opening a game. I suspect these to be unrelated to the patches here though and believe there need to be fixes to libliftoff to make them disappear.