### PR TITLE
Dynamic VBlank Rework

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -188,7 +188,9 @@ static void page_flip_handler(int fd, unsigned int frame, unsigned int sec, unsi
 	if ( g_DRM.crtc->id != crtc_id )
 		return;
 
-	vblank_mark_possible_vblank();
+	// This is the last vblank time
+	uint64_t vblanktime = sec * 1'000'000'000lu + usec * 1'000lu;
+	vblank_mark_possible_vblank(vblanktime);
 
 	// TODO: get the fbids_queued instance from data if we ever have more than one in flight
 

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "log.hpp"
 
 #include "gpuvis_trace_utils.h"
+#include "steamcompmgr.hpp"
 
 #include <algorithm>
 #include <thread>
@@ -846,6 +847,13 @@ int drm_commit(struct drm_t *drm, struct Composite_t *pComposite, struct VulkanP
 			drm->crtcs[i].current = drm->crtcs[i].pending;
 		}
 	}
+
+	// Update the draw time
+	// Ideally this would be updated by something right before the page flip
+	// is queued and would end up being the new page flip, rather than here.
+	// However, the page flip handler is called when the page flip occurs,
+	// not when it is successfully queued.
+	g_uVblankDrawTimeNS = get_time_in_nanos() - g_SteamCompMgrVBlankTime;
 
 	// Wait for flip handler to unlock
 	drm->flip_lock.lock();

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -488,7 +488,8 @@ static inline void stats_printf( const char* format, ...)
 uint64_t get_time_in_nanos()
 {
 	timespec ts;
-	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+	// Kernel reports page flips with CLOCK_MONOTONIC.
+	clock_gettime(CLOCK_MONOTONIC, &ts);
 	return ts.tv_sec * 1'000'000'000ul + ts.tv_nsec;
 }
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3431,6 +3431,14 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 			}
 		}
 	}
+	if ( ev->atom == ctx->atoms.gamescopeTuneableVBlankRedZone )
+	{
+		g_uVblankDrawBufferRedZoneNS = (uint64_t)get_prop( ctx, ctx->root, ctx->atoms.gamescopeTuneableVBlankRedZone, g_uDefaultVBlankRedZone );
+	}
+	if ( ev->atom == ctx->atoms.gamescopeTuneableRateOfDecay )
+	{
+		g_uVBlankRateOfDecayPercentage = (uint64_t)get_prop( ctx, ctx->root, ctx->atoms.gamescopeTuneableRateOfDecay, g_uDefaultVBlankRateOfDecayPercentage );
+	}
 }
 
 static int
@@ -4268,6 +4276,10 @@ void init_xwayland_ctx(gamescope_xwayland_server_t *xwayland_server)
 	ctx->atoms.gamescopeFocusDisplay = XInternAtom(ctx->dpy, "GAMESCOPE_FOCUS_DISPLAY", false);
 	ctx->atoms.gamescopeMouseFocusDisplay = XInternAtom(ctx->dpy, "GAMESCOPE_MOUSE_FOCUS_DISPLAY", false);
 	ctx->atoms.gamescopeKeyboardFocusDisplay = XInternAtom( ctx->dpy, "GAMESCOPE_KEYBOARD_FOCUS_DISPLAY", false );
+
+	// In nanoseconds...
+	ctx->atoms.gamescopeTuneableVBlankRedZone = XInternAtom( ctx->dpy, "GAMESCOPE_TUNEABLE_VBLANK_REDZONE", false );
+	ctx->atoms.gamescopeTuneableRateOfDecay = XInternAtom( ctx->dpy, "GAMESCOPE_TUNEABLE_VBLANK_RATE_OF_DECAY_PERCENTAGE", false );
 
 	ctx->root_width = DisplayWidth(ctx->dpy, ctx->scr);
 	ctx->root_height = DisplayHeight(ctx->dpy, ctx->scr);

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -215,6 +215,8 @@ bool			synchronize;
 
 std::mutex g_SteamCompMgrXWaylandServerMutex;
 
