### PR TITLE
Silence some compiler warnings

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -184,8 +184,8 @@ static void page_flip_handler(int fd, unsigned int frame, unsigned int sec, unsi
 
 	// TODO: get the fbids_queued instance from data if we ever have more than one in flight
 
-	drm_verbose_log.debugf("page_flip_handler %lu", flipcount);
-	gpuvis_trace_printf("page_flip_handler %lu", flipcount);
+	drm_verbose_log.debugf("page_flip_handler %" PRIu64, flipcount);
+	gpuvis_trace_printf("page_flip_handler %" PRIu64, flipcount);
 
 	for ( uint32_t i = 0; i < g_DRM.fbids_on_screen.size(); i++ )
 	{
@@ -774,8 +774,8 @@ int drm_commit(struct drm_t *drm, struct Composite_t *pComposite, struct VulkanP
 
 	g_DRM.flipcount++;
 
-	drm_verbose_log.debugf("flip commit %lu", (uint64_t)g_DRM.flipcount);
-	gpuvis_trace_printf( "flip commit %lu", (uint64_t)g_DRM.flipcount );
+	drm_verbose_log.debugf("flip commit %" PRIu64, (uint64_t)g_DRM.flipcount);
+	gpuvis_trace_printf( "flip commit %" PRIu64, (uint64_t)g_DRM.flipcount );
 
 	ret = drmModeAtomicCommit(drm->fd, drm->req, drm->flags, (void*)(uint64_t)g_DRM.flipcount );
 	if ( ret != 0 )

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -427,7 +427,7 @@ static void wlserver_new_surface(struct wl_listener *l, void *data)
 	struct wlserver_surface *s, *tmp;
 	wl_list_for_each_safe(s, tmp, &pending_surfaces, pending_link)
 	{
-		if (s->wl_id == id && s->wlr == nullptr)
+		if (s->wl_id == (long)id && s->wlr == nullptr)
 		{
 			wlserver_surface_set_wlr( s, wlr_surf );
 		}

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -487,6 +487,7 @@ static void create_gamescope_xwayland( void )
 	wl_global_create( wlserver.display, &gamescope_xwayland_interface, version, NULL, gamescope_xwayland_bind );
 }
 
+#if HAVE_PIPEWIRE
 static void gamescope_pipewire_handle_destroy( struct wl_client *client, struct wl_resource *resource )
 {
 	wl_resource_destroy( resource );
@@ -501,11 +502,7 @@ static void gamescope_pipewire_bind( struct wl_client *client, void *data, uint3
 	struct wl_resource *resource = wl_resource_create( client, &gamescope_pipewire_interface, version, id );
 	wl_resource_set_implementation( resource, &gamescope_pipewire_impl, NULL, NULL );
 
-#if HAVE_PIPEWIRE
 	gamescope_pipewire_send_stream_node( resource, get_pipewire_stream_node_id() );
-#else
-	assert( 0 ); // unreachable
-#endif
 }
 
 static void create_gamescope_pipewire( void )
@@ -513,6 +510,7 @@ static void create_gamescope_pipewire( void )
 	uint32_t version = 1;
 	wl_global_create( wlserver.display, &gamescope_pipewire_interface, version, NULL, gamescope_pipewire_bind );
 }
+#endif
 
 static void handle_session_active( struct wl_listener *listener, void *data )
 {


### PR DESCRIPTION
GCC 11 + Clang 13 report:
```c++
src/wlserver.cpp: In function 'void wlserver_new_surface(wl_listener*, void*)':
src/wlserver.cpp:430:30: warning: comparison of integer expressions of different signedness: 'long int' and 'uint32_t' {aka 'unsigned int'} [-Wsign-compare]
  430 |                 if (s->wl_id == id && s->wlr == nullptr)
      |                     ~~~~~~~~~^~~~~
src/drm.cpp: In function 'void page_flip_handler(int, unsigned int, unsigned int, unsigned int, unsigned int, void*)':
src/drm.cpp:187:53: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'uint64_t' {aka 'long long unsigned int'} [-Wformat=]
  187 |         drm_verbose_log.debugf("page_flip_handler %lu", flipcount);
      |                                                   ~~^   ~~~~~~~~~
      |                                                     |   |
      |                                                     |   uint64_t {aka long long unsigned int}
      |                                                     long unsigned int
      |                                                   %llu
src/drm.cpp: In function 'int drm_commit(drm_t*, Composite_t*, VulkanPipeline_t*)':
src/drm.cpp:777:47: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'std::__atomic_base<long long unsigned int>::__int_type' {aka 'long long unsigned int'} [-Wformat=]
  777 |         drm_verbose_log.debugf("flip commit %lu", (uint64_t)g_DRM.flipcount);
      |                                             ~~^   ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                               |   |
      |                                               |   std::__atomic_base<long long unsigned int>::__int_type {aka long long unsigned int}
      |                                               long unsigned int
      |                                             %llu
```
This GCC-only is left unfixed:
```c++
src/steamcompmgr.cpp: In function 'uint32_t get_appid_from_pid(pid_t)':
src/steamcompmgr.cpp:2161:36: warning: 'lastParens' may be used uninitialized in this function [-Wmaybe-uninitialized]
 2161 |                 sscanf( lastParens + 1, " %c %d", &state, &parent_pid );
      |                         ~~~~~~~~~~~^~~
```
This Clang-only is left unfixed:
```c++
src/pipewire.cpp:320:3: warning: array designators are a C99 extension [-Wc99-designator]
                [EVENT_PIPEWIRE] = {
                ^~~~~~~~~~~~~~~~
src/steamcompmgr.cpp:3760:3: warning: array designators are a C99 extension [-Wc99-designator]
                [ EVENT_X11 ] = {
                ^~~~~~~~~~~~~
```
