### PR TITLE
Use libliftoff by default

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -30,7 +30,7 @@ struct drm_t g_DRM = {};
 uint32_t g_nDRMFormat = DRM_FORMAT_INVALID;
 bool g_bRotated = false;
 
-bool g_bUseLayers = false;
+bool g_bUseLayers = true;
 bool g_bDebugLayers = false;
 
 static int s_drm_log = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,8 +92,8 @@ int main(int argc, char **argv)
 			case 's':
 				bSleepAtStartup = true;
 				break;
-			case 'l':
-				g_bUseLayers = true;
+			case 'L':
+				g_bUseLayers = false;
 				break;
 			case 'd':
 				g_bDebugLayers = true;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define GAMESCOPE_OPTIONS ":R:T:C:w:h:W:H:r:o:NFSvVecsdlnbfx"
+#define GAMESCOPE_OPTIONS ":R:T:C:w:h:W:H:r:o:NFSvVecsdLnbfx"
 
 int initOutput(void);
 


### PR DESCRIPTION
Remove the -l option. Introduce a -L option to disable libliftoff.
Don't use the same option to avoid muscle memory issues.