### PR TITLE
Get libliftoff to work consistently

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -856,7 +856,7 @@ drm_prepare_liftoff( struct drm_t *drm, struct Composite_t *pComposite, struct V
 		}
 	}
 
-	bool ret = liftoff_output_apply( drm->lo_output, drm->req );
+	bool ret = liftoff_output_apply( drm->lo_output, drm->req, drm->flags );
 
 	int scanoutLayerCount = 0;
 	if ( ret )

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -717,7 +717,9 @@ void drm_drop_fbid( struct drm_t *drm, uint32_t fbid )
 	}
 }
 
-bool drm_can_avoid_composite( struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline )
+/* Prepares an atomic commit for the provided scene-graph. Returns false on
+ * error or if the scene-graph can't be presented directly. */
+bool drm_prepare( struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline )
 {
 	int nLayerCount = pComposite->nLayerCount;
 	

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -896,7 +896,6 @@ bool drm_prepare( struct drm_t *drm, struct Composite_t *pComposite, struct Vulk
 	if ( 1 || bFirstSwap == true )
 	{
 		flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
-		bFirstSwap = false;
 	}
 
 	// We do internal refcounting with these events
@@ -922,7 +921,9 @@ bool drm_prepare( struct drm_t *drm, struct Composite_t *pComposite, struct Vulk
 		result = drm_prepare_basic( drm, pComposite, pPipeline );
 	}
 
-	if ( !result ) {
+	if ( result ) {
+		bFirstSwap = false;
+	} else {
 		drmModeAtomicFree( drm->req );
 		drm->req = nullptr;
 

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -101,4 +101,4 @@ int init_drm(struct drm_t *drm, const char *device, const char *mode_str, unsign
 int drm_atomic_commit(struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline );
 uint32_t drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_buffer *buf, struct wlr_dmabuf_attributes *dma_buf );
 void drm_drop_fbid( struct drm_t *drm, uint32_t fbid );
-bool drm_can_avoid_composite( struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline );
+bool drm_prepare( struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1207,7 +1207,7 @@ paint_all(Display *dpy, MouseCursor *cursor)
 
 	if ( BIsNested() == false && alwaysComposite == False && takeScreenshot == False )
 	{
-		if ( drm_can_avoid_composite( &g_DRM, &composite, &pipeline ) == true )
+		if ( drm_prepare( &g_DRM, &composite, &pipeline ) == true )
 		{
 			bDoComposite = false;
 		}
@@ -1244,7 +1244,7 @@ paint_all(Display *dpy, MouseCursor *cursor)
 			pipeline.layerBindings[ 0 ].fbid = vulkan_get_last_composite_fbid();
 			pipeline.layerBindings[ 0 ].bFilter = false;
 
-			bool bFlip = drm_can_avoid_composite( &g_DRM, &composite, &pipeline );
+			bool bFlip = drm_prepare( &g_DRM, &composite, &pipeline );
 
 			// We should always handle a 1-layer flip
 			assert( bFlip == true );


### PR DESCRIPTION
This fixes black screens when using libliftoff. The main culprit was that the `ALLOW_MODESET` flag wasn't passed during test-only commits. Some refactoring is also included.

In my testing, libliftoff was able to use two planes at the same time without composition (when showing a Steam notification for instance).

Closes: https://github.com/Plagman/gamescope/issues/41