### PR TITLE
pipewire: allocate our own buffers 

### DIFF
--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -18,7 +18,9 @@ static LogScope log("pipewire");
 static struct pipewire_state pipewire_state = { .stream_node_id = SPA_ID_INVALID };
 static int nudgePipe[2] = { -1, -1 };
 
+// Pending buffer for PipeWire → steamcompmgr
 static std::atomic<struct pipewire_buffer *> out_buffer;
+// Pending buffer for steamcompmgr → PipeWire
 static std::atomic<struct pipewire_buffer *> in_buffer;
 
 static void destroy_buffer(struct pipewire_buffer *buffer) {

--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -107,7 +107,10 @@ static void dispatch_nudge(struct pipewire_state *state, int fd)
 		buffer->copying = false;
 
 		if (buffer->buffer != nullptr) {
-			pw_stream_queue_buffer(state->stream, buffer->buffer);
+			int ret = pw_stream_queue_buffer(state->stream, buffer->buffer);
+			if (ret < 0) {
+				log.errorf("pw_stream_queue_buffer failed");
+			}
 		} else {
 			destroy_buffer(buffer);
 		}

--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -19,10 +19,18 @@ struct pipewire_state {
 };
 
 struct pipewire_buffer {
-	struct pw_buffer *buffer;
 	struct spa_video_info_raw video_info;
 	int stride;
 	uint8_t *data;
+	int fd;
+
+	// The following fields are not thread-safe
+
+	// The PipeWire buffer, or nullptr if it's been destroyed.
+	struct pw_buffer *buffer;
+	// We pass the buffer to the steamcompmgr thread for copying. This is set
+	// to true if the buffer is currently owned by the steamcompmgr thread.
+	bool copying;
 };
 
 bool init_pipewire(void);

--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -18,6 +18,11 @@ struct pipewire_state {
 	uint64_t seq;
 };
 
+/**
+ * PipeWire buffers are allocated by the PipeWire thread, and are temporarily
+ * shared with the steamcompmgr thread (via dequeue_pipewire_buffer and
+ * push_pipewire_buffer) for copying.
+ */
 struct pipewire_buffer {
 	struct spa_video_info_raw video_info;
 	int stride;


### PR DESCRIPTION
This allows us to have more control over the buffers, in particular delay their destruction until after the steamcompmgr thread is done with them. 

Depends on https://github.com/Plagman/gamescope/pull/219