### PR TITLE
Add IME protocol

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,7 @@ src = [
   'src/vblankmanager.cpp',
   'src/rendervulkan.cpp',
   'src/log.cpp',
+  'src/ime.cpp',
   spirv_shader,
 ]
 

--- a/protocol/gamescope-input-method.xml
+++ b/protocol/gamescope-input-method.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="gamescope_input_method">
+
+  <copyright>
+    Copyright © 2008-2011 Kristian Høgsberg
+    Copyright © 2010-2011 Intel Corporation
+    Copyright © 2012-2013 Collabora, Ltd.
+    Copyright © 2012, 2013 Intel Corporation
+    Copyright © 2015, 2016 Jan Arne Petersen
+    Copyright © 2017, 2018 Red Hat, Inc.
+    Copyright © 2018       Purism SPC
+    Copyright © 2021       Valve Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for creating input methods">
+    This protocol allows applications to act as input methods for compositors.
+
+    An input method context is used to manage the state of the input method.
+
+    Text strings are UTF-8 encoded, their indices and lengths are in bytes.
+
+    This iteration of the protocol is a subset of this work-in-progress proposal:
+    https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/112
+
+    This is a private Gamescope protocol. Regular Wayland clients must not use
+    it.
+  </description>
+
+  <interface name="gamescope_input_method_manager" version="1">
+    <description summary="input method manager">
+      The input method manager allows the client to become the input method on
+      a chosen seat.
+
+      No more than one input method must be associated with any seat at any
+      given time.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the input method manager">
+        Destroys the gamescope_input_method_manager object.
+
+        The gamescope_input_method objects originating from it remain valid.
+      </description>
+    </request>
+
+    <request name="create_input_method">
+      <description summary="create an input method object">
+        Create a new gamescope_input_method object associated with a given
+        seat.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="input_method" type="new_id" interface="gamescope_input_method"/>
+    </request>
+  </interface>
+
+  <interface name="gamescope_input_method" version="1">
+    <description summary="input method">
+      An input method object allows for clients to compose text.
+
+      The objects connects the client to a text input in an application, and
+      lets the client to serve as an input method for a seat.
+
+      There must be no more than one input method object per seat.
+    </description>
+
+    <event name="unavailable">
+      <description summary="input method unavailable">
+        The input method ceased to be available.
+
+        The compositor must issue this event as the only event on the object if
+        there was another input_method object associated with the same seat at
+        the time of its creation.
+
+        The compositor must issue this request when the object is no longer
+        useable, e.g. due to seat removal.
+
+        The input method context becomes inert and should be destroyed. Any
+        further requests and events except for the destroy request must be
+        ignored.
+      </description>
+    </event>
+
+    <event name="done">
+      <description summary="compositor state change notification">
+        Notify the client that the compositor state has changed.
+
+        The serial is used to synchronize compositor state changes and client
+        state changes. The serial allows the compositor to ignore requests
+        meant for a previous text input.
+
+        In the future, will be used to atomically apply compositor state
+        changes sent to the client (but currently there's no such state).
+      </description>
+      <arg name="serial" type="uint"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the text input">
+        Destroys the gamescope_text_input object.
+      </description>
+    </request>
+
+    <request name="commit">
+      <description summary="apply state">
+        Apply state changes from set_string and set_action requests.
+
+        The state relating to these events is double-buffered, and each one
+        modifies the pending state. This request replaces the current state
+        with the pending state.
+
+        The client must set the serial to the last received serial in the done
+        event.
+      </description>
+      <arg name="serial" type="uint" summary="last received serial"/>
+    </request>
+
+    <request name="set_string">
+      <description summary="set string to be committed">
+        Send the string text for insertion to the application.
+
+        Inserts a string at current cursor position (see commit event
+        sequence). The string to commit could be either just a single character
+        after a key press or the result of some composing.
+
+        Values set with this event are double-buffered. They must be applied
+        and reset to initial on the next gamescope_text_input.commit request.
+
+        The initial value of text is an empty string.
+      </description>
+      <arg name="text" type="string" summary="text to insert"/>
+    </request>
+  </interface>
+</protocol>

--- a/protocol/gamescope-input-method.xml
+++ b/protocol/gamescope-input-method.xml
@@ -148,5 +148,30 @@
       </description>
       <arg name="text" type="string" summary="text to insert"/>
     </request>
+
+    <enum name="action">
+      <description summary="action">
+        A possible action to perform on a text input.
+
+        The backspace and delete actions should be handled in a similar manner
+        to backpace and delete keys being pressed on a keyboard.
+      </description>
+      <entry name="none" value="0" summary="no action"/>
+      <entry name="submit" value="1" summary="submit"/>
+      <entry name="delete_left" value="2" summary="delete one unit before the cursor"/>
+      <entry name="delete_right" value="3" summary="delete one unit after the cursor"/>
+      <entry name="move_left" value="4" summary="move the cursor to the left by one unit"/>
+      <entry name="move_right" value="5" summary="move the cursor to the right by one unit"/>
+    </enum>
+
+    <request name="set_action">
+      <description summary="perform an action">
+        Set the action to be performed on commit.
+
+        Values set with this event are double-buffered. They must be applied
+        and reset to initial on the next gamescope_text_input.commit request.
+      </description>
+      <arg name="action" type="uint" enum="action" summary="action performed"/>
+    </request>
   </interface>
 </protocol>

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -5,6 +5,7 @@ wayland_scanner = find_program(wayland_scanner_path, native: true)
 protocols = [
 	'gamescope-xwayland',
 	'gamescope-pipewire',
+	'gamescope-input-method',
 ]
 
 foreach name : protocols

--- a/src/ime.cpp
+++ b/src/ime.cpp
@@ -136,12 +136,6 @@ static struct xkb_keymap *generate_keymap(struct wlserver_input_method *ime)
 
 		char keysym_name[256];
 		xkb_keysym_get_name(keysym, keysym_name, sizeof(keysym_name));
-
-		if (keysym_name[0] == '0' && keysym_name[1] == 'x') {
-			// Unicode keysyms need special handling
-			snprintf(keysym_name, sizeof(keysym_name), "U%04x", keysym);
-		}
-
 		fprintf(f, "	key <K%u> {[ %s ]};\n", keycode, keysym_name);
 	}
 

