### PR TITLE
rendervulkan: Remove swap channels.

### DIFF
--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -51,7 +51,6 @@ struct vec2_t
 struct Composite_t
 {
 	int nLayerCount;
-	int nSwapChannels;
 	int nYCBCRMask;
 
 	struct CompositeData_t

--- a/src/shaders/cs_composite_blit.comp
+++ b/src/shaders/cs_composite_blit.comp
@@ -11,9 +11,8 @@ layout(
 const int MaxLayers = 6;
 
 layout(constant_id = 0) const int  c_layerCount   = 1;
-layout(constant_id = 1) const bool c_swapChannels = false;
-layout(constant_id = 2) const uint c_ycbcrMask    = 0;
-layout(constant_id = 3) const bool c_compositing_debug = false;
+layout(constant_id = 1) const uint c_ycbcrMask    = 0;
+layout(constant_id = 2) const bool c_compositing_debug = false;
 
 layout(binding = 0, rgba8) writeonly uniform image2D dst;
 
@@ -116,9 +115,6 @@ void main() {
         float layerAlpha = opacity * layerColor.a;
         outputValue = layerColor * opacity + outputValue * (1.0f - layerAlpha);
     }
-
-    if (c_swapChannels)
-        outputValue = outputValue.bgra;
 
     imageStore(dst, ivec2(coord), linearToSrgb(outputValue));
 


### PR DESCRIPTION
Unused since 76292f0, partially broken and
unnecessary because we should be able to always use the correct VkFormat.