### PR TITLE
mangoapp + requirements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,7 @@ src = [
   'src/rendervulkan.cpp',
   'src/log.cpp',
   'src/ime.cpp',
+  'src/mangoapp.cpp',
   spirv_shader,
 ]
 

--- a/src/composite.comp
+++ b/src/composite.comp
@@ -8,7 +8,7 @@ layout(
   local_size_y = 8,
   local_size_z = 1) in;
 
-const int MaxLayers = 4;
+const int MaxLayers = 6;
 
 layout(constant_id = 0) const int  c_layerCount   = 1;
 layout(constant_id = 1) const bool c_swapChannels = false;

--- a/src/composite.comp
+++ b/src/composite.comp
@@ -22,7 +22,7 @@ uniform layers_t {
     vec2 u_scale[MaxLayers];
     vec2 u_offset[MaxLayers];
     float u_opacity[MaxLayers];
-    float u_borderAlpha[MaxLayers];
+    uint u_borderMask;
     uint u_frameId;
 };
 
@@ -75,8 +75,10 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv) {
     vec2 texSize = textureSize(layerSampler, 0);
 
     if (coord.x < 0.0f       || coord.y < 0.0f ||
-        coord.x >= texSize.x || coord.y >= texSize.y )
-        return vec4(0.0f, 0.0f, 0.0f, u_borderAlpha[layerIdx]);
+        coord.x >= texSize.x || coord.y >= texSize.y) {
+        float border = (u_borderMask & (1u << layerIdx)) != 0 ? 1.0f : 0.0f;
+        return vec4(0.0f, 0.0f, 0.0f, border);
+    }
 
     return textureLod(layerSampler, coord, 0.0f);
 }

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -1,0 +1,40 @@
+#include <sys/ipc.h>
+#include <unistd.h>
+#include <sys/msg.h>
+#include <cstring>
+
+#include "steamcompmgr.hpp"
+static bool inited = false;
+static int msgid = 0;
+uint64_t now, last_frametime = 0;
+
+struct mangoapp_msg_header {
+    long msg_type;  // Message queue ID, never change
+    uint32_t version;  // for major changes in the way things work //
+} __attribute__((packed));
+
+struct mangoapp_msg_v1 {
+    struct mangoapp_msg_header hdr;
+    
+    uint32_t pid;
+    uint64_t frametime_ns;
+    // WARNING: Always ADD fields, never remove or repurpose fields
+} __attribute__((packed)) mangoapp_msg_v1;
+
+void init_mangoapp(){
+    int key = ftok("mangoapp", 65);
+    msgid = msgget(key, 0666 | IPC_CREAT);
+    mangoapp_msg_v1.hdr.msg_type = 1;
+    mangoapp_msg_v1.hdr.version = 1;
+    inited = true;
+}
+
+void frame_timing(){
+    if (!inited)
+        init_mangoapp();
+
+    now = get_time_in_nanos();
+    mangoapp_msg_v1.frametime_ns = now - last_frametime;
+    last_frametime = now;
+    msgsnd(msgid, &mangoapp_msg_v1, sizeof(mangoapp_msg_v1), IPC_NOWAIT);
+}

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -29,7 +29,7 @@ void init_mangoapp(){
     inited = true;
 }
 
-void frame_timing(){
+void mangoapp_update(){
     if (!inited)
         init_mangoapp();
 

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -6,7 +6,22 @@
 #include <stdint.h>
 #include <memory>
 
-#define k_nMaxLayers 4
+// 1: Fade Plane (Fade outs between switching focus)
+// 2: Video Underlay (The actual video)
+// 3: Video Streaming UI (Game, App)
+// 4: External Overlay (Mangoapp, etc)
+// 5: Primary Overlay (Steam Overlay)
+// 6: Cursor
+
+// or
+
+// 1: Fade Plane (Fade outs between switching focus)
+// 2: Base Plane (Game, App)
+// 3: Override Plane (Dropdowns, etc)
+// 4: External Overlay (Mangoapp, etc)
+// 5: Primary Overlay (Steam Overlay)
+// 6: Cursor
+#define k_nMaxLayers 6
 #define k_nMaxYcbcrMask 16
 
 class CVulkanTexture;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -44,8 +44,9 @@ struct Composite_t
 		vec2_t vScale[k_nMaxLayers];
 		vec2_t vOffset[k_nMaxLayers];
 		float flOpacity[k_nMaxLayers];
-		float flBorderAlpha[k_nMaxLayers];
+		uint32_t nBorderMask;
 	} data;
+
 };
 
 #include "drm.hpp"

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1190,6 +1190,7 @@ namespace PaintWindowFlag
 	static const uint32_t FadeTarget = 1u << 1;
 	static const uint32_t NotificationMode = 1u << 2;
 	static const uint32_t DrawBorders = 1u << 3;
+	static const uint32_t NoScale = 1u << 4;
 }
 using PaintWindowFlags = uint32_t;
 