--- a/src/ime.cpp
+++ b/src/ime.cpp
@@ -1,0 +1,267 @@
+#include "ime.hpp"
+#include "wlserver.hpp"
+#include "log.hpp"
+
+#include <unistd.h>
+
+#include <unordered_map>
+#include <vector>
+
+extern "C" {
+#define delete delete_
+#include <wlr/interfaces/wlr_input_device.h>
+#include <wlr/interfaces/wlr_keyboard.h>
+#include <wlr/types/wlr_input_method_v2.h>
+#include <wlr/types/wlr_keyboard.h>
+#undef delete
+}
+
+/* The C/C++ standard library doesn't expose a reliable way to decode UTF-8,
+ * so we need to ship our own implementation. Yay for locales. */
+
+static const uint32_t UTF8_INVALID = 0xFFFD;
+
+static size_t utf8_size(const char *str)
+{
+	uint8_t u8 = (uint8_t)str[0];
+	if ((u8 & 0x80) == 0) {
+		return 1;
+	} else if ((u8 & 0xE0) == 0xC0) {
+		return 2;
+	} else if ((u8 & 0xF0) == 0xE0) {
+		return 3;
+	} else if ((u8 & 0xF8) == 0xF0) {
+		return 4;
+	} else {
+		return 0;
+	}
+}
+
+static uint32_t utf8_decode(const char **str_ptr)
+{
+	const char *str = *str_ptr;
+	size_t size = utf8_size(str);
+	if (size == 0) {
+		*str_ptr = &str[1];
+		return UTF8_INVALID;
+	}
+
+	*str_ptr = &str[size];
+
+	const uint32_t masks[] = { 0x7F, 0x1F, 0x0F, 0x07 };
+	uint32_t ret = (uint32_t)str[0] & masks[size - 1];
+	for (size_t i = 1; i < size; i++) {
+		ret <<= 6;
+		ret |= str[i] & 0x3F;
+	}
+	return ret;
+}
+
+struct wlserver_input_method_key {
+	xkb_keycode_t keycode;
+	xkb_keysym_t keysym;
+};
+
+struct wlserver_input_method {
+	struct wlr_input_method_v2 *input_method;
+	struct wlserver_t *server;
+
+	// Used to send emulated input events
+	struct wlr_keyboard keyboard;
+	struct wlr_input_device keyboard_device;
+	std::unordered_map<uint32_t, struct wlserver_input_method_key> keys;
+
+	struct wl_listener commit;
+	struct wl_listener destroy;
+};
+
+static LogScope ime_log("ime");
+
+static struct wlserver_input_method *active_input_method = nullptr;
+
+static xkb_keycode_t keycode_from_ch(struct wlserver_input_method *ime, uint32_t ch)
+{
+	if (ime->keys.count(ch) > 0) {
+		return ime->keys[ch].keycode;
+	}
+
+	xkb_keysym_t keysym = xkb_utf32_to_keysym(ch);
+	if (keysym == XKB_KEY_NoSymbol) {
+		return XKB_KEYCODE_INVALID;
+	}
+
+	// Add 1 because some clients don't handle correctly zero keycodes
+	xkb_keycode_t keycode = ime->keys.size() + 1;
+	ime->keys[ch] = (struct wlserver_input_method_key){ keycode, keysym };
+	return keycode;
+}
+
+static struct xkb_keymap *generate_keymap(struct wlserver_input_method *ime)
+{
+	uint32_t keycode_offset = 8;
+
+	char *str = NULL;
+	size_t str_size = 0;
+	FILE *f = open_memstream(&str, &str_size);
+
+	fprintf(f,
+		"xkb_keymap {\n"
+		"\n"
+		"xkb_keycodes \"(unnamed)\" {\n"
+		"	minimum = %u;\n"
+		"	maximum = %lu;\n",
+		keycode_offset + 1,
+		ime->keys.size() + keycode_offset + 1
+	);
+
+	for (const auto kv : ime->keys) {
+		xkb_keycode_t keycode = kv.second.keycode;
+		fprintf(f, "	<K%u> = %u;\n", keycode, keycode + keycode_offset);
+	}
+
+	// TODO: should we really be including "complete" here?
+	fprintf(f,
+		"};\n"
+		"\n"
+		"xkb_types \"(unnamed)\" { include \"complete\" };\n"
+		"\n"
+		"xkb_compatibility \"(unnamed)\" { include \"complete\" };\n"
+		"\n"
+		"xkb_symbols \"(unnamed)\" {\n"
+	);
+
+	for (const auto kv : ime->keys) {
+		xkb_keycode_t keycode = kv.second.keycode;
+		xkb_keysym_t keysym = kv.second.keysym;
+
+		char keysym_name[256];
+		xkb_keysym_get_name(keysym, keysym_name, sizeof(keysym_name));
+
+		if (keysym_name[0] == '0' && keysym_name[1] == 'x') {
+			// Unicode keysyms need special handling
+			snprintf(keysym_name, sizeof(keysym_name), "U%04x", keysym);
+		}
+
+		fprintf(f, "	key <K%u> {[ %s ]};\n", keycode, keysym_name);
+	}
+
+	fprintf(f,
+		"};\n"
+		"\n"
+		"};\n"
+	);
+
+	fclose(f);
+
+	struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+	struct xkb_keymap *keymap = xkb_keymap_new_from_buffer(context, str, str_size, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+	xkb_context_unref(context);
+
+	free(str);
+
+	return keymap;
+}
+
+static void type_text(struct wlserver_input_method *ime, const char *text)
+{
+	ime->keys.clear();
+
+	std::vector<xkb_keycode_t> keycodes;
+	while (text[0] != '\0') {
+		uint32_t ch = utf8_decode(&text);
+
+		xkb_keycode_t keycode = keycode_from_ch(ime, ch);
+		if (keycode == XKB_KEYCODE_INVALID) {
+			ime_log.errorf("warning: cannot type character U+%X\n", ch);
+			continue;
+		}
+
+		keycodes.push_back(keycode);
+	}
+
+	struct xkb_keymap *keymap = generate_keymap(ime);
+	if (keymap == nullptr) {
+		ime_log.errorf("failed to generate keymap\n");
+		return;
+	}
+	wlr_keyboard_set_keymap(&ime->keyboard, keymap);
+	xkb_keymap_unref(keymap);
+
+	struct wlr_seat *seat = ime->server->wlr.seat;
+	wlr_seat_set_keyboard(seat, &ime->keyboard_device);
+	for (size_t i = 0; i < keycodes.size(); i++) {
+		wlr_seat_keyboard_notify_key(seat, 0, keycodes[i], WL_KEYBOARD_KEY_STATE_PRESSED);
+		wlr_seat_keyboard_notify_key(seat, 0, keycodes[i], WL_KEYBOARD_KEY_STATE_RELEASED);
+	}
+}
+
+static void ime_handle_commit(struct wl_listener *l, void *data)
+{
+	struct wlserver_input_method *ime = wl_container_of(l, ime, commit);
+
+	const char *text = ime->input_method->current.commit_text;
+	if (text != nullptr) {
+		type_text(ime, text);
+	}
+}
+
+static void ime_handle_destroy(struct wl_listener *l, void *data)
+{
+	struct wlserver_input_method *ime = wl_container_of(l, ime, destroy);
+
+	active_input_method = nullptr;
+
+	wlr_input_device_destroy(&ime->keyboard_device);
+
+	wl_list_remove(&ime->commit.link);
+	wl_list_remove(&ime->destroy.link);
+	delete ime;
+}
+
+static void keyboard_destroy(struct wlr_keyboard *kyeboard) {}
+
+static const struct wlr_keyboard_impl keyboard_impl = {
+	.destroy = keyboard_destroy,
+};
+
+static void keyboard_device_destroy(struct wlr_input_device *dev) {}
+
+static const struct wlr_input_device_impl keyboard_device_impl = {
+	.destroy = keyboard_device_destroy,
+};
+
+static void wlserver_new_input_method(struct wl_listener *l, void *data)
+{
+	struct wlserver_t *wlserver = wl_container_of(l, wlserver, new_input_method);
+	struct wlr_input_method_v2 *wlr_ime = (struct wlr_input_method_v2 *)data;
+
+	if (active_input_method != nullptr) {
+		wlr_input_method_v2_send_unavailable(wlr_ime);
+		return;
+	}
+
+	struct wlserver_input_method *ime = new wlserver_input_method();
+	ime->input_method = wlr_ime;
+	ime->server = wlserver;
+	ime->commit.notify = ime_handle_commit;
+	wl_signal_add(&wlr_ime->events.commit, &ime->commit);
+	ime->destroy.notify = ime_handle_destroy;
+	wl_signal_add(&wlr_ime->events.destroy, &ime->destroy);
+
+	wlr_keyboard_init(&ime->keyboard, &keyboard_impl);
+	wlr_input_device_init(&ime->keyboard_device, WLR_INPUT_DEVICE_KEYBOARD, &keyboard_device_impl, "ime", 0, 0);
+	ime->keyboard_device.keyboard = &ime->keyboard;
+
+	wlr_input_method_v2_send_activate(wlr_ime);
+	wlr_input_method_v2_send_done(wlr_ime);
+
+	active_input_method = ime;
+}
+
+void create_ime_manager(struct wlserver_t *wlserver)
+{
+	struct wlr_input_method_manager_v2 *ime_manager = wlr_input_method_manager_v2_create(wlserver->display);
+
+	wlserver->new_input_method.notify = wlserver_new_input_method;
+	wl_signal_add(&ime_manager->events.input_method, &wlserver->new_input_method);
+}

--- a/src/ime.cpp
+++ b/src/ime.cpp
@@ -135,7 +135,12 @@ static struct xkb_keymap *generate_keymap(struct wlserver_input_method *ime)
 		xkb_keysym_t keysym = kv.second.keysym;
 
 		char keysym_name[256];
-		xkb_keysym_get_name(keysym, keysym_name, sizeof(keysym_name));
+		int ret = xkb_keysym_get_name(keysym, keysym_name, sizeof(keysym_name));
+		if (ret <= 0) {
+			ime_log.errorf("xkb_keysym_get_name failed for keysym %u", keysym);
+			return nullptr;
+		}
+
 		fprintf(f, "	key <K%u> {[ %s ]};\n", keycode, keysym_name);
 	}
 

