### PR TITLE
Repaint the window when it receives expose events in non-fullscreen mode

### DIFF
--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -190,6 +190,12 @@ void inputSDLThreadRun( void )
 						g_nNestedRefresh = g_nOldNestedRefresh;
 						g_bWindowFocused = true;
 						break;
+					case SDL_WINDOWEVENT_EXPOSED:
+						if ( g_bFullscreen == false )
+						{
+							request_repaint();
+						}
+						break;
 				}
 				break;
 			default:

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -324,6 +324,7 @@ static std::unordered_map<struct wlr_buffer*, wlr_buffer_map_entry> wlr_buffer_m
 
 static std::atomic< bool > g_bTakeScreenshot{false};
 static bool g_bPropertyRequestedScreenshot;
+static std::atomic< bool > g_bRepaintRequested{false};
 
 static int g_nudgePipe[2] = {-1, -1};
 
@@ -3467,7 +3468,7 @@ void take_screenshot( void )
 
 void request_repaint( void )
 {
-	hasRepaint = true;
+	g_bRepaintRequested = true;
 	nudge_steamcompmgr();
 }
 
@@ -4273,6 +4274,11 @@ steamcompmgr_main(int argc, char **argv)
 		handle_done_commits();
 
 		check_new_wayland_res();
+
+		if ( g_bRepaintRequested.exchange(false) )
+		{
+			hasRepaint = true;
+		}
 
 		if ( ( g_bTakeScreenshot == true || hasRepaint == true || is_fading_out() ) && vblank == true )
 		{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3465,6 +3465,12 @@ void take_screenshot( void )
 	nudge_steamcompmgr();
 }
 
+void request_repaint( void )
+{
+	hasRepaint = true;
+	nudge_steamcompmgr();
+}
+
 void check_new_wayland_res( void )
 {
 	// When importing buffer, we'll potentially need to perform operations with

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -97,3 +97,4 @@ extern uint32_t inputCounter;
 
 void nudge_steamcompmgr( void );
 void take_screenshot( void );
+void request_repaint( void );


### PR DESCRIPTION
If another window covers / moves over and then damages the SDL window without the application inside Gamescope updating the screen (e.g. running some launcher or other program that doesn't constantly refresh the screen) and there is no desktop compositor (e.g. one uses a regular window manager under Xorg), the window will be left damaged with "trails" over whatever moved over the window.

This PR fixes that by issuing a repaint whenever an expose event is received from SDL.