### PR TITLE
Force a redraw if the window focus changes.

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1593,6 +1593,8 @@ determine_and_apply_focus(Display *dpy, MouseCursor *cursor)
 	gameFocused = false;
 
 	Window prevFocusWindow = currentFocusWindow;
+	Window prevOverlayWindow = currentOverlayWindow;
+	Window prevNotificationWindow = currentNotificationWindow;
 	currentFocusWindow = None;
 	currentFocusWin = nullptr;
 	currentOverlayWindow = None;
@@ -1631,6 +1633,12 @@ determine_and_apply_focus(Display *dpy, MouseCursor *cursor)
 		{
 			inputFocus = w;
 		}
+	}
+
+	if ( prevOverlayWindow != currentOverlayWindow ||
+	     prevNotificationWindow != currentNotificationWindow )
+	{
+		hasRepaint = true;
 	}
 
 	std::vector< unsigned long > focusable_appids;
@@ -1776,6 +1784,8 @@ found:
 		XChangeProperty(dpy, focus->id, WMStateAtom, WMStateAtom, 32,
 					PropModeReplace, (unsigned char *)wmState,
 					sizeof(wmState) / sizeof(wmState[0]));
+
+		hasRepaint = true;
 
 		gpuvis_trace_printf( "determine_and_apply_focus focus %lu", focus->id );
 


### PR DESCRIPTION
Otherwise if all of the windows in the new situation never redraw
we never update to show the new focus configuration.

This change avoids things like stuck overlays and notification
windows if the underlying game is stuck.