### PR TITLE
Use DRM_CAP_CURSOR_{WIDTH,HEIGTH} for cursor buffer

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -395,6 +395,13 @@ int init_drm(struct drm_t *drm, const char *device, const char *mode_str, unsign
 	drmModeFreeResources(resources);
 	
 	drm->connector_id = connector->connector_id;
+
+	if (drmGetCap(drm->fd, DRM_CAP_CURSOR_WIDTH, &drm->cursor_width) != 0) {
+		drm->cursor_width = 64;
+	}
+	if (drmGetCap(drm->fd, DRM_CAP_CURSOR_HEIGHT, &drm->cursor_height) != 0) {
+		drm->cursor_height = 64;
+	}
 	
 	drmSetClientCap(drm->fd, DRM_CLIENT_CAP_ATOMIC, 1);
 	drmSetClientCap(drm->fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -50,6 +50,8 @@ struct fb {
 
 struct drm_t {
 	int fd;
+
+	uint64_t cursor_width, cursor_height;
 	
 	/* only used for atomic: */
 	struct plane *plane;

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -218,7 +218,7 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, VkFormat format, cr
 {
 	VkResult res = VK_ERROR_INITIALIZATION_FAILED;
 
-	VkImageTiling tiling = flags.bMappable ? VK_IMAGE_TILING_LINEAR : VK_IMAGE_TILING_OPTIMAL;
+	VkImageTiling tiling = (flags.bMappable || flags.bLinear) ? VK_IMAGE_TILING_LINEAR : VK_IMAGE_TILING_OPTIMAL;
 	VkImageUsageFlags usage = flags.bTextureable ? VK_IMAGE_USAGE_SAMPLED_BIT : VK_IMAGE_USAGE_STORAGE_BIT;
 	VkMemoryPropertyFlags properties;
 
@@ -1372,6 +1372,7 @@ VulkanTexture_t vulkan_create_texture_from_bits( uint32_t width, uint32_t height
 
 	CVulkanTexture::createFlags texCreateFlags;
 	texCreateFlags.bFlippable = BIsNested() == false;
+	texCreateFlags.bLinear = true; // cursor buffer needs to be linear
 	texCreateFlags.bTextureable = true;
 	texCreateFlags.bTransferDst = true;
 	

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -67,6 +67,7 @@ public:
 			bMappable = false;
 			bTransferSrc = false;
 			bTransferDst = false;
+			bLinear = false;
 		}
 
 		bool bFlippable : 1;
@@ -74,6 +75,7 @@ public:
 		bool bMappable : 1;
 		bool bTransferSrc : 1;
 		bool bTransferDst : 1;
+		bool bLinear : 1;
 	};
 
 	bool BInit( uint32_t width, uint32_t height, VkFormat format, createFlags flags, wlr_dmabuf_attributes *pDMA = nullptr );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -864,6 +864,7 @@ bool MouseCursor::getTexture()
 		return false;
 	}
 
+	// TODO: choose format & modifiers from cursor plane
 	m_texture = vulkan_create_texture_from_bits(m_width, m_height, VK_FORMAT_R8G8B8A8_UNORM,
 												cursorDataBuffer);
 	assert(m_texture);

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -827,6 +827,11 @@ bool MouseCursor::getTexture()
 
 	m_width = image->width;
 	m_height = image->height;
+	if ( BIsNested() == false && alwaysComposite == False )
+	{
+		m_width = g_DRM.cursor_width;
+		m_height = g_DRM.cursor_height;
+	}
 
 	if (m_texture) {
 		vulkan_free_texture(m_texture);
@@ -836,12 +841,14 @@ bool MouseCursor::getTexture()
 	// Assume the cursor is fully translucent unless proven otherwise.
 	bool bNoCursor = true;
 
-	unsigned int cursorDataBuffer[m_width * m_height];
-	for (int i = 0; i < m_width * m_height; i++) {
-		cursorDataBuffer[i] = image->pixels[i];
+	uint32_t cursorDataBuffer[m_width * m_height] = {0};
+	for (int i = 0; i < image->height; i++) {
+		for (int j = 0; j < image->width; j++) {
+			cursorDataBuffer[i * m_width + j] = image->pixels[i * image->width + j];
 
-		if ( cursorDataBuffer[i] & 0x000000ff ) {
-			bNoCursor = false;
+			if ( cursorDataBuffer[i * m_width + j] & 0x000000ff ) {
+				bNoCursor = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
This makes it so the buffer for the cursor can pass amdgpu's size checks.

Tested with:

```
build/gamescope -e -l -d -w 1920 -h 1080 -- steam -tenfoot -steamos
```

(-w and -h are necessary to remove any scaling because the cursor plane can't be used together with primary plane scaling.)

Then check that the cursor plane is used with `drm_info`.

~~This is not ready to be merged because amdgpu prints some errors, oops and the cursor isn't displayed properly. https://gitlab.freedesktop.org/drm/amd/-/issues/1390~~