### PR TITLE
Don't use VK_STRUCTURE_TYPE_WSI_IMAGE_CREATE_INFO_MESA for imported DMA-BUFs

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -246,10 +246,9 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, VkFormat format, bo
 		assert( format == DRMFormatToVulkan( pDMA->format ) );
 	}
 	
-	if ( bFlippable == true || pDMA != nullptr )
+	if ( bFlippable == true )
 	{
-		// Either we're scanning out the image, or if we're importing them, they got
-		// allocated with scanout in mind by their original WSI.
+		// We want to scan-out the image
 		wsiImageCreateInfo.sType = VK_STRUCTURE_TYPE_WSI_IMAGE_CREATE_INFO_MESA;
 		wsiImageCreateInfo.scanout = VK_TRUE;
 		wsiImageCreateInfo.pNext = imageInfo.pNext;


### PR DESCRIPTION
We don't know whether clients create scanout-able DMA-BUFs.

Depends on https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/4885

Closes: https://github.com/Plagman/gamescope/issues/40