### PR TITLE
Add a CLI option and shortcut key to toggle mouse cursor grab.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,8 @@ const struct option *gamescope_options = (struct option[]){
 	{ "nested-unfocused-refresh", required_argument, nullptr, 'o' },
 	{ "borderless", no_argument, nullptr, 'b' },
 	{ "fullscreen", no_argument, nullptr, 'f' },
+	{ "no-mouse-capture", required_argument, nullptr, 'M' },
+	{ "center-mouse-on-focus-loss", no_argument, nullptr, 0 },
 
 	// embedded mode options
 	{ "disable-layers", no_argument, nullptr, 0 },
@@ -91,6 +93,8 @@ const char usage[] =
 	"  -o, --nested-unfocused-refresh game refresh rate when unfocused\n"
 	"  -b, --borderless               make the window borderless\n"
 	"  -f, --fullscreen               make the window fullscreen\n"
+	"  -M, --no-mouse-capture         do not capture the mouse\n"
+	"  --center-mouse-on-focus-loss   center the virtual mouse when focus is lost (only usable with -M)\n"
 	"\n"
 	"Embedded mode options:\n"
 	"  -O, --prefer-output            list of connectors in order of preference\n"
@@ -111,6 +115,7 @@ const char usage[] =
 	"Keyboard shortcuts:\n"
 	"  Super + F                      toggle fullscreen\n"
 	"  Super + N                      toggle nearest neighbour filtering\n"
+	"  Super + Scroll Lock            toggle mouse capture\n"
 	"  Super + S                      take a screenshot\n"
 	"";
 
@@ -126,6 +131,9 @@ uint32_t g_nOutputHeight = 0;
 int g_nOutputRefresh = 0;
 
 bool g_bFullscreen = false;
+
+bool g_bNoMouseCapture = false;
+bool g_bCenterMouseOnFocusLoss = false;
 
 bool g_bIsNested = false;
 
@@ -243,6 +251,9 @@ int main(int argc, char **argv)
 			case 'f':
 				g_bFullscreen = true;
 				break;
+			case 'M':
+				g_bNoMouseCapture = true;
+				break;
 			case 'O':
 				g_sOutputName = optarg;
 				break;
@@ -262,6 +273,9 @@ int main(int argc, char **argv)
 					g_nTouchClickMode = g_nDefaultTouchClickMode;
 				} else if (strcmp(opt_name, "generate-drm-mode") == 0) {
 					g_drmModeGeneration = parse_drm_mode_generation( optarg );
+				} else if (strcmp(opt_name, "center-mouse-on-focus-loss") == 0) {
+					g_bCenterMouseOnFocusLoss = true;
+                                        fprintf(stderr, "ffs\n");
 				}
 				break;
 			case '?':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,7 +275,6 @@ int main(int argc, char **argv)
 					g_drmModeGeneration = parse_drm_mode_generation( optarg );
 				} else if (strcmp(opt_name, "center-mouse-on-focus-loss") == 0) {
 					g_bCenterMouseOnFocusLoss = true;
-                                        fprintf(stderr, "ffs\n");
 				}
 				break;
 			case '?':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "fullscreen", no_argument, nullptr, 'f' },
 	{ "no-mouse-capture", required_argument, nullptr, 'M' },
 	{ "center-mouse-on-focus-loss", no_argument, nullptr, 0 },
+	{ "no-mod-key", no_argument, nullptr, 0 },
 
 	// embedded mode options
 	{ "disable-layers", no_argument, nullptr, 0 },
@@ -95,6 +96,7 @@ const char usage[] =
 	"  -f, --fullscreen               make the window fullscreen\n"
 	"  -M, --no-mouse-capture         do not capture the mouse\n"
 	"  --center-mouse-on-focus-loss   center the virtual mouse when focus is lost (only usable with -M)\n"
+	"  --no-mod-key                   do not generate events for the Super key\n"
 	"\n"
 	"Embedded mode options:\n"
 	"  -O, --prefer-output            list of connectors in order of preference\n"
@@ -134,6 +136,8 @@ bool g_bFullscreen = false;
 
 bool g_bNoMouseCapture = false;
 bool g_bCenterMouseOnFocusLoss = false;
+
+bool g_bNoModKey = false;
 
 bool g_bIsNested = false;
 
