### PR TITLE
rendervulkan: Multiple blending fixes

### DIFF
--- a/src/composite.comp
+++ b/src/composite.comp
@@ -30,6 +30,30 @@ layout(binding = 1) uniform sampler2D s_samplers[MaxLayers];
 
 layout(binding = 5) uniform sampler2D s_ycbcr_samplers[MaxLayers];
 
+vec3 srgbToLinear(vec3 color) {
+    bvec3 isLo = lessThanEqual(color, vec3(0.04045f));
+
+    vec3 loPart = color / 12.92f;
+    vec3 hiPart = pow((color + 0.055f) / 1.055f, vec3(12.0f / 5.0f));
+    return mix(hiPart, loPart, isLo);
+}
+
+vec4 srgbToLinear(vec4 color) {
+  return vec4(srgbToLinear(color.rgb), color.a);
+}
+
+vec3 linearToSrgb(vec3 color) {
+    bvec3 isLo = lessThanEqual(color, vec3(0.0031308f));
+
+    vec3 loPart = color * 12.92f;
+    vec3 hiPart = pow(color, vec3(5.0f / 12.0f)) * 1.055f - 0.055f;
+    return mix(hiPart, loPart, isLo);
+}
+
+vec4 linearToSrgb(vec4 color) {
+  return vec4(linearToSrgb(color.rgb), color.a);
+}
+
 void compositing_debug(uvec2 size, uvec2 coord) {
     uvec2 pos = coord;
     pos.x -= (u_frameId & 2) != 0 ? /* size.x - 160 */ 128 : 0;
@@ -59,7 +83,7 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv) {
 
 vec4 sampleLayer(uint layerIdx, vec2 uv) {
     if ((c_ycbcrMask & (1 << layerIdx)) != 0)
-        return sampleLayer(s_ycbcr_samplers[layerIdx], layerIdx, uv);
+        return srgbToLinear(sampleLayer(s_ycbcr_samplers[layerIdx], layerIdx, uv));
     return sampleLayer(s_samplers[layerIdx], layerIdx, uv);
 }
 
@@ -85,7 +109,7 @@ void main() {
     if (c_swapChannels)
         outputValue = outputValue.bgra;
 
-    imageStore(dst, ivec2(coord), outputValue);
+    imageStore(dst, ivec2(coord), linearToSrgb(outputValue));
 
     // Indicator to quickly tell if we're in the compositing path or not.
     if (c_compositing_debug)

--- a/src/composite.comp
+++ b/src/composite.comp
@@ -102,8 +102,14 @@ void main() {
 
     for (int i = 1; i < c_layerCount; i++) {
         vec4 layerColor = sampleLayer(i, uv);
-        float layerAlpha = u_opacity[i] * layerColor.a;
-        outputValue = layerColor * layerAlpha + outputValue * (1.0f - layerAlpha);
+        // wl_surfaces come with premultiplied alpha, so that's them being
+        // premultiplied by layerColor.a.
+        // We need to then multiply that by the layer's opacity to get to our
+        // final premultiplied state.
+        // For the other side of things, we need to multiply by (1.0f - (layerColor.a * opacity))
+        float opacity = u_opacity[i];
+        float layerAlpha = opacity * layerColor.a;
+        outputValue = layerColor * opacity + outputValue * (1.0f - layerAlpha);
     }
 
     if (c_swapChannels)


### PR DESCRIPTION
We must blend in linear space, not SRGB space or we get these horrible browns.

The surface should already have premultiplied alpha.

Gets us to how we look with planes when blending.

Before:

![image](https://user-images.githubusercontent.com/21316711/141661600-4060348d-1e17-4051-a029-80ddce415eef.png)


After:

![image](https://user-images.githubusercontent.com/21316711/141662035-0c110b65-4210-43b0-88b5-7bf02b1f91d4.png)

I modified MangoApp very quickly to have a transparent overlay that would do this: https://github.com/Joshua-Ashton/MangoHud/tree/test-app-blending
