### PR TITLE
steamcompmgr: Fix fd leaks + some X errors

### DIFF
--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -212,11 +212,23 @@ bool sdlwindow_init( void )
 	return g_bSDLInitOK;
 }
 
+extern bool steamMode;
+extern bool g_bFirstFrame;
+
 void sdlwindow_update( void )
 {
-	if ( g_bWindowShown != hasFocusWindow )
+	bool should_show = hasFocusWindow;
+
+	// If we are Steam Mode in nested, show the window
+	// whenever we have had a first frame to match
+	// what we do in embedded with Steam for testing
+	// held commits, etc.
+	if ( steamMode )
+		should_show |= !g_bFirstFrame;
+
+	if ( g_bWindowShown != should_show )
 	{
-		g_bWindowShown = hasFocusWindow;
+		g_bWindowShown = should_show;
 
 		if ( g_bWindowShown )
 		{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2357,6 +2357,8 @@ map_win(Display *dpy, Window id, unsigned long sequence)
 	XSelectInput(dpy, id, PropertyChangeMask | SubstructureNotifyMask |
 		PointerMotionMask | LeaveWindowMask | FocusChangeMask);
 
+	XFlush(dpy);
+
 	/* This needs to be here since we don't get PropertyNotify when unmapped */
 	w->opacity = get_prop(dpy, w->id, opacityAtom, OPAQUE);
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2777,6 +2777,10 @@ finish_destroy_win(Display *dpy, Window id, bool gone)
 				w->damage = None;
 			}
 
+			// release all commits now we are closed.
+			for ( commit_t& commit : w->commit_queue )
+				release_commit( commit );
+
 			wlserver_lock();
 			wlserver_surface_finish( &w->surface );
 			wlserver_unlock();

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -632,6 +632,10 @@ static win * find_win( struct wlr_surface *surf )
 	return nullptr;
 }
 
+#ifdef COMMIT_REF_DEBUG
+static int buffer_refs = 0;
+#endif
+
 static void
 destroy_buffer( struct wl_listener *listener, void * )
 {
@@ -649,6 +653,10 @@ destroy_buffer( struct wl_listener *listener, void * )
 	}
 
 	wl_list_remove( &entry->listener.link );
+
+#ifdef COMMIT_REF_DEBUG
+	fprintf(stderr, "destroy_buffer - refs: %d\n", --buffer_refs);
+#endif
 
 	/* Has to be the last thing we do as this deletes *entry. */
 	wlr_buffer_map.erase( wlr_buffer_map.find( entry->buf ) );
@@ -703,6 +711,10 @@ import_commit ( struct wlr_buffer *buf, commit_t &commit )
 
 		return true;
 	}
+
+#ifdef COMMIT_REF_DEBUG
+	fprintf(stderr, "import_commit - refs %d\n", ++buffer_refs);
+#endif
 
 	wlr_buffer_map_entry& entry = wlr_buffer_map[buf];
 	/* [1]

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2586,6 +2586,7 @@ add_win(Display *dpy, Window id, Window prev, unsigned long sequence)
 		new_win->damage = None;
 	else
 	{
+		set_ignore(dpy, NextRequest(dpy));
 		new_win->damage = XDamageCreate(dpy, id, XDamageReportRawRectangles);
 	}
 	new_win->opacity = OPAQUE;
@@ -2840,8 +2841,14 @@ damage_win(Display *dpy, XDamageNotifyEvent *de)
 		w->damage_sequence > focus->damage_sequence)
 		focusDirty = true;
 
+	// Josh: This will sometimes cause a BadDamage error.
+	// I looked around at different compositors to see what
+	// they do here and they just seem to ignore it.
 	if (w->damage)
+	{
+		set_ignore(dpy, NextRequest(dpy));
 		XDamageSubtract(dpy, w->damage, None, None);
+	}
 
 	gpuvis_trace_printf( "damage_win win %lx appID %u", w->id, w->appID );
 }

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -303,7 +303,7 @@ float			currentFrameRate;
 static bool		debugFocus = false;
 static bool		drawDebugInfo = false;
 static bool		debugEvents = false;
-static bool		steamMode = false;
+bool			steamMode = false;
 static bool		alwaysComposite = false;
 static bool		useXRes = true;
 
@@ -1408,7 +1408,7 @@ paint_debug_info(Display *dpy)
 	}
 }
 
-static bool g_bFirstFrame = true;
+bool g_bFirstFrame = true;
 
 static bool is_fading_out()
 {

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4260,6 +4260,20 @@ steamcompmgr_main(int argc, char **argv)
 		vblank = false;
 	}
 
+	// Clean up any commits.
+
+	for ( win *w = list; w; w = w->next )
+	{
+		for ( commit_t& commit : w->commit_queue )
+			release_commit( commit );
+	}
+
+	if ( g_HeldCommits[ HELD_COMMIT_BASE ].done )
+		release_commit( g_HeldCommits[ HELD_COMMIT_BASE ] );
+
+	if ( g_HeldCommits[ HELD_COMMIT_FADE ].done )
+		release_commit( g_HeldCommits[ HELD_COMMIT_FADE ] );
+
 	imageWaitThreadRun = false;
 	waitListSem.signal();
 


### PR DESCRIPTION
Closes: #324

With this we get `refs: 0` on close and `refs: 1` with no windows (held commit).