@@ -275,6 +279,8 @@ int main(int argc, char **argv)
 					g_drmModeGeneration = parse_drm_mode_generation( optarg );
 				} else if (strcmp(opt_name, "center-mouse-on-focus-loss") == 0) {
 					g_bCenterMouseOnFocusLoss = true;
+				} else if (strcmp(opt_name, "no-mod-key") == 0) {
+					g_bNoModKey = true;
 				}
 				break;
 			case '?':

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -25,6 +25,8 @@ extern bool g_bFullscreen;
 extern bool g_bNoMouseCapture;
 extern bool g_bCenterMouseOnFocusLoss;
 
+extern bool g_bNoModKey;
+
 extern bool g_bFilterGameWindow;
 
 extern bool g_bBorderlessOutputWindow;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -22,6 +22,9 @@ extern int g_nOutputRefresh; // Hz
 
 extern bool g_bFullscreen;
 
+extern bool g_bNoMouseCapture;
+extern bool g_bCenterMouseOnFocusLoss;
+
 extern bool g_bFilterGameWindow;
 
 extern bool g_bBorderlessOutputWindow;

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -236,6 +236,12 @@ void inputSDLThreadRun( void )
 							wlserver_unlock();
 						}
 						break;
+					case SDL_WINDOWEVENT_EXPOSED:
+						if ( g_bFullscreen == false )
+						{
+							request_repaint();
+						}
+						break;
 				}
 				break;
 			default:

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -156,6 +156,11 @@ void inputSDLThreadRun( void )
 			case SDL_KEYUP:
 				key = SDLScancodeToLinuxKey( event.key.keysym.scancode );
 
+				if ( g_bNoModKey == true && key == KEY_LEFTMETA )
+				{
+					break;
+				}
+
 				if ( event.type == SDL_KEYUP && ( event.key.keysym.mod & KMOD_LGUI ) )
 				{
 					bool handled = true;
@@ -190,6 +195,11 @@ void inputSDLThreadRun( void )
 					{
 						break;
 					}
+				}
+
+				if ( g_bNoModKey == true && ( event.key.keysym.mod & KMOD_LGUI ) )
+				{
+					break;
 				}
 
 				// On Wayland, clients handle key repetition

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3435,6 +3435,12 @@ void take_screenshot( void )
 	nudge_steamcompmgr();
 }
 
+void request_repaint( void )
+{
+	hasRepaint = true;
+	nudge_steamcompmgr();
+}
+
 void check_new_wayland_res( void )
 {
 	// When importing buffer, we'll potentially need to perform operations with

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -97,3 +97,4 @@ extern uint32_t inputCounter;
 
 void nudge_steamcompmgr( void );
 void take_screenshot( void );
+void request_repaint( void );

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -858,6 +858,15 @@ void wlserver_mousemotion( int x, int y, uint32_t time )
 	}
 }
 
+void wlserver_absmousemotion( int x, int y, uint32_t time )
+{
+	if( g_XWLDpy != NULL )
+	{
+		XTestFakeMotionEvent( g_XWLDpy, -1, focusedWindowScaleX * x, focusedWindowScaleY * y, CurrentTime );
+		XFlush( g_XWLDpy );
+	}
+}
+
 void wlserver_mousebutton( int button, bool press, uint32_t time )
 {
 	wlr_seat_pointer_notify_button( wlserver.wlr.seat, time, button, press ? WLR_BUTTON_PRESSED : WLR_BUTTON_RELEASED );

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -92,6 +92,7 @@ void wlserver_key( uint32_t key, bool press, uint32_t time );
 
 void wlserver_mousefocus( struct wlr_surface *wlrsurface, int x = 0, int y = 0 );
 void wlserver_mousemotion( int x, int y, uint32_t time );
+void wlserver_absmousemotion( int x, int y, uint32_t time );
 void wlserver_mousebutton( int button, bool press, uint32_t time );
 void wlserver_mousewheel( int x, int y, uint32_t time );
 


### PR DESCRIPTION
A new CLI option, --no-mouse-capture or -M, can be used to skip the mouse cursor grab at startup. The mouse grab can also be toggled via Mod+ScrollLock at any time.

This can be very useful for when running games under a window that work largely with a mouse (e.g. top down RPGs, etc).

In addition the CLI option --center-mouse-on-focus-loss can be used to center the virtual mouse cursor when the window loses focus and put it back where it was when the window regains focus. This can also be useful when running some games in a window that use the screen edges to scroll the screen (e.g. ATOM RPG).