--- a/src/ime.cpp
+++ b/src/ime.cpp
@@ -246,6 +246,8 @@ static void wlserver_new_input_method(struct wl_listener *l, void *data)
 	wlr_input_device_init(&ime->keyboard_device, WLR_INPUT_DEVICE_KEYBOARD, &keyboard_device_impl, "ime", 0, 0);
 	ime->keyboard_device.keyboard = &ime->keyboard;
 
+	wlr_keyboard_set_repeat_info(&ime->keyboard, 0, 0);
+
 	wlr_input_method_v2_send_activate(wlr_ime);
 	wlr_input_method_v2_send_done(wlr_ime);
 

--- a/src/ime.hpp
+++ b/src/ime.hpp
@@ -1,0 +1,7 @@
+// Input Method Editor
+
+#pragma once
+
+#include "wlserver.hpp"
+
+void create_ime_manager(struct wlserver_t *wlserver);

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -44,6 +44,7 @@ extern "C" {
 #include "main.hpp"
 #include "steamcompmgr.hpp"
 #include "log.hpp"
+#include "ime.hpp"
 
 #if HAVE_PIPEWIRE
 #include "pipewire.hpp"
@@ -417,7 +418,7 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 	}
 }
 
-struct wl_listener new_input_listener = { .notify = wlserver_new_input };
+static struct wl_listener new_input_listener = { .notify = wlserver_new_input };
 
 static void wlserver_new_surface(struct wl_listener *l, void *data)
 {
@@ -434,7 +435,7 @@ static void wlserver_new_surface(struct wl_listener *l, void *data)
 	}
 }
 
