### PR TITLE
ci: turn on auto features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Build with gcc
         run: |
           export CC=gcc CXX=g++
-          meson build-gcc/ --werror
+          meson build-gcc/ --werror --auto-features=enabled
           ninja -C build-gcc/
       - name: Build with clang
         run: |
           export CC=clang CXX=clang++
-          meson build-clang/ --werror
+          meson build-clang/ --werror --auto-features=enabled
           ninja -C build-clang/


### PR DESCRIPTION
Ensures a feature doesn't get auto-disabled because a dep isn't
found.