### PR TITLE
Eliminate usage of `gettimeofday`

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -396,20 +396,17 @@ static inline void stats_printf( const char* format, ...)
 	}
 }
 
-unsigned int
-get_time_in_milliseconds (void)
-{
-	struct timeval  tv;
-
-	gettimeofday (&tv, NULL);
-	return tv.tv_sec * 1000 + tv.tv_usec / 1000;
-}
-
 uint64_t get_time_in_nanos()
 {
 	timespec ts;
 	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
 	return ts.tv_sec * 1000000000ul + ts.tv_nsec;
+}
+
+unsigned int
+get_time_in_milliseconds (void)
+{
+	return (unsigned int)(get_time_in_nanos() / 1000000ul);
 }
 
 static std::atomic<uint64_t> g_lastvblank = { 0lu };

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -32,6 +32,7 @@
 #include <thread>
 #include <condition_variable>
 #include <mutex>
+#include <atomic>
 #include <vector>
 
 #include <assert.h>
@@ -404,14 +405,18 @@ get_time_in_milliseconds (void)
 	return tv.tv_sec * 1000 + tv.tv_usec / 1000;
 }
 
-struct timeval lastvblankmsgtv;
-std::mutex lastvblankmsgtv_lock;
+uint64_t get_time_in_nanos()
+{
+	timespec ts;
+	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+	return ts.tv_sec * 1000000000ul + ts.tv_nsec;
+}
+
+static std::atomic<uint64_t> g_lastvblank = { 0lu };
 
 void mark_vblank_message_time ( void )
 {
-	std::lock_guard<std::mutex> lock( lastvblankmsgtv_lock );
-
-	gettimeofday( &lastvblankmsgtv, NULL );
+	g_lastvblank = get_time_in_nanos();
 }
 
 static void
@@ -2840,18 +2845,12 @@ steamcompmgr_main (int argc, char **argv)
 
 					if ( ev.xclient.data.l[0] == 24 && ev.xclient.data.l[1] == 8 )
 					{
-						// Message from vblankmanager
-						std::lock_guard<std::mutex> lock( lastvblankmsgtv_lock );
-
-						struct timeval vblankmsgreceivedtv = {};
-						gettimeofday( &vblankmsgreceivedtv, nullptr );
-
-						struct timeval timediff = {};
-
-						timersub( &vblankmsgreceivedtv, &lastvblankmsgtv, &timediff );
+						uint64_t vblanktime = g_lastvblank;
+						uint64_t vblankreceived = get_time_in_nanos();
+						uint64_t diff = vblankreceived - vblanktime;
 
 						// give it 1 ms of slack.. maybe too long
-						if ( timediff.tv_sec != 0 || timediff.tv_usec > 1000 )
+						if ( diff > 1000000ul )
 						{
 							gpuvis_trace_printf( "ignored stale vblank\n" );
 						}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -172,7 +172,7 @@ bool			hasRepaint = false;
 
 unsigned long	damageSequence = 0;
 
-#define			CURSOR_HIDE_TIME 10000
+#define			CURSOR_HIDE_TIME 10'000
 
 Bool			gotXError = False;
 
@@ -400,13 +400,13 @@ uint64_t get_time_in_nanos()
 {
 	timespec ts;
 	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-	return ts.tv_sec * 1000000000ul + ts.tv_nsec;
+	return ts.tv_sec * 1'000'000'000ul + ts.tv_nsec;
 }
 
 unsigned int
 get_time_in_milliseconds (void)
 {
-	return (unsigned int)(get_time_in_nanos() / 1000000ul);
+	return (unsigned int)(get_time_in_nanos() / 1'000'000ul);
 }
 
 static std::atomic<uint64_t> g_lastvblank = { 0lu };
@@ -2847,7 +2847,7 @@ steamcompmgr_main (int argc, char **argv)
 						uint64_t diff = vblankreceived - vblanktime;
 
 						// give it 1 ms of slack.. maybe too long
-						if ( diff > 1000000ul )
+						if ( diff > 1'000'000ul )
 						{
 							gpuvis_trace_printf( "ignored stale vblank\n" );
 						}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2944,6 +2944,9 @@ steamcompmgr_main (int argc, char **argv)
 				hasRepaint = false;
 			}
 
+			// TODO: Look into making this _RAW
+			// wlroots, seems to just use normal MONOTONIC
+			// all over so this may be problematic to just change.
 			struct timespec now;
 			clock_gettime(CLOCK_MONOTONIC, &now);
 


### PR DESCRIPTION
``gettimeofday`` is expensive and suffers from NTP drift which means we could miss vblank on time updates.

