### PR TITLE
drm: Reset layer z-pos when disabled

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1144,6 +1144,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct Composite_t *pComposite, co
 		else
 		{
 			liftoff_layer_set_property( drm->lo_layers[ i ], "FB_ID", 0 );
+			liftoff_layer_set_property( drm->lo_layers[ i ], "zpos", 0 );
 		}
 	}
 


### PR DESCRIPTION
Works around a libliftoff bug that makes the layer go from "test-only commit failed (Invalid argument)" -> "has composited layer on top" when there used to be a layer with a higher z-pos there as it doesn't check for the fb_id's existance in has_composited_layer_over.

https://gitlab.freedesktop.org/emersion/libliftoff/-/issues/67