### PR TITLE
steamcompmgr: Fix crusty cursor in some scenarios

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3701,7 +3701,11 @@ load_mouse_cursor( MouseCursor *cursor, const char *path )
 	std::transform(data, data + w * h, data, [](rgba_t x) {
 		if (x.a == 0)
 			return rgba_t{};
-		return rgba_t{ x.b, x.g, x.r, x.a };
+		return rgba_t{
+			uint8_t((x.b * x.a) / 255),
+			uint8_t((x.g * x.a) / 255),
+			uint8_t((x.r * x.a) / 255),
+			x.a };
 	});
 
 	// Data is freed by XDestroyImage in setCursorImage.


### PR DESCRIPTION
The PNG spec says that alpha is not premultiplied, so we need to do that.

(Although there are some things that do use PNG with premultiplied alpha... but let's just ignore that for now and go with the PNG spec and what we are getting exported to us to use on Deck.)

Cursor in X must have premultiplied alpha, our blending setup breaks a lot if this is not true.