### PR TITLE
Add support for modifiers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,6 +191,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	wlserver_init(argc, argv, g_bIsNested == true );
+
 	// Prevent our clients from connecting to the parent compositor
 	unsetenv("WAYLAND_DISPLAY");
 

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -2137,6 +2137,15 @@ int vulkan_get_texture_fence( VulkanTexture_t vulkanTex )
 	return pTex->m_FD;
 }
 
+static void texture_destroy( struct wlr_texture *wlr_texture )
+{
+	VulkanWlrTexture_t *tex = (VulkanWlrTexture_t *)wlr_texture;
+	delete tex;
+}
+
+static const struct wlr_texture_impl texture_impl = {
+	.destroy = texture_destroy,
+};
 
 static void renderer_begin( struct wlr_renderer *renderer, uint32_t width, uint32_t height )
 {
@@ -2206,10 +2215,14 @@ static const struct wlr_drm_format_set *renderer_get_dmabuf_texture_formats( str
 	return &sampledDRMFormats;
 }
 
-static struct wlr_texture *renderer_texture_from_dmabuf( struct wlr_renderer *wlr_renderer, struct wlr_dmabuf_attributes *dmabuf )
+static struct wlr_texture *renderer_texture_from_dmabuf(
+	struct wlr_renderer *renderer, struct wlr_dmabuf_attributes *dmabuf)
 {
-	VulkanRenderer_t *renderer = (VulkanRenderer_t *) wlr_renderer;
-	return wlr_texture_from_dmabuf( renderer->parent, dmabuf );
+	VulkanWlrTexture_t *tex = new VulkanWlrTexture_t();
+	wlr_texture_init( &tex->base, &texture_impl, dmabuf->width, dmabuf->height );
+	// TODO: check format/modifier
+	// TODO: try importing it into Vulkan
+	return &tex->base;
 }
 
 static bool renderer_resource_is_wl_drm_buffer( struct wlr_renderer *wlr_renderer, struct wl_resource *resource )

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -2202,10 +2202,108 @@ static const uint32_t *renderer_get_shm_texture_formats(
 	return sampledShmFormats.data();
 }
 
-static struct wlr_texture *renderer_texture_from_pixels( struct wlr_renderer *wlr_renderer, uint32_t shmFormat, uint32_t stride, uint32_t width, uint32_t height, const void *src )
+static struct wlr_texture *renderer_texture_from_pixels(
+	struct wlr_renderer *renderer, uint32_t nDRMFormat,
+	uint32_t stride, uint32_t width,
+	uint32_t height, const void *src)
 {
-	VulkanRenderer_t *renderer = (VulkanRenderer_t *) wlr_renderer;
-	return wlr_texture_from_pixels( renderer->parent, shmFormat, stride, width, height, src );
+	VkFormat format = DRMFormatToVulkan( nDRMFormat );
+
+	VkResult result;
+
+	VkBufferCreateInfo bufferCreateInfo = {};
+	bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+	bufferCreateInfo.size = stride * height;
+	bufferCreateInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+	VkBuffer buffer;
+	result = vkCreateBuffer( device, &bufferCreateInfo, nullptr, &buffer );
+	if ( result != VK_SUCCESS )
+	{
+		return nullptr;
+	}
+
+	VkMemoryRequirements memRequirements;
+	vkGetBufferMemoryRequirements(device, buffer, &memRequirements);
+
+	int memTypeIndex =  findMemoryType(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT|VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, memRequirements.memoryTypeBits );
+	if ( memTypeIndex == -1 )
+	{
+		return nullptr;
+	}
+
+	VkMemoryAllocateInfo allocInfo = {};
+	allocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+	allocInfo.allocationSize = memRequirements.size;
+	allocInfo.memoryTypeIndex = memTypeIndex;
+
+	VkDeviceMemory bufferMemory;
+	result = vkAllocateMemory( device, &allocInfo, nullptr, &bufferMemory);
+	if ( result != VK_SUCCESS )
+	{
+		return nullptr;
+	}
+
+	result = vkBindBufferMemory( device, buffer, bufferMemory, 0 );
+	if ( result != VK_SUCCESS )
+	{
+		return nullptr;
+	}
+
+	void *dst;
+	result = vkMapMemory( device, bufferMemory, 0, VK_WHOLE_SIZE, 0, &dst );
+	if ( result != VK_SUCCESS )
+	{
+		return nullptr;
+	}
+
+	memcpy( dst, src, stride * height );
+
+	vkUnmapMemory( device, bufferMemory );
+
+	CVulkanTexture *pTex = new CVulkanTexture();
+	CVulkanTexture::createFlags texCreateFlags = {};
+	//texCreateFlags.bFlippable = BIsNested() == false;
+	texCreateFlags.bTextureable = true;
+	texCreateFlags.bTransferDst = true;
+	if ( pTex->BInit( width, height, format, texCreateFlags ) == false )
+	{
+		delete pTex;
+		return nullptr;
+	}
+
+	VkCommandBuffer commandBuffer;
+	uint32_t handle = get_command_buffer( commandBuffer, nullptr );
+
+	VkBufferImageCopy region = {};
+	region.imageSubresource = {
+		.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+		.layerCount = 1
+	};
+	region.imageExtent = {
+		.width = width,
+		.height = height,
+		.depth = 1
+	};
+	vkCmdCopyBufferToImage( commandBuffer, buffer, pTex->m_vkImage, VK_IMAGE_LAYOUT_GENERAL, 1, &region );
+
+	std::vector<CVulkanTexture *> refs;
+	refs.push_back( pTex );
+
+	submit_command_buffer( handle, refs );
+
+	VulkanTexture_t texid = ++g_nMaxVulkanTexHandle;
+	g_mapVulkanTextures[ texid ] = pTex;
+
+	pTex->handle = texid;
+
+	VulkanWlrTexture_t *wlrTex = new VulkanWlrTexture_t();
+	wlr_texture_init( &wlrTex->base, &texture_impl, width, height );
+	wlrTex->tex = texid;
+
+	vkFreeMemory( device, bufferMemory, nullptr );
+	vkDestroyBuffer( device, buffer, nullptr );
+
+	return &wlrTex->base;
 }
 
 static bool renderer_init_wl_display( struct wlr_renderer *wlr_renderer, struct wl_display *wl_display )

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -119,6 +119,7 @@ std::vector< VulkanSamplerCacheEntry_t > g_vecVulkanSamplerCache;
 VulkanTexture_t g_emptyTex;
 
 static std::map< VkFormat, std::map< uint64_t, VkDrmFormatModifierPropertiesEXT > > DRMModifierProps = {};
+static std::vector< uint32_t > sampledShmFormats{};
 static struct wlr_drm_format_set sampledDRMFormats = {};
 
 #define MAX_DEVICE_COUNT 8
@@ -705,6 +706,8 @@ void init_formats()
 			fprintf( stderr, "vkGetPhysicalDeviceImageFormatProperties2 failed for DRM format 0x%" PRIX32 "\n", drmFormat );
 			continue;
 		}
