### PR TITLE
wlserver: Fix FPS games using a mouse&keyboard (embedded)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -104,6 +104,7 @@ subdir('protocol')
 executable(
   'gamescope',
   src,
+  include_directories: ['./subprojects/wlroots/protocol/'],
   dependencies: [
     dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
     dep_xxf86vm, dep_xres, drm_dep, wayland_server, wayland_protos,

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -4,6 +4,9 @@
 
 #include <wayland-server-core.h>
 #include <atomic>
+extern "C" {
+#include <wlr/util/region.h>
+}
 
 #define WLSERVER_BUTTON_COUNT 4
 #define WLSERVER_TOUCH_COUNT 11 // Ten fingers + nose ought to be enough for anyone
@@ -27,6 +30,19 @@ struct wlserver_t {
 
 		// Used to simulate key events when nested
 		struct wlr_input_device *virtual_keyboard_device;
+
+		struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
+		struct wl_listener relative_pointer_listener;
+
+		struct wlr_pointer_constraints_v1 *pointer_constraints;
+		struct wl_listener pointer_constraints_listener;
+
+		struct {
+			struct wlr_pointer_constraint_v1 *active;
+			pixman_region32_t confine; // invalid if active == NULL
+			struct wl_listener commit;
+		} constraint;
+
 	} wlr;
 	
 	struct wlr_surface *mouse_focus_surface;


### PR DESCRIPTION
This is a rebase and simplication of @subdiff's merge request #28 that
was reverted.

This fixes #19 "Mouse input in embedded doesn't work when grabbed".

I have tested this commit for some weeks now. I can play FPS games
(like Goat Simulator) with a mouse&keyboard. I can still play games
without grab like Factorio, with mouse, but also with a controller (I
used the Steam Controller to test).

The original branch broke some mouse games with game controllers. See