### PR TITLE
Remove ALLOW_MODESET workaround

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -892,8 +892,7 @@ bool drm_prepare( struct drm_t *drm, struct Composite_t *pComposite, struct Vulk
 	static bool bFirstSwap = true;
 	uint32_t flags = DRM_MODE_ATOMIC_NONBLOCK;
 
-	// Temporary hack until we figure out what AMDGPU DC expects when changing the dest rect
-	if ( 1 || bFirstSwap == true )
+	if ( bFirstSwap == true )
 	{
 		flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
 	}


### PR DESCRIPTION
This is no longer needed as of Linux 5.10.

Closes: https://github.com/Plagman/gamescope/issues/67

~~Submitting as a draft, waiting for a stable kernel release.~~ Known to be broken on 5.9.3.