@@ -1251,6 +1252,11 @@ paint_window(Display *dpy, win *w, win *scaleW, struct Composite_t *pComposite,
 	{
 		sourceWidth = mainOverlayWindow->a.width;
 		sourceHeight = mainOverlayWindow->a.height;
+	}
+	else if ( flags & PaintWindowFlag::NoScale )
+	{
+		sourceWidth = currentOutputWidth;
+		sourceHeight = currentOutputHeight;
 	}
 	else
 	{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1134,8 +1134,6 @@ void MouseCursor::paint(win *window, struct Composite_t *pComposite,
 	pComposite->data.vOffset[ curLayer ].x = -scaledX;
 	pComposite->data.vOffset[ curLayer ].y = -scaledY;
 
-	pComposite->data.flBorderAlpha[ curLayer ] = 0.0f;
-
 	pPipeline->layerBindings[ curLayer ].surfaceWidth = m_width;
 	pPipeline->layerBindings[ curLayer ].surfaceHeight = m_height;
 
@@ -1173,6 +1171,8 @@ paint_cached_base_layer(const std::shared_ptr<commit_t>& commit, const BaseLayer
 	pPipeline->layerBindings[ curLayer ].tex = commit->vulkanTex;
 	pPipeline->layerBindings[ curLayer ].fbid = commit->fb_id;
 	pPipeline->layerBindings[ curLayer ].bFilter = true;
+
+	pComposite->data.nBorderMask |= (1u << curLayer);
 
 	pComposite->nLayerCount++;
 }
@@ -1279,8 +1279,6 @@ paint_window(Display *dpy, win *w, win *scaleW, struct Composite_t *pComposite,
 	{
 		pComposite->data.vOffset[ curLayer ].x = -drawXOffset;
 		pComposite->data.vOffset[ curLayer ].y = -drawYOffset;
-
-		pComposite->data.flBorderAlpha[ curLayer ] = 0.0f;
 	}
 	else if (notificationMode)
 	{
@@ -1297,15 +1295,13 @@ paint_window(Display *dpy, win *w, win *scaleW, struct Composite_t *pComposite,
 
 		pComposite->data.vOffset[ curLayer ].x = (currentOutputWidth - xOffset - width) * -1.0f;
 		pComposite->data.vOffset[ curLayer ].y = (currentOutputHeight - yOffset - height) * -1.0f;
-
-		pComposite->data.flBorderAlpha[ curLayer ] = 0.0f;
 	}
 	else
 	{
 		pComposite->data.vOffset[ curLayer ].x = -drawXOffset;
 		pComposite->data.vOffset[ curLayer ].y = -drawYOffset;
 
-		pComposite->data.flBorderAlpha[ curLayer ] = 1.0f;
+		pComposite->data.nBorderMask |= (1u << curLayer);
 	}
 
 	pPipeline->layerBindings[ curLayer ].surfaceWidth = w->a.width;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3508,7 +3508,10 @@ void handle_done_commits( void )
 					// If this is the main plane, repaint
 					if ( w->id == currentFocusWindow && !w->isSteamStreamingClient )
 					{
-						frame_timing();
+						// TODO: Check for a mangoapp atom in future.
+						// (Needs the win* refactor from the multiple xwayland branch)
+						if (currentExternalOverlayWindow != None)
+							mangoapp_update();
 						g_HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
 						hasRepaint = true;
 					}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3523,6 +3523,8 @@ void handle_done_commits( void )
 
 					if ( w->isSteamStreamingClientVideo && currentFocusWin && currentFocusWin->isSteamStreamingClient )
 					{
+						if (currentExternalOverlayWindow != None)
+							mangoapp_update();
 						g_HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
 						hasRepaint = true;
 					}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1580,7 +1580,7 @@ paint_all(Display *dpy, MouseCursor *cursor)
 	{
 		if (externalOverlay->opacity)
 		{
-			paint_window(dpy, externalOverlay, externalOverlay, &composite, &pipeline, cursor);
+			paint_window(dpy, externalOverlay, externalOverlay, &composite, &pipeline, cursor, PaintWindowFlag::NoScale);
 
 			if ( externalOverlay->id == currentInputFocusWindow )
 				update_touch_scaling( &composite );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3469,6 +3469,7 @@ void handle_done_commits( void )
 					// If this is the main plane, repaint
 					if ( w->id == currentFocusWindow && !w->isSteamStreamingClient )
 					{
+						frame_timing();
 						g_HeldCommits[ HELD_COMMIT_BASE ] = w->commit_queue[ j ];
 						hasRepaint = true;
 					}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1528,7 +1528,9 @@ paint_all(Display *dpy, MouseCursor *cursor)
 
 	// TODO: We want to paint this at the same scale as the normal window and probably
 	// with an offset.
-	if (override)
+	// Josh: No override if we're streaming video
+	// as we will have too many layers. Better to be safe than sorry.
+	if ( override && !w->isSteamStreamingClient )
 	{
 		paint_window(dpy, override, w, &composite, &pipeline, false, cursor);
 		update_touch_scaling( &composite );

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -97,3 +97,5 @@ extern uint32_t inputCounter;
 
 void nudge_steamcompmgr( void );
 void take_screenshot( void );
+
+extern void frame_timing();

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -98,4 +98,4 @@ extern uint32_t inputCounter;
 void nudge_steamcompmgr( void );
 void take_screenshot( void );
 
-extern void frame_timing();
+extern void mangoapp_update();


### PR DESCRIPTION
 - Pulls in and rebases https://github.com/Plagman/gamescope/pull/289 for mangoapp
 - Replace layer border alpha with a border mask to fit more layers
 - Bump max layer count to 6
   - Fade Plane (Fade outs between switching focus)
   - Video Underlay (The actual video)
   - Video Streaming UI (Game, App)
   - External Overlay (Mangoapp, etc)
   - Primary Overlay (Steam Overlay)
   - Cursor
 - **OR**
   - Fade Plane (Fade outs between switching focus)
   - Base Plane (Game, App)
   - Override Plane (Dropdowns, etc)
   - External Overlay (Mangoapp, etc)
   - Primary Overlay (Steam Overlay)
   - Cursor
 - Bring in and rebase mangohud frametime message queue

(Dependent on https://github.com/Plagman/gamescope/pull/353 for now also)