### PR TITLE
build: link to librt since the pipewire code uses shm_open()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ thread_dep = dependency('threads')
 cap_dep = dependency('libcap')
 sdl_dep = dependency('SDL2')
 pipewire_dep = dependency('libpipewire-0.3', required: get_option('pipewire'))
+librt_dep = cppc.find_library('rt', required : get_option('pipewire'))
 
 stb_dep = dependency('stb')
 
@@ -133,7 +134,7 @@ executable(
     dep_x11, dep_xdamage, dep_xcomposite, dep_xrender, dep_xext, dep_xfixes,
     dep_xxf86vm, dep_xres, drm_dep, wayland_server, wayland_protos,
     xkbcommon, thread_dep, sdl_dep, wlroots_dep,
-    vulkan_dep, liftoff_dep, dep_xtst, cap_dep, pipewire_dep, stb_dep,
+    vulkan_dep, liftoff_dep, dep_xtst, cap_dep, pipewire_dep, librt_dep, stb_dep,
   ],
   install: true,
 )


### PR DESCRIPTION
Just a small fix for a  build failure on my system.