### PR TITLE
drm: Don't forget about modesetting + modesetting robustness

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1226,15 +1226,21 @@ int drm_prepare( struct drm_t *drm, const struct Composite_t *pComposite, const 
 
 		drm->fbids_in_req.clear();
 
-		drm->pending = drm->current;
-
-		for ( size_t i = 0; i < drm->crtcs.size(); i++ )
-		{
-			drm->crtcs[i].pending = drm->crtcs[i].current;
-		}
+		if ( needs_modeset )
+			drm->needs_modeset = true;
 	}
 
 	return ret;
+}
+
+void drm_rollback( struct drm_t *drm )
+{
+	drm->pending = drm->current;
+
+	for ( size_t i = 0; i < drm->crtcs.size(); i++ )
+	{
+		drm->crtcs[i].pending = drm->crtcs[i].current;
+	}
 }
 
 bool drm_poll_state( struct drm_t *drm )

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -142,6 +142,7 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh);
 void finish_drm(struct drm_t *drm);
 int drm_commit(struct drm_t *drm, struct Composite_t *pComposite, struct VulkanPipeline_t *pPipeline );
 int drm_prepare( struct drm_t *drm, const struct Composite_t *pComposite, const struct VulkanPipeline_t *pPipeline );
+void drm_rollback( struct drm_t *drm );
 bool drm_poll_state(struct drm_t *drm);
 uint32_t drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_buffer *buf, struct wlr_dmabuf_attributes *dma_buf );
 void drm_lock_fbid( struct drm_t *drm, uint32_t fbid );


### PR DESCRIPTION
Makes it so that we don't forget about any required modesets we need to undertake, and makes modesetting robust by trying again when compositing (in case the error was not mode but plane related), and falling back to the previous mode if that fails.

If we have no mode to fall back to then we abort, same if we fail our mode fallback commit.