### PR TITLE
Update SDL window title from the focused window's title.

### DIFF
--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -29,7 +29,7 @@ static SDL_Event g_SDLUserEvent;
 
 static std::mutex g_SDLWindowTitleLock;
 static std::string g_SDLWindowTitle;
-static std::atomic<bool> g_bUpdateSDLWindowTitle{false};
+static bool g_bUpdateSDLWindowTitle = false;
 
 //-----------------------------------------------------------------------------
 // Purpose: Convert from the remote scancode to a Linux event keycode
@@ -246,12 +246,13 @@ void sdlwindow_update( void )
 		}
 	}
 
-	if ( g_bUpdateSDLWindowTitle.exchange(false) )
+	g_SDLWindowTitleLock.lock();
+	if ( g_bUpdateSDLWindowTitle )
 	{
-		g_SDLWindowTitleLock.lock();
+		g_bUpdateSDLWindowTitle = false;
 		SDL_SetWindowTitle( g_SDLWindow, g_SDLWindowTitle.c_str() );
-		g_SDLWindowTitleLock.unlock();
 	}
+	g_SDLWindowTitleLock.unlock();
 }
 
 void sdlwindow_title( const char* title )

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -27,6 +27,9 @@ SDL_Window *g_SDLWindow;
 static uint32_t g_unSDLUserEventID;
 static SDL_Event g_SDLUserEvent;
 
+static std::string g_SDLWindowTitle;
+static bool g_bUpdateSDLWindowTitle = false;
+
 //-----------------------------------------------------------------------------
 // Purpose: Convert from the remote scancode to a Linux event keycode
 //-----------------------------------------------------------------------------
@@ -241,11 +244,23 @@ void sdlwindow_update( void )
 			SDL_HideWindow( g_SDLWindow );
 		}
 	}
+
+	if ( g_bUpdateSDLWindowTitle == true )
+	{
+		g_bUpdateSDLWindowTitle = false;
+		SDL_SetWindowTitle( g_SDLWindow, g_SDLWindowTitle.c_str() );
+	}
 }
 
 void sdlwindow_title( const char* title )
 {
-	SDL_SetWindowTitle( g_SDLWindow, title ? title : DEFAULT_TITLE );
+	title = title ? title : DEFAULT_TITLE;
+	if ( g_SDLWindowTitle != title )
+	{
+		g_SDLWindowTitle = title ? title : DEFAULT_TITLE;
+		g_bUpdateSDLWindowTitle = true;
+		sdlwindow_pushupdate();
+	}
 }
 
 void sdlwindow_pushupdate( void )

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -13,6 +13,8 @@
 
 #include "sdlscancodetable.hpp"
 
+#define DEFAULT_TITLE "gamescope"
+
 static bool g_bSDLInitOK = false;
 static std::mutex g_SDLInitLock;
 
@@ -84,7 +86,7 @@ void inputSDLThreadRun( void )
 		nSDLWindowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
 
-	g_SDLWindow = SDL_CreateWindow( "gamescope",
+	g_SDLWindow = SDL_CreateWindow( DEFAULT_TITLE,
 							   SDL_WINDOWPOS_UNDEFINED,
 							SDL_WINDOWPOS_UNDEFINED,
 							g_nOutputWidth,
@@ -239,6 +241,11 @@ void sdlwindow_update( void )
 			SDL_HideWindow( g_SDLWindow );
 		}
 	}
+}
+
+void sdlwindow_title( const char* title )
+{
+	SDL_SetWindowTitle( g_SDLWindow, title ? title : DEFAULT_TITLE );
 }
 
 void sdlwindow_pushupdate( void )

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -257,14 +257,14 @@ void sdlwindow_update( void )
 void sdlwindow_title( const char* title )
 {
 	title = title ? title : DEFAULT_TITLE;
+	g_SDLWindowTitleLock.lock();
 	if ( g_SDLWindowTitle != title )
 	{
-		g_SDLWindowTitleLock.lock();
 		g_SDLWindowTitle = title ? title : DEFAULT_TITLE;
 		g_bUpdateSDLWindowTitle = true;
-		g_SDLWindowTitleLock.unlock();
 		sdlwindow_pushupdate();
 	}
+	g_SDLWindowTitleLock.unlock();
 }
 
 void sdlwindow_pushupdate( void )

--- a/src/sdlwindow.hpp
+++ b/src/sdlwindow.hpp
@@ -8,6 +8,7 @@
 bool sdlwindow_init( void );
 
 void sdlwindow_update( void );
+void sdlwindow_title( const char* title );
 
 // called from other threads with interesting things have happened with clients that might warrant updating the nested window
 void sdlwindow_pushupdate( void );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2227,6 +2227,8 @@ found:
 	}
 
 	XFree(children);
+
+	sdlwindow_title( w->title );
 }
 
 static void
@@ -3207,6 +3209,10 @@ handle_property_notify(Display *dpy, XPropertyEvent *ev)
 		win *w = find_win(dpy, ev->window);
 		if (w) {
 			get_win_title(dpy, w, ev->atom);
+			if (w == currentFocusWin)
+			{
+				sdlwindow_title( w->title );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Instead of using the default "gamescope" title for the SDL window, this
makes the SDL window title be updated with the focused window's title
whenever a window is focused or whenever the focused window's title is
changed. "gamescope" is still used whenever a title cannot be obtained.