### PR TITLE
hack: paint latest updated surface on virtual output

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1165,6 +1165,10 @@ paint_all(Display *dpy, MouseCursor *cursor)
 		drm_atomic_commit( &g_DRM, &composite, &pipeline );
 	}
 
+	wlserver_lock();
+	wlserver_draw();
+	wlserver_unlock();
+
 	gpuvis_trace_printf( "paint_all end_ctx=%llu\n", paintID );
 	gpuvis_trace_printf( "paint_all %i layers, composite %i\n", (int)composite.nLayerCount, bDoComposite );
 }

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -82,3 +82,5 @@ void wlserver_send_frame_done( struct wlr_surface *surf, const struct timespec *
 struct wlr_surface *wlserver_get_surface( long surfaceID );
 
 const char *wlserver_get_nested_display( void );
+
+void wlserver_draw( void );


### PR DESCRIPTION
Not meant to be merged.

This is a hack to paint the latest updated surface on a virtual output using wlroots' Wayland backend and OpenGL. This can be used to understand whether our Vulkan codepath is buggy, or whether the issue lies somewhere else.