### PR TITLE
Introduce wlserver_surface

### DIFF
--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <wayland-server-core.h>
+#include <atomic>
 
 #define WLSERVER_BUTTON_COUNT 4
 #define WLSERVER_TOUCH_COUNT 11 // Ten fingers + nose ought to be enough for anyone
@@ -82,6 +83,19 @@ void wlserver_mousebutton( int button, bool press, uint32_t time );
 void wlserver_mousewheel( int x, int y, uint32_t time );
 
 void wlserver_send_frame_done( struct wlr_surface *surf, const struct timespec *when );
-struct wlr_surface *wlserver_get_surface( long surfaceID );
 
 const char *wlserver_get_nested_display( void );
+
+struct wlserver_surface
+{
+	std::atomic<struct wlr_surface *> wlr;
+
+	// owned by wlserver
+	long id;
+	struct wl_list pending_link;
+	struct wl_listener destroy;
+};
+
+void wlserver_surface_init( struct wlserver_surface *surf );
+void wlserver_surface_set_id( struct wlserver_surface *surf, long id );
+void wlserver_surface_finish( struct wlserver_surface *surf );


### PR DESCRIPTION
This fixes a state mismatch between wlserver and steamcompmgr. steamcompmgr could have old Wayland surface IDs stored in `win`. This would blow up once another Wayland object re-uses the ID:

```
gamescope: types/wlr_surface.c:560: wlr_surface_from_resource: Assertion `wl_resource_instance_of(resource, &wl_surface_interface, &surface_interface)' failed.
```

Stack trace:

```
#0  0x00007fe8ac9deef5 in raise () at /usr/lib/libc.so.6
#1  0x00007fe8ac9c8862 in abort () at /usr/lib/libc.so.6
#2  0x00007fe8ac9c8747 in _nl_load_domain.cold () at /usr/lib/libc.so.6
#3  0x00007fe8ac9d7646 in  () at /usr/lib/libc.so.6
#4  0x0000562af010058d in wlr_surface_from_resource (resource=0x60c000277cc0)
    at ../subprojects/wlroots/types/wlr_surface.c:560
#5  0x0000562af0030eed in wlserver_get_surface(long) (surfaceID=25)
    at ../src/wlserver.cpp:654
#6  0x0000562af0004cea in handle_wl_surface_id(win*, long)
    (w=0x6130000f9640, surfaceID=25) at ../src/steamcompmgr.cpp:2145
#7  0x0000562af000b568 in steamcompmgr_main(int, char**)
    (argc=12, argv=0x7ffd423b9c88) at ../src/steamcompmgr.cpp:3235
#8  0x0000562af002bb58 in steamCompMgrThreadRun() () at ../src/main.cpp:209
#9  0x0000562af002b0de in std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) (__f=@0x6020001e6df8: 0x562af002bb3d <steamCompMgrThreadRun()>)
    at /usr/include/c++/10.2.0/bits/invoke.h:60
#10 0x0000562af002b059 in std::__invoke<void (*)()>(void (*&&)())
    (__fn=@0x6020001e6df8: 0x562af002bb3d <steamCompMgrThreadRun()>)
    at /usr/include/c++/10.2.0/bits/invoke.h:95
#11 0x0000562af002afe0 in std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (this=0x6020001e6df8)
    at /usr/include/c++/10.2.0/thread:264
#12 0x0000562af002af7c in std::thread::_Invoker<std::tuple<void (*)()> >::operator()() (this=0x6020001e6df8) at /usr/include/c++/10.2.0/thread:271
#13 0x0000562af002ad28 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() (this=0x6020001e6df0)
    at /usr/include/c++/10.2.0/thread:215
#14 0x00007fe8acdc0bc4 in std::execute_native_thread_routine(void*)
    (__p=0x6020001e6df0)
    at /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80
#15 0x00007fe8acb7a299 in start_thread () at /usr/lib/libpthread.so.0
#16 0x00007fe8acaa1053 in clone () at /usr/lib/libc.so.6
```