### PR TITLE
Name our threads

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -223,6 +223,8 @@ static void page_flip_handler(int fd, unsigned int frame, unsigned int sec, unsi
 
 void flip_handler_thread_run(void)
 {
+	pthread_setname_np( pthread_self(), "gamescope-kms" );
+
 	struct pollfd pollfd = {
 		.fd = g_DRM.fd,
 		.events = POLLIN,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -394,6 +394,8 @@ int main(int argc, char **argv)
 
 static void steamCompMgrThreadRun(int argc, char **argv)
 {
+	pthread_setname_np( pthread_self(), "gamescope-xwm" );
+
 	steamcompmgr_main( argc, argv );
 
 	pthread_kill( g_mainThread, SIGINT );

--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -313,6 +313,8 @@ enum event_type {
 
 static void run_pipewire(struct pipewire_state *state)
 {
+	pthread_setname_np( pthread_self(), "gamescope-pw" );
+
 	struct pollfd pollfds[] = {
 		[EVENT_PIPEWIRE] = {
 			.fd = pw_loop_get_fd(state->loop),

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -336,6 +336,8 @@ bool imageWaitThreadRun = true;
 
 void imageWaitThreadMain( void )
 {
+	pthread_setname_np( pthread_self(), "gamescope-img" );
+
 wait:
 	waitListSem.wait();
 
@@ -398,6 +400,7 @@ bool statsThreadRun;
 
 void statsThreadMain( void )
 {
+	pthread_setname_np( pthread_self(), "gamescope-stats" );
 	signal(SIGPIPE, SIG_IGN);
 
 	while ( statsPipeFD == -1 )
@@ -3233,6 +3236,8 @@ spawn_client( char **argv )
 	}
 
 	std::thread waitThread([]() {
+		pthread_setname_np( pthread_self(), "gamescope-wait" );
+
 		// Because we've set PR_SET_CHILD_SUBREAPER above, we'll get process
 		// status notifications for all of our child processes, even if our
 		// direct child exits. Wait until all have exited.

--- a/src/vblankmanager.cpp
+++ b/src/vblankmanager.cpp
@@ -24,6 +24,8 @@ uint64_t g_uVblankDrawBufferNS = 5'000'000;
 
 void vblankThreadRun( void )
 {
+	pthread_setname_np( pthread_self(), "gamescope-vblk" );
+
 	while ( true )
 	{
 		uint64_t lastVblank = g_lastVblank - g_uVblankDrawBufferNS;


### PR DESCRIPTION
Unfortunately the name length is limited to 15 characters, and the executable name is dropped from the name if we don't include it.