### PR TITLE
sdlwindow: Only process mouse motion when we're focused

### DIFF
--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -110,9 +110,12 @@ void inputSDLThreadRun( void )
 		switch( event.type )
 		{
 			case SDL_MOUSEMOTION:
-				wlserver_lock();
-				wlserver_mousemotion( event.motion.xrel, event.motion.yrel, event.motion.timestamp );
-				wlserver_unlock();
+				if ( g_bWindowFocused )
+				{
+					wlserver_lock();
+					wlserver_mousemotion( event.motion.xrel, event.motion.yrel, event.motion.timestamp );
+					wlserver_unlock();
+				}
 				break;
 			case SDL_MOUSEBUTTONDOWN:
 			case SDL_MOUSEBUTTONUP:


### PR DESCRIPTION
Annoying to have the cursor moving around or the game view having a moment when we're not focused on the window.