### PR TITLE
Encode vblank time in message and vblankmanager cleanup

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -403,6 +403,22 @@ uint64_t get_time_in_nanos()
 	return ts.tv_sec * 1'000'000'000ul + ts.tv_nsec;
 }
 
+void sleep_for_nanos(uint64_t nanos)
+{
+	timespec ts;
+	ts.tv_sec = time_t(nanos / 1'000'000'000ul);
+	ts.tv_nsec = long(nanos % 1'000'000'000ul);
+	nanosleep(&ts, nullptr);
+}
+
+void sleep_until_nanos(uint64_t nanos)
+{
+	uint64_t now = get_time_in_nanos();
+	if (now >= nanos)
+		return;
+	sleep_for_nanos(nanos - now);
+}
+
 unsigned int
 get_time_in_milliseconds (void)
 {

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -409,13 +409,6 @@ get_time_in_milliseconds (void)
 	return (unsigned int)(get_time_in_nanos() / 1'000'000ul);
 }
 
-static std::atomic<uint64_t> g_lastvblank = { 0lu };
-
-void mark_vblank_message_time ( void )
-{
-	g_lastvblank = get_time_in_nanos();
-}
-
 static void
 discard_ignore (Display *dpy, unsigned long sequence)
 {
@@ -2830,7 +2823,9 @@ steamcompmgr_main (int argc, char **argv)
 
 					if ( ev.xclient.data.l[0] == 24 && ev.xclient.data.l[1] == 8 )
 					{
-						uint64_t vblanktime = g_lastvblank;
+						// Decode the split up vblanktime... Sign-extend nonsense...
+						uint64_t vblanktime = (uint64_t(uint32_t(ev.xclient.data.l[2])) << 32) |
+											   uint64_t(uint32_t(ev.xclient.data.l[3]));
 						uint64_t vblankreceived = get_time_in_nanos();
 						uint64_t diff = vblankreceived - vblanktime;
 

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -9,6 +9,7 @@ extern uint32_t currentOutputWidth;
 extern uint32_t currentOutputHeight;
 
 unsigned int get_time_in_milliseconds(void);
+uint64_t get_time_in_nanos();
 
 int steamcompmgr_main(int argc, char **argv);
 
@@ -83,5 +84,3 @@ extern float focusedWindowScaleX;
 extern float focusedWindowScaleY;
 extern float focusedWindowOffsetX;
 extern float focusedWindowOffsetY;
-
-void mark_vblank_message_time( void );

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -10,6 +10,8 @@ extern uint32_t currentOutputHeight;
 
 unsigned int get_time_in_milliseconds(void);
 uint64_t get_time_in_nanos();
+void sleep_for_nanos(uint64_t nanos);
+void sleep_until_nanos(uint64_t nanos);
 
 int steamcompmgr_main(int argc, char **argv);
 

--- a/src/vblankmanager.cpp
+++ b/src/vblankmanager.cpp
@@ -19,16 +19,14 @@ static Display *g_nestedDpy;
 
 std::atomic<uint64_t> g_lastVblank;
 
-float g_flVblankDrawBufferMS = 5.0;
+uint64_t g_uVblankDrawBufferNS = 5'000'000;
 
 void vblankThreadRun( void )
 {
 	while ( true )
 	{
-		uint64_t lastVblank = g_lastVblank;
-		uint64_t nsecInterval = uint64_t(1.0 / g_nOutputRefresh * 1000.0 * 1000.0 * 1000.0);
-		
-		lastVblank -= (uint64_t)(g_flVblankDrawBufferMS * 1000 * 1000);
+		uint64_t lastVblank = g_lastVblank - g_uVblankDrawBufferNS;
+		uint64_t nsecInterval = 1'000'000'000ul / g_nOutputRefresh;
 
 		uint64_t now = get_time_in_nanos();
 		uint64_t targetPoint = lastVblank + nsecInterval;
@@ -58,7 +56,7 @@ void vblankThreadRun( void )
 		gpuvis_trace_printf( "sent vblank\n" );
 		
 		// Get on the other side of it now
-		sleep_for_nanos( (uint64_t)((g_flVblankDrawBufferMS + 1.0) * 1000 * 1000) );
+		sleep_for_nanos( g_uVblankDrawBufferNS + 1'000'000 );
 	}
 }
 

--- a/src/vblankmanager.cpp
+++ b/src/vblankmanager.cpp
@@ -16,7 +16,6 @@
 #include "main.hpp"
 
 static Display *g_nestedDpy;
-static XEvent repaintMsg;
 
 std::mutex g_vblankLock;
 std::chrono::time_point< std::chrono::system_clock > g_lastVblank;
@@ -48,8 +47,19 @@ void vblankThreadRun( void )
 		std::this_thread::sleep_until( targetPoint );
 
 		// give the time of vblank to steamcompmgr
-		mark_vblank_message_time();
-		
+		uint64_t vblanktime = get_time_in_nanos();
+		XEvent repaintMsg = {};
+		repaintMsg.xclient.type = ClientMessage;
+		repaintMsg.xclient.window = DefaultRootWindow( g_nestedDpy );
+		repaintMsg.xclient.format = 32;
+		repaintMsg.xclient.data.l[0] = 24;
+		repaintMsg.xclient.data.l[1] = 8;
+		// Although these are longs which are 64-bit, something funky goes on
+		// that stops us from encoding more than 32-bits in each element.
+		// This matches the format above which is "32".
+		repaintMsg.xclient.data.l[2] = uint32_t(vblanktime >> 32);
+		repaintMsg.xclient.data.l[3] = uint32_t(vblanktime & 0xFFFFFFFF);
+
 		// send a message to nudge it out of its event loop
 		XSendEvent( g_nestedDpy , DefaultRootWindow( g_nestedDpy ), True, SubstructureRedirectMask, &repaintMsg);
 		XFlush( g_nestedDpy );
@@ -65,12 +75,6 @@ void vblank_init( void )
 {
 	g_nestedDpy = XOpenDisplay( wlserver_get_nested_display() );
 	assert( g_nestedDpy != nullptr );
-		
-	repaintMsg.xclient.type = ClientMessage;
-	repaintMsg.xclient.window = DefaultRootWindow( g_nestedDpy );
-	repaintMsg.xclient.format = 32;
-	repaintMsg.xclient.data.l[0] = 24;
-	repaintMsg.xclient.data.l[1] = 8;
 	
 	g_lastVblank = std::chrono::system_clock::now();
 


### PR DESCRIPTION
- Encode vblank time in client message.
- Eliminate mutex for last vblank.
- Keep everything on the same timescale.
- Avoid using floats here when we can just use integer maths.
- Add demarcations.
- Misc. cleanup.