### PR TITLE
rendervulkan: Rework sampler cache.

### DIFF
--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -24,7 +24,6 @@ struct VulkanPipeline_t
 		
 		int zpos;
 
-		// These fields below count for the sampler cache
 		bool bFilter;
 	} layerBindings[ k_nMaxLayers ];
 };


### PR DESCRIPTION
Less awkward to use and also fixes a texture leak because the shared_ptr
to the texture is no longer stored in the sampler cache.