### PR TITLE
Fix alloc-dealloc-mismatch for win objects

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1740,7 +1740,7 @@ finish_destroy_win (Display *dpy, Window id, Bool gone)
 				XDamageDestroy (dpy, w->damage);
 				w->damage = None;
 			}
-			free (w);
+			delete w;
 			break;
 		}
 }


### PR DESCRIPTION
win objects are allocated with `new`, so they need to be de-allocated
with `delete` instead of `free`.

    ==589398==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free) on 0x61200017f140
    (EE) failed to read Wayland events: Broken pipe
    X connection to :1 broken (explicit kill or server shutdown).
        #0 0x7f5468ae4720 in __interceptor_free /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:122
        #1 0x559820f5c9a0 in finish_destroy_win ../src/steamcompmgr.cpp:1743
        #2 0x559820f5ca6d in destroy_win ../src/steamcompmgr.cpp:1759
        #3 0x559820f6163e in steamcompmgr_main ../src/steamcompmgr.cpp:2288
        #4 0x559820f8e977 in steamCompMgrThreadRun() ../src/main.cpp:121
        #5 0x559820f8e3e9 in void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/include/c++/9.3.0/bits/invoke.h:60
        #6 0x559820f8e24f in std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/include/c++/9.3.0/bits/invoke.h:95
        #7 0x559820f8e0b3 in void std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/9.3.0/thread:244
        #8 0x559820f8dfae in std::thread::_Invoker<std::tuple<void (*)()> >::operator()() /usr/include/c++/9.3.0/thread:251
        #9 0x559820f8d7ba in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() /usr/include/c++/9.3.0/thread:195
        #10 0x7f5468006b23 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80
        #11 0x7f546745346e in start_thread (/usr/lib/libpthread.so.0+0x946e)
        #12 0x7f54673833d2 in clone (/usr/lib/libc.so.6+0xff3d2)

    0x61200017f140 is located 0 bytes inside of 296-byte region [0x61200017f140,0x61200017f268)
    allocated by thread T40 here:
        #0 0x7f5468ae6968 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cc:104
        #1 0x559820f595fe in add_win ../src/steamcompmgr.cpp:1548
        #2 0x559820f614e8 in steamcompmgr_main ../src/steamcompmgr.cpp:2278
        #3 0x559820f8e977 in steamCompMgrThreadRun() ../src/main.cpp:121
        #4 0x559820f8e3e9 in void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/include/c++/9.3.0/bits/invoke.h:60
        #5 0x559820f8e24f in std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/include/c++/9.3.0/bits/invoke.h:95
        #6 0x559820f8e0b3 in void std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/9.3.0/thread:244
        #7 0x559820f8dfae in std::thread::_Invoker<std::tuple<void (*)()> >::operator()() /usr/include/c++/9.3.0/thread:251
        #8 0x559820f8d7ba in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() /usr/include/c++/9.3.0/thread:195
        #9 0x7f5468006b23 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80

    Thread T40 created by T0 here:
        #0 0x7f5468a0e377 in __interceptor_pthread_create /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cc:208
        #1 0x7f5468006df9 in __gthread_create /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663
        #2 0x7f5468006df9 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:135
        #3 0x559820f8ea10 in startSteamCompMgr ../src/main.cpp:126
        #4 0x559820f95cfb in xwayland_ready ../src/wlserver.c:119
        #5 0x5598210de191 in wlr_signal_emit_safe ../subprojects/wlroots/util/signal.c:29
        #6 0x559820ff596b in xserver_handle_ready ../subprojects/wlroots/xwayland/xwayland.c:251
        #7 0x7f5468744434  (/usr/lib/libwayland-server.so.0+0xa434)
        #8 0x7ffc9796869f  ([stack]+0x1f69f)