### PR TITLE
Get DMA-BUF from wlr_buffer if possible

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -86,7 +86,15 @@ void xwayland_surface_role_commit(struct wlr_surface *wlr_surface) {
 	
 	struct wlr_dmabuf_attributes dmabuf_attribs = {};
 	bool result = False;
-	result = wlr_texture_to_dmabuf( tex, &dmabuf_attribs );
+	if ( wlr_buffer_get_dmabuf( &wlr_surface->buffer->base, &dmabuf_attribs ) ) {
+		result = true;
+		for ( int i = 0; i < dmabuf_attribs.n_planes; i++ ) {
+			dmabuf_attribs.fd[i] = dup( dmabuf_attribs.fd[i] );
+			assert( dmabuf_attribs.fd[i] >= 0 );
+		}
+	} else {
+		result = wlr_texture_to_dmabuf( tex, &dmabuf_attribs );
+	}
 	assert( result == true );
 	
 	gpuvis_trace_printf( "xwayland_surface_role_commit wlr_surface %p\n", wlr_surface );


### PR DESCRIPTION
wlr_texture_to_dmabuf involves issuing EGL commands to get a DMA-BUF out
of an EGLImage.

When the client submits a DMA-BUF via the linux-dmabuf protocol, there's
no need to go through EGL. We can directly import the client's DMA-BUF
into Vulkan.

The old code is still retained as a fallback in case the client uses
wl_drm (old Xwayland) or wl_shm. Removing it would involve creating a
Vulkan-based wlr_renderer.

References: https://github.com/Plagman/gamescope/issues/16