### PR TITLE
steamcompmgr: unbreak build with libc++

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -35,6 +35,7 @@
 #include <atomic>
 #include <vector>
 #include <algorithm>
+#include <array>
 #include <iostream>
 #include <fstream>
 #include <string>


### PR DESCRIPTION
Regressed by 296a3d498d02 + 06cb10683aac. From [error log](https://github.com/Plagman/gamescope/files/7713443/gamescope-3.10.log):
```c++
$ export CC=clang CXX=clang++ CXXFLAGS=-stdlib=libc++
$ meson setup _build
$ meson compile -C _build
[...]
../src/steamcompmgr.cpp:270:41: error: implicit instantiation of undefined template 'std::array<commit_t, 2>'
std::array<commit_t, HELD_COMMIT_COUNT> g_HeldCommits;
                                        ^
/usr/include/c++/v1/__tuple:219:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
../src/steamcompmgr.cpp:1160:50: error: implicit instantiation of undefined template 'std::array<BaseLayerInfo_t, 2>'
std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > g_CachedPlanes = {};
                                                 ^
/usr/include/c++/v1/__tuple:219:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
2 errors generated.
```
