### PR TITLE
WIP: Hold client buffers when scanning out via KMS

### DIFF
--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -65,6 +65,7 @@ struct drm_t {
 	std::vector < uint32_t > fbids_on_screen;
 	
 	std::unordered_map< uint32_t, std::pair< bool, std::atomic< uint32_t > > > map_fbid_inflightflips;
+	std::unordered_map< uint32_t, struct wlr_buffer * > map_fbid_buf;
 	std::mutex free_queue_lock;
 	std::vector< uint32_t > fbid_free_queue;
 	
@@ -90,7 +91,7 @@ extern bool g_bDebugLayers;
 
 int init_drm(struct drm_t *drm, const char *device, const char *mode_str, unsigned int vrefresh);
 int drm_atomic_commit(struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline );
-uint32_t drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_dmabuf_attributes *dma_buf );
+uint32_t drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_buffer *buf, struct wlr_dmabuf_attributes *dma_buf );
 void drm_free_fbid( struct drm_t *drm, uint32_t fbid );
 bool drm_can_avoid_composite( struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,14 +172,14 @@ int initOutput(void)
 	}
 }
 
-void wayland_commit(struct wlr_surface *surf, struct wlr_dmabuf_attributes *attribs)
+void wayland_commit(struct wlr_surface *surf, struct wlr_buffer *buf)
 {
 	{
 		std::lock_guard<std::mutex> lock( wayland_commit_lock );
 		
 		ResListEntry_t newEntry = {
 			.surf = surf,
-			.attribs = *attribs
+			.buf = buf,
 		};
 		wayland_commit_queue.push_back( newEntry );
 	}

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -15,7 +15,7 @@ void startSteamCompMgr(void);
 
 void register_signal(void);
 
-void wayland_commit(struct wlr_surface *surf, struct wlr_dmabuf_attributes *attribs);
+void wayland_commit(struct wlr_surface *surf, struct wlr_buffer *buf);
 
 extern int g_nNestedWidth;
 extern int g_nNestedHeight;

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -3,6 +3,9 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+
+#include <wlr/render/dmabuf.h>
+#include <wlr/types/wlr_buffer.h>
 	
 extern uint32_t currentOutputWidth;
 extern uint32_t currentOutputHeight;
@@ -19,13 +22,11 @@ int steamcompmgr_main(int argc, char **argv);
 #include <mutex>
 #include <vector>
 
-#include <wlr/render/dmabuf.h>
-
 #include <X11/extensions/Xfixes.h>
 
 struct ResListEntry_t {
 	struct wlr_surface *surf;
-	struct wlr_dmabuf_attributes attribs;
+	struct wlr_buffer *buf;
 };
 
 struct _XDisplay;

--- a/src/wlserver.c
+++ b/src/wlserver.c
@@ -71,21 +71,15 @@ const struct wlr_surface_role xwayland_surface_role;
 
 void xwayland_surface_role_commit(struct wlr_surface *wlr_surface) {
 	assert(wlr_surface->role == &xwayland_surface_role);
-	
-	struct wlr_texture *tex = wlr_surface_get_texture( wlr_surface );
 
-	if ( tex == NULL )
-	{
+	if (wlr_surface->buffer == NULL) {
 		return;
 	}
+
+	struct wlr_buffer *buf = wlr_buffer_lock(&wlr_surface->buffer->base);
 	
 	struct wlr_dmabuf_attributes dmabuf_attribs = {};
-	bool result = False;
-	result = wlr_texture_to_dmabuf( tex, &dmabuf_attribs );
-	
-	assert( result == true );
-	if ( result == false || dmabuf_attribs.fd[0] == -1 )
-	{
+	if (!wlr_buffer_get_dmabuf( buf, &dmabuf_attribs ) || dmabuf_attribs.n_planes != 1) {
 		struct timespec now;
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		
@@ -95,7 +89,7 @@ void xwayland_surface_role_commit(struct wlr_surface *wlr_surface) {
 	
 	gpuvis_trace_printf( "xwayland_surface_role_commit wlr_surface %p\n", wlr_surface );
 	
-	wayland_commit( wlr_surface, &dmabuf_attribs );
+	wayland_commit( wlr_surface, buf );
 }
 
 static void xwayland_surface_role_precommit(struct wlr_surface *wlr_surface) {

--- a/src/wlserver.h
+++ b/src/wlserver.h
@@ -67,10 +67,14 @@ extern struct wlserver_t wlserver;
 #ifndef C_SIDE
 extern "C" {
 #endif
-	
+
+#include <wlr/types/wlr_buffer.h>
+
 extern bool run;
 
 extern int g_nTouchClickMode;
+
+extern pthread_mutex_t waylock;
 
 void xwayland_surface_role_commit(struct wlr_surface *wlr_surface);
 


### PR DESCRIPTION
We need to release the `wlr_buffer` objects from the DRM side. Currently `waylock` is used but that's not great.