### PR TITLE
Expose a PipeWire stream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           pacman -S --noconfirm git meson clang glslang libcap wlroots \
             sdl2 vulkan-headers libx11 libxcomposite libxrender libxres \
             libxtst libxkbcommon libdrm libinput wayland-protocols \
-            xorg-xwayland
+            xorg-xwayland pipewire
       - uses: actions/checkout@v2
         with:
           submodules: recursive

--- a/meson.build
+++ b/meson.build
@@ -73,8 +73,6 @@ add_project_arguments(
   language: 'cpp',
 )
 
-subdir('protocol')
-
 src = [
   'src/steamcompmgr.cpp',
   'src/main.cpp',
@@ -86,12 +84,13 @@ src = [
   'src/rendervulkan.cpp',
   'src/log.cpp',
   spirv_shader,
-  gamescope_xwayland_proto_files,
 ]
 
 if pipewire_dep.found()
   src += 'src/pipewire.cpp'
 endif
+
+subdir('protocol')
 
 executable(
   'gamescope',

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ xkbcommon = dependency('xkbcommon')
 thread_dep = dependency('threads')
 cap_dep = dependency('libcap')
 sdl_dep = dependency('SDL2')
+pipewire_dep = dependency('libpipewire-0.3', required: get_option('pipewire'))
 
 wlroots_dep = dependency(
   'wlroots',
@@ -67,28 +68,39 @@ liftoff_dep = dependency(
   default_options: ['default_library=static'],
 )
 
+add_project_arguments(
+  '-DHAVE_PIPEWIRE=@0@'.format(pipewire_dep.found().to_int()),
+  language: 'cpp',
+)
+
 subdir('protocol')
+
+src = [
+  'src/steamcompmgr.cpp',
+  'src/main.cpp',
+  'src/wlserver.cpp',
+  'src/drm.cpp',
+  'src/cvt.cpp',
+  'src/sdlwindow.cpp',
+  'src/vblankmanager.cpp',
+  'src/rendervulkan.cpp',
+  'src/log.cpp',
+  spirv_shader,
+  gamescope_xwayland_proto_files,
+]
+
+if pipewire_dep.found()
+  src += 'src/pipewire.cpp'
+endif
 
 executable(
   'gamescope',
-  [
-    'src/steamcompmgr.cpp',
-    'src/main.cpp',
-    'src/wlserver.cpp',
-    'src/drm.cpp',
-    'src/cvt.cpp',
-    'src/sdlwindow.cpp',
-    'src/vblankmanager.cpp',
-    'src/rendervulkan.cpp',
-    'src/log.cpp',
-    spirv_shader,
-    gamescope_xwayland_proto_files,
-  ],
+  src,
   dependencies: [
     dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
     dep_xxf86vm, dep_xres, drm_dep, wayland_server, wayland_protos,
     xkbcommon, thread_dep, sdl_dep, wlroots_dep,
-    vulkan_dep, liftoff_dep, dep_xtst, cap_dep
+    vulkan_dep, liftoff_dep, dep_xtst, cap_dep, pipewire_dep,
   ],
   install: true,
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('pipewire', type: 'feature', description: 'Screen capture via PipeWire')

--- a/protocol/gamescope-pipewire.xml
+++ b/protocol/gamescope-pipewire.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="gamescope_pipewire">
+  <copyright>
+    Copyright © 2021 Valve Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="gamescope-specific PipeWire protocol">
+    This is a private Gamescope protocol. Regular Wayland clients must not use
+    it.
+  </description>
+
+  <interface name="gamescope_pipewire" version="1">
+    <request name="destroy" type="destructor"></request>
+
+    <event name="stream_node">
+      <description summary="pipewire stream node advertisement">
+        This event advertises a PipeWire stream node identifier suitable for
+        capturing the main output.
+
+        A roundtrip after binding to the gamescope_pipewire global ensures this
+        event has been received.
+      </description>
+      <arg name="node_id" type="uint" summary="PipeWire stream node ID"/>
+    </event>
+  </interface>
+</protocol>

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -2,18 +2,25 @@ wayland_scanner_dep = dependency('wayland-scanner', native: true)
 wayland_scanner_path = wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner')
 wayland_scanner = find_program(wayland_scanner_path, native: true)
 
-code = custom_target(
-	'gamescope-xwayland-protocol.c',
-	input: 'gamescope-xwayland.xml',
-	output: '@BASENAME@-protocol.c',
-	command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
-)
+protocols = [
+	'gamescope-xwayland',
+	'gamescope-pipewire',
+]
 
-server_header = custom_target(
-	'gamescope-xwayland-protocol.h',
-	input: 'gamescope-xwayland.xml',
-	output: '@BASENAME@-protocol.h',
-	command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
-)
+foreach name : protocols
+	code = custom_target(
+		name + '-protocol.c',
+		input: name + '.xml',
+		output: '@BASENAME@-protocol.c',
+		command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+	)
 
-gamescope_xwayland_proto_files = [code, server_header]
+	server_header = custom_target(
+		name + '-protocol.h',
+		input: name + '.xml',
+		output: '@BASENAME@-protocol.h',
+		command: [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+	)
+
+	src += [code, server_header]
+endforeach

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,10 @@
 #include "wlserver.hpp"
 #include "gpuvis_trace_utils.h"
 
+#if HAVE_PIPEWIRE
+#include "pipewire.hpp"
+#endif
+
 std::atomic< bool > g_bRun{true};
 
 int g_nNestedWidth = 0;
@@ -254,6 +258,13 @@ int main(int argc, char **argv)
 
 	setenv("DISPLAY", wlserver_get_nested_display_name(), 1);
 	setenv("GAMESCOPE_WAYLAND_DISPLAY", wlserver_get_wl_display_name(), 1);
+
+#if HAVE_PIPEWIRE
+	if ( !init_pipewire() )
+	{
+		fprintf( stderr, "Warning: failed to setup PipeWire, screen capture won't be available\n" );
+	}
+#endif
 
 	std::thread steamCompMgrThread( steamCompMgrThreadRun, argc, argv );
 	steamCompMgrThread.detach();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,8 +42,6 @@ bool g_bFilterGameWindow = true;
 
 bool g_bBorderlessOutputWindow = false;
 
-bool g_bTakeScreenshot = false;
-
 bool g_bNiceCap = false;
 int g_nOldNice = 0;
 int g_nNewNice = 0;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -23,8 +23,6 @@ extern bool g_bFilterGameWindow;
 
 extern bool g_bBorderlessOutputWindow;
 
-extern bool g_bTakeScreenshot;
-
 extern bool g_bNiceCap;
 extern int g_nOldNice;
 extern int g_nNewNice;

--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
-#include <spa/param/video/format-utils.h>
+
+#include <thread>
 
 #include "main.hpp"
 #include "pipewire.hpp"
@@ -15,27 +16,94 @@ static void stream_handle_state_changed(void *data, enum pw_stream_state old_str
 		if (state->stream_node_id == SPA_ID_INVALID) {
 			state->stream_node_id = pw_stream_get_node_id(state->stream);
 		}
+		state->streaming = false;
 		break;
 	case PW_STREAM_STATE_STREAMING:
+		state->streaming = true;
+		break;
+	case PW_STREAM_STATE_ERROR:
+	case PW_STREAM_STATE_UNCONNECTED:
+		state->running = false;
 		break;
 	default:
 		break;
 	}
 }
 
+static void stream_handle_param_changed(void *data, uint32_t id, const struct spa_pod *param)
+{
+	struct pipewire_state *state = (struct pipewire_state *) data;
+
+	if (param == nullptr || id != SPA_PARAM_Format)
+		return;
+
+	int bpp = 3;
+	int ret = spa_format_video_raw_parse(param, &state->video_info);
+	if (ret < 0) {
+		fprintf(stderr, "pipewire: spa_format_video_raw_parse failed\n");
+		return;
+	}
+	state->stride = SPA_ROUND_UP_N(state->video_info.size.width * bpp, 4);
+	state->size = state->stride * state->video_info.size.height;
+
+	uint8_t buf[1024];
+	struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+
+	int buffers = 1;
+	int data_type = 1 << SPA_DATA_MemPtr;
+
+	const struct spa_pod *buffers_param =
+		(const struct spa_pod *) spa_pod_builder_add_object(&builder,
+		SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+		SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(buffers, 1, 32),
+		SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1),
+		SPA_PARAM_BUFFERS_size, SPA_POD_Int(state->size),
+		SPA_PARAM_BUFFERS_stride, SPA_POD_Int(state->stride),
+		SPA_PARAM_BUFFERS_dataType, SPA_POD_CHOICE_FLAGS_Int(data_type));
+	const struct spa_pod *meta_param =
+		(const struct spa_pod *) spa_pod_builder_add_object(&builder,
+		SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,
+		SPA_PARAM_META_type, SPA_POD_Id(SPA_META_Header),
+		SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_header)));
+	const struct spa_pod *params[] = { buffers_param, meta_param };
+
+	ret = pw_stream_update_params(state->stream, params, sizeof(params) / sizeof(params[0]));
+	if (ret != 0) {
+		fprintf(stderr, "pipewire: pw_stream_update_params failed\n");
+	}
+}
+
 static const struct pw_stream_events stream_events = {
 	.version = PW_VERSION_STREAM_EVENTS,
 	.state_changed = stream_handle_state_changed,
-	//.param_changed = stream_handle_param_changed,
+	.param_changed = stream_handle_param_changed,
 	//.add_buffer = stream_handle_add_buffer,
 	//.remove_buffer = stream_handle_remove_buffer,
 };
+
+static void run_pipewire(struct pipewire_state *state)
+{
+	state->running = true;
+	while (state->running) {
+		int ret = pw_loop_iterate(state->loop, -1);
+		if (ret < 0) {
+			fprintf(stderr, "pipewire: pw_loop_iterate failed\n");
+			break;
+		}
+	}
+
+	fprintf(stderr, "pipewire: exiting\n");
+	pw_stream_destroy(state->stream);
+	pw_core_disconnect(state->core);
+	pw_context_destroy(state->context);
+	pw_loop_destroy(state->loop);
+}
 
 bool init_pipewire(void)
 {
 	pw_init(nullptr, nullptr);
 
-	struct pipewire_state state = { .stream_node_id = SPA_ID_INVALID };
+	static struct pipewire_state state = { .stream_node_id = SPA_ID_INVALID };
 
 	state.loop = pw_loop_new(nullptr);
 	if (!state.loop) {
@@ -64,7 +132,7 @@ bool init_pipewire(void)
 		return false;
 	}
 
-	struct spa_hook stream_hook;
+	static struct spa_hook stream_hook;
 	pw_stream_add_listener(state.stream, &stream_hook, &stream_events, &state);
 
 	struct spa_rectangle size = SPA_RECTANGLE(g_nOutputWidth, g_nOutputHeight);
@@ -72,7 +140,8 @@ bool init_pipewire(void)
 
 	uint8_t buf[1024];
 	struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
-	const struct spa_pod *param = (const struct spa_pod *)spa_pod_builder_add_object(&builder,
+	const struct spa_pod *format_param =
+		(const struct spa_pod *)spa_pod_builder_add_object(&builder,
 		SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
 		SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
 		SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
@@ -82,7 +151,7 @@ bool init_pipewire(void)
 
 	// TODO: PW_STREAM_FLAG_ALLOC_BUFFERS
 	enum pw_stream_flags flags = PW_STREAM_FLAG_DRIVER;
-	int ret = pw_stream_connect(state.stream, PW_DIRECTION_OUTPUT, PW_ID_ANY, flags, &param, 1);
+	int ret = pw_stream_connect(state.stream, PW_DIRECTION_OUTPUT, PW_ID_ANY, flags, &format_param, 1);
 	if (ret != 0) {
 		fprintf(stderr, "pipewire: pw_stream_connect failed\n");
 		return false;
@@ -97,6 +166,9 @@ bool init_pipewire(void)
 	}
 
 	fprintf(stderr, "pipewire: stream available on node ID: %u\n", state.stream_node_id);
+
+	std::thread thread(run_pipewire, &state);
+	thread.detach();
 
 	return true;
 }

--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -1,0 +1,102 @@
+#include <stdio.h>
+#include <spa/param/video/format-utils.h>
+
+#include "main.hpp"
+#include "pipewire.hpp"
+
+static void stream_handle_state_changed(void *data, enum pw_stream_state old_stream_state, enum pw_stream_state stream_state, const char *error)
+{
+	struct pipewire_state *state = (struct pipewire_state *) data;
+
+	fprintf(stderr, "pipewire: stream state changed: %s\n", pw_stream_state_as_string(stream_state));
+
+	switch (stream_state) {
+	case PW_STREAM_STATE_PAUSED:
+		if (state->stream_node_id == SPA_ID_INVALID) {
+			state->stream_node_id = pw_stream_get_node_id(state->stream);
+		}
+		break;
+	case PW_STREAM_STATE_STREAMING:
+		break;
+	default:
+		break;
+	}
+}
+
+static const struct pw_stream_events stream_events = {
+	.version = PW_VERSION_STREAM_EVENTS,
+	.state_changed = stream_handle_state_changed,
+	//.param_changed = stream_handle_param_changed,
+	//.add_buffer = stream_handle_add_buffer,
+	//.remove_buffer = stream_handle_remove_buffer,
+};
+
+bool init_pipewire(void)
+{
+	pw_init(nullptr, nullptr);
+
+	struct pipewire_state state = { .stream_node_id = SPA_ID_INVALID };
+
+	state.loop = pw_loop_new(nullptr);
+	if (!state.loop) {
+		fprintf(stderr, "pipewire: pw_loop_new failed\n");
+		return false;
+	}
+
+	state.context = pw_context_new(state.loop, nullptr, 0);
+	if (!state.context) {
+		fprintf(stderr, "pipewire: pw_context_new failed\n");
+		return false;
+	}
+
+	state.core = pw_context_connect(state.context, nullptr, 0);
+	if (!state.core) {
+		fprintf(stderr, "pipewire: pw_context_connect failed\n");
+		return false;
+	}
+
+	state.stream = pw_stream_new(state.core, "gamescope",
+		pw_properties_new(
+			PW_KEY_MEDIA_CLASS, "Video/Source",
+			nullptr));
+	if (!state.stream) {
+		fprintf(stderr, "pipewire: pw_stream_new failed\n");
+		return false;
+	}
+
+	struct spa_hook stream_hook;
+	pw_stream_add_listener(state.stream, &stream_hook, &stream_events, &state);
+
+	struct spa_rectangle size = SPA_RECTANGLE(g_nOutputWidth, g_nOutputHeight);
+	struct spa_fraction framerate = SPA_FRACTION(0, 1);
+
+	uint8_t buf[1024];
+	struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+	const struct spa_pod *param = (const struct spa_pod *)spa_pod_builder_add_object(&builder,
+		SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
+		SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
+		SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+		SPA_FORMAT_VIDEO_format, SPA_POD_Id(SPA_VIDEO_FORMAT_RGB),
+		SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&size),
+		SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&framerate));
+
+	// TODO: PW_STREAM_FLAG_ALLOC_BUFFERS
+	enum pw_stream_flags flags = PW_STREAM_FLAG_DRIVER;
+	int ret = pw_stream_connect(state.stream, PW_DIRECTION_OUTPUT, PW_ID_ANY, flags, &param, 1);
+	if (ret != 0) {
+		fprintf(stderr, "pipewire: pw_stream_connect failed\n");
+		return false;
+	}
+
+	while (state.stream_node_id == SPA_ID_INVALID) {
+		int ret = pw_loop_iterate(state.loop, -1);
+		if (ret < 0) {
+			fprintf(stderr, "pipewire: pw_loop_iterate failed\n");
+			return false;
+		}
+	}
+
+	fprintf(stderr, "pipewire: stream available on node ID: %u\n", state.stream_node_id);
+
+	return true;
+}

--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -27,3 +27,4 @@ struct pipewire_buffer {
 bool init_pipewire(void);
 struct pipewire_buffer *dequeue_pipewire_buffer(void);
 void push_pipewire_buffer(struct pipewire_buffer *buffer);
+void nudge_pipewire(void);

--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -12,6 +12,7 @@ struct pipewire_state {
 	struct pw_stream *stream;
 	uint32_t stream_node_id;
 	bool streaming;
+	bool needs_buffer;
 	struct spa_video_info_raw video_info;
 	int stride;
 	uint64_t seq;

--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <pipewire/pipewire.h>
+
+struct pipewire_state {
+	struct pw_loop *loop;
+	struct pw_context *context;
+	struct pw_core *core;
+	struct pw_stream *stream;
+	uint32_t stream_node_id;
+};
+
+bool init_pipewire(void);

--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -26,6 +26,7 @@ struct pipewire_buffer {
 };
 
 bool init_pipewire(void);
+uint32_t get_pipewire_stream_node_id(void);
 struct pipewire_buffer *dequeue_pipewire_buffer(void);
 void push_pipewire_buffer(struct pipewire_buffer *buffer);
 void nudge_pipewire(void);

--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -13,7 +13,17 @@ struct pipewire_state {
 	uint32_t stream_node_id;
 	bool streaming;
 	struct spa_video_info_raw video_info;
-	int size, stride;
+	int stride;
+	uint64_t seq;
+};
+
+struct pipewire_buffer {
+	struct pw_buffer *buffer;
+	struct spa_video_info_raw video_info;
+	int stride;
+	uint8_t *data;
 };
 
 bool init_pipewire(void);
+struct pipewire_buffer *dequeue_pipewire_buffer(void);
+void push_pipewire_buffer(struct pipewire_buffer *buffer);

--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -1,13 +1,19 @@
 #pragma once
 
 #include <pipewire/pipewire.h>
+#include <spa/param/video/format-utils.h>
 
 struct pipewire_state {
 	struct pw_loop *loop;
 	struct pw_context *context;
 	struct pw_core *core;
+	bool running;
+
 	struct pw_stream *stream;
 	uint32_t stream_node_id;
+	bool streaming;
+	struct spa_video_info_raw video_info;
+	int size, stride;
 };
 
 bool init_pipewire(void);

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -139,7 +139,7 @@ uint32_t vulkan_texture_get_fbid( VulkanTexture_t vulkanTex );
 
 void vulkan_free_texture( VulkanTexture_t vulkanTex );
 
-bool vulkan_composite( struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline, bool bScreenshot );
+bool vulkan_composite( struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline, CVulkanTexture **pScreenshotTexture );
 uint32_t vulkan_get_last_composite_fbid( void );
 
 void vulkan_present_to_window( void );

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -160,7 +160,7 @@ void inputSDLThreadRun( void )
 							g_bFilterGameWindow = !g_bFilterGameWindow;
 							break;
 						case KEY_S:
-							g_bTakeScreenshot = true;
+							take_screenshot();
 							break;
 						default:
 							handled = false;

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -89,3 +89,4 @@ extern float focusedWindowOffsetX;
 extern float focusedWindowOffsetY;
 
 void nudge_steamcompmgr( void );
+void take_screenshot( void );

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -71,7 +71,7 @@ void sig_handler(int signal)
 {
 	if ( signal == SIGUSR2 )
 	{
-		g_bTakeScreenshot = true;
+		take_screenshot();
 		return;
 	}
 


### PR DESCRIPTION
Tested with:

    gst-launch-1.0 pipewiresrc path=<node ID> ! videoconvert ! xvimagesink

To automatically find the PipeWire node ID:

    gst-launch-1.0 pipewiresrc "path=$(pw-dump | jq '.[] | select(.info.props["node.name"] == "gamescope") | .id')" ! videoconvert ! xvimagesink

Closes: https://github.com/Plagman/gamescope/issues/213