+uint64_t g_SteamCompMgrVBlankTime = 0;
+
 enum HeldCommitTypes_t
 {
 	HELD_COMMIT_BASE,
@@ -1619,6 +1621,9 @@ paint_all()
 		if ( BIsNested() == true )
 		{
 			vulkan_present_to_window();
+			// Update the time it took us to present.
+			// TODO: Use Vulkan present timing in future.
+			g_uVblankDrawTimeNS = get_time_in_nanos() - g_SteamCompMgrVBlankTime;
 		}
 		else
 		{
@@ -4055,6 +4060,7 @@ dispatch_vblank( int fd )
 			break;
 		}
 
+		g_SteamCompMgrVBlankTime = vblanktime;
 		uint64_t diff = get_time_in_nanos() - vblanktime;
 
 		// give it 1 ms of slack.. maybe too long

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -107,3 +107,5 @@ void take_screenshot( void );
 extern void mangoapp_update();
 gamescope_xwayland_server_t *steamcompmgr_get_focused_server();
 struct wlr_surface *steamcompmgr_get_server_input_surface( size_t idx );
+
+extern uint64_t g_SteamCompMgrVBlankTime;

--- a/src/vblankmanager.cpp
+++ b/src/vblankmanager.cpp
@@ -27,17 +27,18 @@ const uint64_t g_uStartingDrawTime = 3'000'000;
 std::atomic<uint64_t> g_uVblankDrawTimeNS = { g_uStartingDrawTime };
 
 // Tuneable
-// 2.0ms
+// 2.0ms by default. (g_DefaultVBlankRedZone)
 // This is the leeway we always apply to our buffer.
 // This also accounts for some time we cannot account for (which (I think) is the drm_commit -> triggering the pageflip)
 // It would be nice to make this lower if we can find a way to track that effectively
 // Perhaps the missing time is spent elsewhere, but given we track from the pipe write
 // to after the return from `drm_commit` -- I am very doubtful.
-uint64_t g_uVblankDrawBufferRedZoneNS = 2'000'000;
+uint64_t g_uVblankDrawBufferRedZoneNS = g_uDefaultVBlankRedZone;
 
 // Tuneable
+// 93% by default. (g_uVBlankRateOfDecayPercentage)
 // The rate of decay (as a percentage) of the rolling average -> current draw time
-uint64_t g_uVBlankRateOfDecayPercentage = 93;
+uint64_t g_uVBlankRateOfDecayPercentage = g_uDefaultVBlankRateOfDecayPercentage;
 
 const uint64_t g_uVBlankRateOfDecayMax = 100;
 

--- a/src/vblankmanager.cpp
+++ b/src/vblankmanager.cpp
@@ -20,21 +20,85 @@ static int g_vblankPipe[2];
 
 std::atomic<uint64_t> g_lastVblank;
 
-uint64_t g_uVblankDrawBufferNS = 5'000'000;
+// 3ms by default -- a good starting value.
+const uint64_t g_uStartingDrawTime = 3'000'000;
+
+// This is the last time a draw took.
+std::atomic<uint64_t> g_uVblankDrawTimeNS = { g_uStartingDrawTime };
+
+// Tuneable
+// 2.0ms
+// This is the leeway we always apply to our buffer.
+// This also accounts for some time we cannot account for (which (I think) is the drm_commit -> triggering the pageflip)
+// It would be nice to make this lower if we can find a way to track that effectively
+// Perhaps the missing time is spent elsewhere, but given we track from the pipe write
+// to after the return from `drm_commit` -- I am very doubtful.
+uint64_t g_uVblankDrawBufferRedZoneNS = 2'000'000;
+
+// Tuneable
+// The rate of decay (as a percentage) of the rolling average -> current draw time
+uint64_t g_uVBlankRateOfDecayPercentage = 93;
+
+const uint64_t g_uVBlankRateOfDecayMax = 100;
+
+//#define VBLANK_DEBUG
 
 void vblankThreadRun( void )
 {
 	pthread_setname_np( pthread_self(), "gamescope-vblk" );
 
+	// Start off our average with our starting draw time.
+	uint64_t rollingMaxDrawTime = g_uStartingDrawTime;
+
+	const uint64_t range = g_uVBlankRateOfDecayMax;
 	while ( true )
 	{
-		uint64_t lastVblank = g_lastVblank - g_uVblankDrawBufferNS;
-		uint64_t nsecInterval = 1'000'000'000ul / g_nOutputRefresh;
+		const uint64_t alpha = g_uVBlankRateOfDecayPercentage;
+		const int refresh = g_nNestedRefresh ? g_nNestedRefresh : g_nOutputRefresh;
 
-		if ( g_nNestedRefresh != 0 )
+		const uint64_t nsecInterval = 1'000'000'000ul / refresh;
+		const uint64_t drawTime = g_uVblankDrawTimeNS;
+
+		// This is a rolling average when drawTime < rollingMaxDrawTime,
+		// and a a max when drawTime > rollingMaxDrawTime.
+		// This allows us to deal with spikes in the draw buffer time very easily.
+		// eg. if we suddenly spike up (eg. because of test commits taking a stupid long time),
+		// we will then be able to deal with spikes in the long term, even if several commits after
+		// we get back into a good state and then regress again.
+		rollingMaxDrawTime = ( ( alpha * std::max( rollingMaxDrawTime, drawTime ) ) + ( range - alpha ) * drawTime ) / range;
+
+		// If we need to offset for our draw more than half of our vblank, something is very wrong.
+		// Clamp our max time to half of the vblank if we can.
+		rollingMaxDrawTime = std::min( rollingMaxDrawTime + g_uVblankDrawBufferRedZoneNS, nsecInterval / 2 ) - g_uVblankDrawBufferRedZoneNS;
+
+		uint64_t offset = rollingMaxDrawTime + g_uVblankDrawBufferRedZoneNS;
+
+#ifdef VBLANK_DEBUG
+		// Debug stuff for logging missed vblanks
+		static uint64_t vblankIdx = 0;
+		static uint64_t lastDrawTime = g_uVblankDrawTimeNS;
+		static uint64_t lastOffset = g_uVblankDrawTimeNS + g_uVblankDrawBufferRedZoneNS;
+
+		if ( vblankIdx++ % 300 == 0 || drawTime > lastOffset )
 		{
-			nsecInterval = 1'000'000'000ul / g_nNestedRefresh;
+			if ( drawTime > lastOffset )
+				fprintf( stderr, " !! missed vblank " );
+
+			fprintf( stderr, "redZone: %.2fms decayRate: %lu%% - rollingMaxDrawTime: %.2fms lastDrawTime: %.2fms lastOffset: %.2fms - drawTime: %.2fms offset: %.2fms\n",
+				g_uVblankDrawBufferRedZoneNS / 1'000'000.0,
+				g_uVBlankRateOfDecayPercentage,
+				rollingMaxDrawTime / 1'000'000.0,
+				lastDrawTime / 1'000'000.0,
+				lastOffset / 1'000'000.0,
+				drawTime / 1'000'000.0,
+				offset / 1'000'000.0 );
 		}
+
+		lastDrawTime = drawTime;
+		lastOffset = offset;
+#endif
+
+		uint64_t lastVblank = g_lastVblank - offset;
 
 		uint64_t now = get_time_in_nanos();
 		uint64_t targetPoint = lastVblank + nsecInterval;
@@ -57,7 +121,7 @@ void vblankThreadRun( void )
 		}
 		
 		// Get on the other side of it now
-		sleep_for_nanos( g_uVblankDrawBufferNS + 1'000'000 );
+		sleep_for_nanos( offset + 1'000'000 );
 	}
 }
 

