### PR TITLE
Added absolute mouse handling

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -766,6 +766,27 @@ void wlserver_mousemotion( int x, int y, uint32_t time )
 	}
 }
 
+void wlserver_absmousemotion( int x, int y, uint32_t time )
+{
+	if( g_XWLDpy != NULL )
+	{
+
+		float scale =
+			fmax(
+					(float)wlserver.mouse_focus_surface->current.height / g_nOutputHeight,
+					(float)wlserver.mouse_focus_surface->current.width / g_nOutputWidth
+				);
+
+		int nestedY = scale * ( y - g_nOutputHeight / 2.0 ) +
+			wlserver.mouse_focus_surface->current.height / 2.0;
+		int nestedX = scale * ( x - g_nOutputWidth / 2.0 ) +
+			wlserver.mouse_focus_surface->current.width / 2.0;
+
+		XTestFakeMotionEvent( g_XWLDpy, -1, nestedX, nestedY, CurrentTime );
+		XFlush( g_XWLDpy );
+	}
+}
+
 void wlserver_mousebutton( int button, bool press, uint32_t time )
 {
 	wlr_seat_pointer_notify_button( wlserver.wlr.seat, time, button, press ? WLR_BUTTON_PRESSED : WLR_BUTTON_RELEASED );

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -86,6 +86,7 @@ void wlserver_key( uint32_t key, bool press, uint32_t time );
 
 void wlserver_mousefocus( struct wlr_surface *wlrsurface );
 void wlserver_mousemotion( int x, int y, uint32_t time );
+void wlserver_absmousemotion( int x, int y, uint32_t time );
 void wlserver_mousebutton( int button, bool press, uint32_t time );
 void wlserver_mousewheel( int x, int y, uint32_t time );
 


### PR DESCRIPTION
Adds an absolute position based mouse handling instead of relative.

Tested with `gamescope -w 5000 -h 5000 -H 1080 --  glxgears` and `gamescope -w 5000 -h 5000 -H 1080 --  pinta` and it seems to work fine?

Currently it's toggled on and off with `Shift+ScrollLock`

This should somewhat resolve #216 since the window doesn't capture the mouse when enabled