### PR TITLE
Fix -Wunused-private-field reported by Clang

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -640,7 +640,6 @@ MouseCursor::MouseCursor(_XDisplay *display)
 	, m_dirty(true)
 	, m_imageEmpty(false)
 	, m_hideForMovement(true)
-	, m_hasPlane(false)
 	, m_display(display)
 {
 }

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -72,8 +72,6 @@ private:
 
 	PointerBarrier m_scaledFocusBarriers[4] = { None };
 
-	bool m_hasPlane;
-
 	_XDisplay *m_display;
 };
 


### PR DESCRIPTION
Regressed by #28 (f7d815a2037e), so CC @subdiff. From Clang 11 [build log](https://github.com/Plagman/gamescope/files/5419260/gamescope-3.7.6.log):
```c
In file included from ../src/steamcompmgr.cpp:74:
src/steamcompmgr.hpp:75:7: warning: private field 'm_hasPlane' is not used [-Wunused-private-field]
        bool m_hasPlane;
             ^
```

For parity with GCC 11 build which is warning-free. Also, not related to b84750e77576 i.e., dropping `warning_level=2` doesn't silence `-Wunused-private-field`.