### PR TITLE
Unbreak build with system wlroots 0.13.0

### DIFF
--- a/src/cvt.cpp
+++ b/src/cvt.cpp
@@ -20,7 +20,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "backend/drm/cvt.h"
+#include "cvt.hpp"
 
 /* top/bottom margin size (% of height) - default: 1.8 */
 #define CVT_MARGIN_PERCENTAGE 1.8


### PR DESCRIPTION
Regressed by b380f3fbf24e. Both gamescope and wlroots define `generate_cvt_mode`.
```
$ meson setup --force-fallback-for=libliftoff /tmp/gamescope_build
$ meson compile -C /tmp/gamescope_build
[...]
src/cvt.cpp:23:10: fatal error: 'backend/drm/cvt.h' file not found
#include "backend/drm/cvt.h"
          ^~~~~~~~~~~~~~~~~~~
1 error generated.
```
