### PR TITLE
steamcompmgr: Fix undefined state of wayland_commit_queue after move.

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3446,6 +3446,7 @@ void check_new_wayland_res( void )
 	{
 		std::lock_guard<std::mutex> lock( wayland_commit_lock );
 		tmp_queue = std::move(wayland_commit_queue);
+		wayland_commit_queue = {};
 	}
 
 	for ( uint32_t i = 0; i < tmp_queue.size(); i++ )


### PR DESCRIPTION
Any reasonable std::vector implementation probably just clears, but technically:
> Unless otherwise specified, all standard library objects that have been moved from are placed in a "valid but unspecified state", meaning the object's class invariants hold (so functions without preconditions, such as the assignment operator, can be safely used on the object after it was moved from):

https://en.cppreference.com/w/cpp/utility/move 