### PR TITLE
rendervulkan: Add --composite-debug

### DIFF
--- a/src/composite.comp
+++ b/src/composite.comp
@@ -1,6 +1,7 @@
 #version 450
 
 #extension GL_EXT_scalar_block_layout : require
+#extension GL_EXT_shader_realtime_clock : require
 
 layout(
   local_size_x = 8,
@@ -12,6 +13,7 @@ const int MaxLayers = 4;
 layout(constant_id = 0) const int  c_layerCount   = 1;
 layout(constant_id = 1) const bool c_swapChannels = false;
 layout(constant_id = 2) const uint c_ycbcrMask    = 0;
+layout(constant_id = 3) const bool c_compositing_debug = false;
 
 layout(binding = 0, rgba8) writeonly uniform image2D dst;
 
@@ -21,11 +23,28 @@ uniform layers_t {
     vec2 u_offset[MaxLayers];
     float u_opacity[MaxLayers];
     float u_borderAlpha[MaxLayers];
+    uint u_frameId;
 };
 
 layout(binding = 1) uniform sampler2D s_samplers[MaxLayers];
 
 layout(binding = 5) uniform sampler2D s_ycbcr_samplers[MaxLayers];
+
+void compositing_debug(uvec2 size, uvec2 coord) {
+    uvec2 pos = coord;
+    pos.x -= (u_frameId & 2) != 0 ? /* size.x - 160 */ 128 : 0;
+    pos.y -= (u_frameId & 1) != 0 ? /* size.y - 160 */ 128 : 0;
+
+    if (pos.x >= 40 && pos.x < 120 && pos.y >= 40 && pos.y < 120) {
+        vec4 value = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+        if (pos.x >= 48 && pos.x < 112 && pos.y >= 48 && pos.y < 112) {
+            vec4 time = round(unpackUnorm4x8(clockRealtime2x32EXT().x * 1664525u + 1013904223u)).xyzw;
+            if (time.x + time.y + time.z + time.w < 2.0f)
+                value = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+        imageStore(dst, ivec2(coord), value);
+    }
+}
 
 vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv) {
     vec2 coord = ((uv + u_offset[layerIdx]) * u_scale[layerIdx]);
@@ -69,6 +88,6 @@ void main() {
     imageStore(dst, ivec2(coord), outputValue);
 
     // Indicator to quickly tell if we're in the compositing path or not.
-    if (false && coord.x > 50 && coord.x < 100 && coord.y > 50 && coord.y < 100)
-        imageStore(dst, ivec2(coord), vec4(1.0f, 0.0f, 1.0f, 1.0f));
+    if (c_compositing_debug)
+        compositing_debug(outSize, coord);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "debug-events", no_argument, nullptr, 0 },
 	{ "steam", no_argument, nullptr, 'e' },
 	{ "force-composition", no_argument, nullptr, 'c' },
+	{ "composite-debug", no_argument, nullptr, 0 },
 	{ "disable-xres", no_argument, nullptr, 'x' },
 
 	{} // keep last
@@ -100,6 +101,7 @@ const char usage[] =
 	"  --debug-hud                    paint HUD with debug info\n"
 	"  --debug-events                 debug X11 events\n"
 	"  --force-composition            disable direct scan-out\n"
+	"  --composite-debug              draw frame markers on alternating corners of the screen when compositing\n"
 	"  --disable-xres                 disable XRes for PID lookup\n"
 	"\n"
 	"Keyboard shortcuts:\n"
@@ -237,6 +239,8 @@ int main(int argc, char **argv)
 					g_bUseLayers = false;
 				} else if (strcmp(opt_name, "debug-layers") == 0) {
 					g_bDebugLayers = true;
+				} else if (strcmp(opt_name, "composite-debug") == 0) {
+					g_bIsCompositeDebug = true;
 				} else if (strcmp(opt_name, "default-touch-mode") == 0) {
 					g_nDefaultTouchClickMode = (enum wlserver_touch_click_mode) atoi( optarg );
 					g_nTouchClickMode = g_nDefaultTouchClickMode;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -128,6 +128,8 @@ extern bool g_vulkanSupportsModifiers;
 extern bool g_vulkanHasDrmPrimaryDevId;
 extern dev_t g_vulkanDrmPrimaryDevId;
 
+extern bool g_bIsCompositeDebug;
+
 bool vulkan_init(void);
 bool vulkan_init_formats(void);
 bool vulkan_make_output(void);


### PR DESCRIPTION
Adds a --composite-debug flag for displaying frame markers on alternating corners of the screen or rotating in a localized square when compositing.

Signed-off-by: Joshua Ashton <joshua@froggi.es>