### PR TITLE
Fix startup race with initializing wlserver and processing SDL events

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,12 @@ int main(int argc, char **argv)
 		g_bIsNested = true;
 	}
 
+	// We need to lock the wlserver before making the SDL2 output,
+	// because we can have a race where we start recieving SDL2 events before
+	// we have initialized the server (or the application ended instantly ie. vulkaninfo)
+	// and SDL2 is trying to send events to the non-existant server.
+	// We unlock after actually initializing the wlserver.
+	wlserver_lock();
 	if ( initOutput() != 0 )
 	{
 		fprintf( stderr, "Failed to initialize output\n" );
@@ -205,6 +211,7 @@ int main(int argc, char **argv)
 		g_nNestedHeight = g_nOutputHeight;
 
 	wlserver_init(argc, argv, g_bIsNested == true );
+	wlserver_unlock(false);
 
 	wlserver_run();
 }

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -598,9 +598,10 @@ void wlserver_lock(void)
 	pthread_mutex_lock(&waylock);
 }
 
-void wlserver_unlock(void)
+void wlserver_unlock( bool bFlush )
 {
-	wl_display_flush_clients(wlserver.wl_display);
+	if ( bFlush )
+		wl_display_flush_clients(wlserver.wl_display);
 	pthread_mutex_unlock(&waylock);
 }
 

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -79,7 +79,7 @@ int wlserver_init( int argc, char **argv, bool bIsNested );
 int wlserver_run(void);
 
 void wlserver_lock(void);
-void wlserver_unlock(void);
+void wlserver_unlock( bool bFlush = true );
 
 void wlserver_keyboardfocus( struct wlr_surface *surface );
 void wlserver_key( uint32_t key, bool press, uint32_t time );


### PR DESCRIPTION
We need to lock the wlserver before making the SDL2 output, because we can have a race where we start recieving SDL2 events before we have initialized the server (or the application ended instantly ie. vulkaninfo) and SDL2 is trying to send events to the non-existant server.
We unlock after actually initializing the wlserver.