+
+		sampledShmFormats.push_back( drmFormat );
 
 		if ( !g_vulkanSupportsModifiers )
 		{
@@ -2192,11 +2195,11 @@ static void renderer_render_ellipse_with_matrix( struct wlr_renderer *renderer, 
 	abort(); // unreachable
 }
 
-static const uint32_t *renderer_get_shm_texture_formats( struct wlr_renderer *wlr_renderer, size_t *len
- )
+static const uint32_t *renderer_get_shm_texture_formats(
+	struct wlr_renderer *renderer, size_t *len)
 {
-	VulkanRenderer_t *renderer = (VulkanRenderer_t *) wlr_renderer;
-	return wlr_renderer_get_shm_texture_formats( renderer->parent, len );
+	*len = sampledShmFormats.size();
+	return sampledShmFormats.data();
 }
 
 static struct wlr_texture *renderer_texture_from_pixels( struct wlr_renderer *wlr_renderer, uint32_t shmFormat, uint32_t stride, uint32_t width, uint32_t height, const void *src )

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -70,6 +70,7 @@ struct VulkanRenderer_t
 struct VulkanWlrTexture_t
 {
 	struct wlr_texture base;
+	VulkanTexture_t tex;
 };
 
 class CVulkanTexture
@@ -140,4 +141,6 @@ void vulkan_present_to_window( void );
 void vulkan_garbage_collect( void );
 bool vulkan_remake_swapchain( void );
 
-struct wlr_renderer *vulkan_renderer_create( struct wlr_renderer *parent );
+struct wlr_renderer *vulkan_renderer_create( void );
+
+VulkanTexture_t vulkan_texture_from_wlr( struct wlr_texture *tex );

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -67,6 +67,11 @@ struct VulkanRenderer_t
 	struct wlr_renderer *parent;
 };
 
+struct VulkanWlrTexture_t
+{
+	struct wlr_texture base;
+};
+
 class CVulkanTexture
 {
 public:

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE 1
 
 #include <assert.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -25,6 +26,7 @@ extern "C" {
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/noop.h>
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_drm.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_touch.h>
@@ -487,6 +489,11 @@ int wlserver_init(int argc, char **argv, bool bIsNested) {
 	wlserver.wlr.renderer = vulkan_renderer_create( headless_renderer );
 
 	wlr_renderer_init_wl_display(wlserver.wlr.renderer, wlserver.wl_display);
+
+	// TODO: get DRM FD from VkPhysicalDevice
+	int drm_fd = open("/dev/dri/renderD128", O_RDWR | O_CLOEXEC);
+	wlr_drm_create(wlserver.wl_display, drm_fd);
+	close(drm_fd);
 
 	wlserver.wlr.compositor = wlr_compositor_create(wlserver.wl_display, wlserver.wlr.renderer);
 


### PR DESCRIPTION
- [x] Query primary plane modifiers from KMS
- [x] Allocate Vulkan buffers with list of scan-out capable modifiers (https://github.com/Plagman/gamescope/pull/170)
- [x] Specify modifier info when importing DMA-BUFs into Vulkan
- [x] Query modifier info when exporting DMA-BUFs from Vulkan (ff33a3738e77ee5898f5b073c0c7e96316f3b1dc, a900bef8b8c9c1b53e91463edefe2b1ae52c29e0, 4f24653d776f570b437182c4fecb9b82d203b1ea)
- [x] Specify modifier info when importing DMA-BUFs into KMS
- [x] Implement our own `wlr_renderer`
   - [x] Advertise DMA-BUF formats that Vulkan supports
   - [x] Import DMA-BUFs into Vulkan at `wlr_texture` creation time
   - [x] Advertise `wl_shm` formats that Vulkan supports
   - [x] Import `wl_shm` buffers into Vulkan
   - [x] ~~Implement `write_pixels` for `wl_shm` Vulkan buffers~~ (left as a follow-up optimization)
- [x] Add proper fallbacks for GFX8
- [ ] Fix Vulkan threading issues

References: https://github.com/Plagman/gamescope/issues/159