### PR TITLE
Fix segfault on exit

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2215,6 +2215,13 @@ error (Display *dpy, XErrorEvent *ev)
 	return 0;
 }
 
+static int
+handle_io_error(Display *dpy)
+{
+	fprintf(stderr, "X11 I/O error\n");
+	pthread_exit(NULL);
+}
+
 static Bool
 register_cm (Display *dpy)
 {
@@ -2464,6 +2471,7 @@ steamcompmgr_main (int argc, char **argv)
 		exit (1);
 	}
 	XSetErrorHandler (error);
+	XSetIOErrorHandler (handle_io_error);
 	if (synchronize)
 		XSynchronize (dpy, 1);
 	scr = DefaultScreen (dpy);


### PR DESCRIPTION
Hitting this one now:

```
=================================================================
==112992==ERROR: AddressSanitizer: heap-use-after-free on address 0x618000019cb0 at pc 0x7ffa5a1270a6 bp 0x7ffa4217b890 sp 0x7ffa4217b038
WRITE of size 16 at 0x618000019cb0 thread T20
    #0 0x7ffa5a1270a5 in __interceptor_clock_gettime /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:2173
    #1 0x5589cd94fb22 in wlr_seat_keyboard_notify_key ../subprojects/wlroots/types/seat/wlr_seat_keyboard.c:336
    #2 0x5589cd8690f1 in wlserver_key(unsigned int, bool, unsigned int) ../src/wlserver.cpp:568
    #3 0x5589cd88b1d5 in inputSDLThreadRun() ../src/inputsdl.cpp:414
    #4 0x5589cd85c7b3 in void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr/include/c++/10.2.0/bits/invoke.h:60
    #5 0x5589cd85c61d in std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /usr/include/c++/10.2.0/bits/invoke.h:95
    #6 0x5589cd85c4db in void std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/include/c++/10.2.0/thread:264
    #7 0x5589cd85c39e in std::thread::_Invoker<std::tuple<void (*)()> >::operator()() /usr/include/c++/10.2.0/thread:271
    #8 0x5589cd85bb1c in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() /usr/include/c++/10.2.0/thread:215
    #9 0x7ffa59980c23 in execute_native_thread_routine /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80
    #10 0x7ffa58dc83e8 in start_thread (/usr/lib/libpthread.so.0+0x93e8)
    #11 0x7ffa58cf6292 in __GI___clone (/usr/lib/libc.so.6+0x100292)

0x618000019cb0 is located 48 bytes inside of 872-byte region [0x618000019c80,0x618000019fe8)
freed by thread T0 here:
    #0 0x7ffa5a1980e9 in __interceptor_free /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:123
    #1 0x5589cd957cc7 in wlr_seat_destroy ../subprojects/wlroots/types/seat/wlr_seat.c:191
    #2 0x5589cd957d20 in handle_display_destroy ../subprojects/wlroots/types/seat/wlr_seat.c:197
    #3 0x7ffa59e9ce0e  (/usr/lib/libwayland-server.so.0+0x8e0e)

previously allocated by thread T0 here:
    #0 0x7ffa5a198639 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x5589cd957d43 in wlr_seat_create ../subprojects/wlroots/types/seat/wlr_seat.c:201
    #2 0x5589cd868a90 in wlserver_init(int, char**, bool) ../src/wlserver.cpp:474
    #3 0x5589cd85cdd5 in main ../src/main.cpp:113
    #4 0x7ffa58c1e151 in __libc_start_main (/usr/lib/libc.so.6+0x28151)

Thread T20 created by T0 here:
    #0 0x7ffa5a13e1c7 in __interceptor_pthread_create /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cpp:214
    #1 0x7ffa59980ef9 in __gthread_create /build/gcc/src/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663
    #2 0x7ffa59980ef9 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:135
    #3 0x5589cd88b4ad in inputsdl_init() ../src/inputsdl.cpp:445
    #4 0x5589cd85d084 in initOutput() ../src/main.cpp:141
    #5 0x5589cd85cdda in main ../src/main.cpp:115
    #6 0x7ffa58c1e151 in __libc_start_main (/usr/lib/libc.so.6+0x28151)

SUMMARY: AddressSanitizer: heap-use-after-free /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:2173 in __interceptor_clock_gettime
Shadow bytes around the buggy address:
  0x0c307fffb340: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c307fffb350: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c307fffb360: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c307fffb370: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa
  0x0c307fffb380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c307fffb390: fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd fd
  0x0c307fffb3a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c307fffb3b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c307fffb3c0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c307fffb3d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c307fffb3e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==112992==ABORTING
```