-struct wl_listener new_surface_listener = { .notify = wlserver_new_surface };
+static struct wl_listener new_surface_listener = { .notify = wlserver_new_surface };
 
 static void destroy_content_override( struct wlserver_content_override *co )
 {
@@ -657,6 +658,8 @@ bool wlserver_init( void ) {
 	wlserver.wlr.compositor = wlr_compositor_create(wlserver.display, wlserver.wlr.renderer);
 
 	wl_signal_add( &wlserver.wlr.compositor->events.new_surface, &new_surface_listener );
+
+	create_ime_manager( &wlserver );
 
 	create_gamescope_xwayland();
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -376,6 +376,8 @@ static void wlserver_new_input(struct wl_listener *listener, void *data)
 			xkb_context_unref(context);
 			wlr_keyboard_set_repeat_info(device->keyboard, 25, 600);
 
+			device->keyboard->data = pKB;
+
 			pKB->modifiers.notify = wlserver_handle_modifiers;
 			wl_signal_add( &device->keyboard->events.modifiers, &pKB->modifiers );
 
@@ -626,7 +628,6 @@ bool wlserver_init( void ) {
 
 	wlserver.wlr.output = wlr_noop_add_output( wlserver.wlr.noop_backend );
 
-	struct wlr_input_device *kbd_dev = nullptr;
 	if ( bIsDRM == True )
 	{
 		wlserver.wlr.libinput_backend = wlr_libinput_backend_create( wlserver.display, wlserver.wlr.session );
@@ -636,20 +637,17 @@ bool wlserver_init( void ) {
 		}
 		wlr_multi_backend_add( wlserver.wlr.multi_backend, wlserver.wlr.libinput_backend );
 	}
-	else
-	{
-		// Create a stub wlr_keyboard only used to set the keymap
-		struct wlr_keyboard *kbd = (struct wlr_keyboard *) calloc(1, sizeof(*kbd));
-		wlr_keyboard_init(kbd, nullptr);
 
-		kbd_dev = (struct wlr_input_device *) calloc(1, sizeof(*kbd_dev));
-		wlr_input_device_init(kbd_dev, WLR_INPUT_DEVICE_KEYBOARD, nullptr, "noop", 0, 0);
-		kbd_dev->keyboard = kbd;
+	// Create a stub wlr_keyboard only used to set the keymap
+	// We need to wait for the backend to be started before adding the device
+	struct wlr_keyboard *kbd = (struct wlr_keyboard *) calloc(1, sizeof(*kbd));
+	wlr_keyboard_init(kbd, nullptr);
 
-		wlserver.wlr.virtual_keyboard_device = kbd_dev;
+	struct wlr_input_device *kbd_dev = (struct wlr_input_device *) calloc(1, sizeof(*kbd_dev));
+	wlr_input_device_init(kbd_dev, WLR_INPUT_DEVICE_KEYBOARD, nullptr, "virtual", 0, 0);
+	kbd_dev->keyboard = kbd;
 
-		// We need to wait for the backend to be started before adding the device
-	}
+	wlserver.wlr.virtual_keyboard_device = kbd_dev;
 
 	wlserver.wlr.renderer = vulkan_renderer_create();
 
@@ -697,8 +695,7 @@ bool wlserver_init( void ) {
 		return false;
 	}
 
-	if ( kbd_dev != nullptr )
-		wl_signal_emit( &wlserver.wlr.multi_backend->events.new_input, kbd_dev );
+	wl_signal_emit( &wlserver.wlr.multi_backend->events.new_input, kbd_dev );
 
 	int refresh = g_nNestedRefresh;
 	if (refresh == 0) {

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -37,6 +37,7 @@ struct wlserver_t {
 	bool touch_down[ WLSERVER_TOUCH_COUNT ];
 
 	struct wl_listener session_active;
+	struct wl_listener new_input_method;
 };
 
 struct wlserver_keyboard {

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -25,7 +25,7 @@ struct wlserver_t {
 		struct wlr_seat *seat;
 		struct wlr_output *output;
 
-		// Used to simulate key events when nested
+		// Used to simulate key events and set the keymap
 		struct wlr_input_device *virtual_keyboard_device;
 	} wlr;
 	
@@ -35,6 +35,8 @@ struct wlserver_t {
 	
 	bool button_held[ WLSERVER_BUTTON_COUNT ];
 	bool touch_down[ WLSERVER_TOUCH_COUNT ];
+
+	struct wl_event_source *ime_reset_keyboard_event_source;
 
 	struct wl_listener session_active;
 	struct wl_listener new_input_method;

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -36,8 +36,6 @@ struct wlserver_t {
 	bool button_held[ WLSERVER_BUTTON_COUNT ];
 	bool touch_down[ WLSERVER_TOUCH_COUNT ];
 
-	struct wl_event_source *ime_reset_keyboard_event_source;
-
 	struct wl_listener session_active;
 	struct wl_listener new_input_method;
 };


### PR DESCRIPTION
This allows a Wayland client to send arbitrary UTF-8 text to the
currently focused X11 client. Useful for virtual keyboards.

We generate a keymap on-the-fly suitable for the text to type.

Tested with https://git.sr.ht/~emersion/wl-ime-type.

Closes: https://github.com/Plagman/gamescope/issues/205