### PR TITLE
Fix build without subprojects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project(
   'gamescope',
+  'c',
   'cpp',
   meson_version: '>=0.55.0',
   default_options: [


### PR DESCRIPTION
In absence of subprojects meson has no reason to look for a C compiler.
But the protocol files require it to compile and thus the build would fail with
```
meson.build:114:0: ERROR: No host machine compiler for "gamescope-xwayland-protocol.c"
```
<details>
<summary>Full log</summary>

```
The Meson build system
Version: 0.60.1
Source dir: /home/alebastr/sources/gamescope
Build dir: /home/alebastr/sources/gamescope/build
Build type: native build
Project name: gamescope
Project version: undefined
C++ compiler for the host machine: ccache c++ (gcc 11.2.1 "c++ (GCC) 11.2.1 20211203 (Red Hat 11.2.1-7)")
C++ linker for the host machine: c++ ld.bfd 2.37-10
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C++ supports arguments -Wno-unused-parameter: YES 
Compiler for C++ supports arguments -Wno-missing-field-initializers: YES 
Compiler for C++ supports arguments -Wno-c99-designator: NO 
Found pkg-config: /usr/bin/pkg-config (1.8.0)
Run-time dependency x11 found: YES 1.7.3.1
Run-time dependency xdamage found: YES 1.1.5
Run-time dependency xcomposite found: YES 0.4.5
Run-time dependency xrender found: YES 0.9.10
Run-time dependency xext found: YES 1.3.4
Run-time dependency xfixes found: YES 6.0.0
Run-time dependency xxf86vm found: YES 1.1.4
Run-time dependency xtst found: YES 1.2.3
Run-time dependency xres found: YES 1.2.0
Run-time dependency libdrm found: YES 2.4.109
Run-time dependency vulkan found: YES 1.2.189
Run-time dependency wayland-server found: YES 1.19.0
Run-time dependency wayland-protocols found: YES 1.24
Run-time dependency xkbcommon found: YES 1.3.1
Run-time dependency threads found: YES
Run-time dependency libcap found: YES 2.48
Run-time dependency sdl2 found: YES 2.0.18
Run-time dependency libpipewire-0.3 found: YES 0.3.40
Run-time dependency stb found: YES 0.1.0
Run-time dependency wlroots found: YES 0.15.0
Check usable header "vulkan/vulkan.h" with dependency vulkan: YES 
Program glslangValidator found: YES (/usr/bin/glslangValidator)
Run-time dependency libliftoff found: YES 0.2.0
Found pkg-config: /usr/bin/pkg-config (1.8.0)
Build-time dependency wayland-scanner found: YES 1.19.0
Program /usr/bin/wayland-scanner found: YES (/usr/bin/wayland-scanner)

meson.build:112:0: ERROR: No host machine compiler for "gamescope-xwayland-protocol.c"
```
</details>

Addres that by adding 'c' language to the project.