### PR TITLE
Fallback to system wlroots/liftoff when subprojects/ is empty

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,8 +47,15 @@ wlroots_proj = subproject('wlroots', required: false, default_options:
   ['default_library=static', 'examples=false'])
 if wlroots_proj.found()
   wlroots_dep = wlroots_proj.get_variable('wlroots')
+  wlroots_conf = wlroots_proj.get_variable('conf_data')
+  wlroots_has_xwayland = wlroots_conf.get('WLR_HAS_XWAYLAND') == 1
 else
-  wlroots_dep = dependency('wlroots')
+  wlroots_dep = dependency('wlroots', version: '>= 0.11.0')
+  wlroots_has_xwayland = cc.get_define('WLR_HAS_XWAYLAND', prefix: '#include <wlr/config.h>', dependencies: wlroots_dep) == '1'
+endif
+
+if not wlroots_has_xwayland
+  error('Cannot use wlroots built without Xwayland support')
 endif
 
 shadercompiler = find_program('glslangValidator')

--- a/meson.build
+++ b/meson.build
@@ -46,9 +46,9 @@ sdl_dep = dependency('SDL2')
 wlroots_proj = subproject('wlroots', required: false, default_options:
   ['default_library=static', 'examples=false'])
 if wlroots_proj.found()
-  wlroots_static_dep = wlroots_proj.get_variable('wlroots')
+  wlroots_dep = wlroots_proj.get_variable('wlroots')
 else
-  wlroots_static_dep = dependency('wlroots')
+  wlroots_dep = dependency('wlroots')
 endif
 
 shadercompiler = find_program('glslangValidator')
@@ -66,9 +66,9 @@ spirv_shader = custom_target('shader_target',
 liftoff_proj = subproject('libliftoff', required: false, default_options:
   ['default_library=static'])
 if liftoff_proj.found()
-  libftoff_dep = liftoff_proj.get_variable('liftoff')
+  liftoff_dep = liftoff_proj.get_variable('liftoff')
 else
-  libftoff_dep = dependency('liftoff')
+  liftoff_dep = dependency('liftoff')
 endif
 
 executable(
@@ -83,8 +83,8 @@ executable(
     dependencies : [
         dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
         dep_xxf86vm, drm_dep, wayland_server, wayland_protos,
-        xkbcommon, math, thread_dep, sdl_dep, wlroots_static_dep,
-        vulkan_dep, libftoff_dep, dep_xtst, cap_dep
+        xkbcommon, math, thread_dep, sdl_dep, wlroots_dep,
+        vulkan_dep, liftoff_dep, dep_xtst, cap_dep
     ],
     install: true,
 )

--- a/meson.build
+++ b/meson.build
@@ -43,9 +43,13 @@ thread_dep = dependency('threads')
 cap_dep = cc.find_library('cap')
 sdl_dep = dependency('SDL2')
 
-wlroots_proj = subproject('wlroots', default_options:
+wlroots_proj = subproject('wlroots', required: false, default_options:
   ['default_library=static', 'examples=false'])
-wlroots_static_dep = wlroots_proj.get_variable('wlroots')
+if wlroots_proj.found()
+  wlroots_static_dep = wlroots_proj.get_variable('wlroots')
+else
+  wlroots_static_dep = dependency('wlroots')
+endif
 
 shadercompiler = find_program('glslangValidator')
 
@@ -59,9 +63,13 @@ spirv_shader = custom_target('shader_target',
   install : false,
 )
 
-liftoff_proj = subproject('libliftoff', default_options:
+liftoff_proj = subproject('libliftoff', required: false, default_options:
   ['default_library=static'])
-libftoff_dep = liftoff_proj.get_variable('liftoff')
+if liftoff_proj.found()
+  libftoff_dep = liftoff_proj.get_variable('liftoff')
+else
+  libftoff_dep = dependency('liftoff')
+endif
 
 executable(
     'gamescope',


### PR DESCRIPTION
Fixes #22:
- after 5ab3129d8e7d system wlroots should be safe to use
- prefer bundled copies to avoid bustage on package upgrades

More concisely it can be:
```meson
project(
  'gamescope',
  ['c','cpp'],
  meson_version: '>=0.54.0',
  default_options: [
    'warning_level=2',
    'default_library=static',
    'examples=false',
  ],
)
....
wlroots_dep = dependency('wlroots', version: '>= 0.11.0', fallback: ['wlroots', 'wlroots'])
liftoff_dep = dependency('liftoff', fallback: ['libliftoff', 'liftoff'])
```