--- a/src/vblankmanager.cpp
+++ b/src/vblankmanager.cpp
@@ -77,7 +77,7 @@ int vblank_init( void )
 	return g_vblankPipe[ 0 ];
 }
 
-void vblank_mark_possible_vblank( void )
+void vblank_mark_possible_vblank( uint64_t nanos )
 {
-	g_lastVblank = get_time_in_nanos();
+	g_lastVblank = nanos;
 }

--- a/src/vblankmanager.hpp
+++ b/src/vblankmanager.hpp
@@ -3,3 +3,5 @@
 int vblank_init( void );
 
 void vblank_mark_possible_vblank( uint64_t nanos );
+
+extern std::atomic<uint64_t> g_uVblankDrawTimeNS;

--- a/src/vblankmanager.hpp
+++ b/src/vblankmanager.hpp
@@ -5,3 +5,9 @@ int vblank_init( void );
 void vblank_mark_possible_vblank( uint64_t nanos );
 
 extern std::atomic<uint64_t> g_uVblankDrawTimeNS;
+
+const unsigned int g_uDefaultVBlankRedZone = 2'000'000;
+const unsigned int g_uDefaultVBlankRateOfDecayPercentage = 93;
+
+extern uint64_t g_uVblankDrawBufferRedZoneNS;
+extern uint64_t g_uVBlankRateOfDecayPercentage;

--- a/src/vblankmanager.hpp
+++ b/src/vblankmanager.hpp
@@ -2,4 +2,4 @@
 
 int vblank_init( void );
 
-void vblank_mark_possible_vblank( void );
+void vblank_mark_possible_vblank( uint64_t nanos );

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -109,5 +109,8 @@ struct xwayland_ctx_t
 		Atom gamescopeFocusDisplay;
 		Atom gamescopeMouseFocusDisplay;
 		Atom gamescopeKeyboardFocusDisplay;
+
+		Atom gamescopeTuneableVBlankRedZone;
+		Atom gamescopeTuneableRateOfDecay;
 	} atoms;
 };


### PR DESCRIPTION
Reworks the VBlank manager to estimate the next draw time using a rolling average when the new draw time was less than the current rolling average, and a max when it goes above to account for spikes.

Includes some tuneables exposed by an atom so we can play with this via xprop or Steam or whatever.