### PR TITLE
meta: Use wrap file for STB rather than submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "subprojects/libliftoff"]
 	path = subprojects/libliftoff
 	url = https://github.com/emersion/libliftoff.git
-[submodule "subprojects/stb"]
-	path = subprojects/stb
-	url = https://github.com/nothings/stb

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,8 @@ cap_dep = dependency('libcap')
 sdl_dep = dependency('SDL2')
 pipewire_dep = dependency('libpipewire-0.3', required: get_option('pipewire'))
 
+stb_dep = dependency('stb')
+
 wlroots_dep = dependency(
   'wlroots',
   version: ['>= 0.13.0', '< 0.14.0'],
@@ -103,7 +105,7 @@ executable(
     dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
     dep_xxf86vm, dep_xres, drm_dep, wayland_server, wayland_protos,
     xkbcommon, thread_dep, sdl_dep, wlroots_dep,
-    vulkan_dep, liftoff_dep, dep_xtst, cap_dep, pipewire_dep,
+    vulkan_dep, liftoff_dep, dep_xtst, cap_dep, pipewire_dep, stb_dep,
   ],
   install: true,
 )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -81,7 +81,7 @@
 #endif
 
 #define STB_IMAGE_IMPLEMENTATION
-#include "../subprojects/stb/stb_image.h"
+#include <stb_image.h>
 
 #define GPUVIS_TRACE_IMPLEMENTATION
 #include "gpuvis_trace_utils.h"

--- a/subprojects/packagefiles/stb/meson.build
+++ b/subprojects/packagefiles/stb/meson.build
@@ -1,0 +1,8 @@
+project('stb', 'c', version : '0.1.0', license : 'MIT')
+
+stb_dep = declare_dependency(
+  include_directories : include_directories('.'),
+  version             : meson.project_version()
+)
+
+meson.override_dependency('stb', stb_dep)

--- a/subprojects/stb.wrap
+++ b/subprojects/stb.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+directory = stb
+
+url = https://github.com/nothings/stb.git
+revision = head
+
+patch_directory = stb


### PR DESCRIPTION
Allows us to use this as a Meson subproject which means that recursive cloning doesn't matter (Meson resolves it for subprojects).

Given this subproject doesn't have a meson file, doing subproject() on it would fail, so:
Make a wrap file with an overlay that declares a proper dependency.

Signed-off-by: Joshua Ashton <joshua@froggi.es>