### PR TITLE
Revert "main: set R600_DEBUG=nodcc ourselves if we have a sub-command."

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It also runs on top of a regular desktop, the 'nested' usecase steamcompmgr didn
 
 It runs on Mesa+AMDGPU, and could be made to run on other Mesa/DRM drivers with minimal work. Can support NVIDIA if/when they support accelerated Xwayland.
 
-If running RadeonSI clients with older cards (GFX8 and below), currently have to set `R600_DEBUG=nodcc`, or corruption will be observed until the stack picks up DRM modifiers support.
+If running RadeonSI clients with older cards (GFX8 and below) or older Mesa version (21.0 and below), currently have to set `R600_DEBUG=nodcc`, or corruption will be observed until the stack picks up DRM modifiers support.
 
 ## Building
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,23 +112,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	// If we're going to execute something monolithic, might as well set this since it'll extend to our clients
-	if ( g_nSubCommandArg != 0 )
-	{
-		const char *pchR600Debug = getenv( "R600_DEBUG" );
-
-		if ( pchR600Debug == nullptr )
-		{
-			setenv( "R600_DEBUG", "nodcc", 1 );
-		}
-		else if ( strstr( pchR600Debug, "nodcc" ) == nullptr )
-		{
-			std::string strPreviousR600Debug = pchR600Debug;
-			strPreviousR600Debug.append( ",nodcc" );
-			setenv( "R600_DEBUG", strPreviousR600Debug.c_str(), 1 );
-		}
-	}
-
 	cap_t caps;
 	caps = cap_get_proc();
 	cap_flag_value_t nicecapvalue = CAP_CLEAR;


### PR DESCRIPTION
This reverts commit 11dd8014ad8de6a3ab0c1cdb7d307d97d22d3b1a.

GFX9+ now supports modifiers. Requires Mesa 21.1+ (for
VK_EXT_image_drm_format_modifier).