### PR TITLE
steamcompmgr: Handle cursor image width being different to surface wi…

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1074,8 +1074,10 @@ drm_prepare_basic( struct drm_t *drm, const struct Composite_t *pComposite, cons
 
 	if ( g_bRotated )
 	{
+		int64_t imageH = pPipeline->layerBindings[ 0 ].imageHeight / pComposite->data.vScale[ 0 ].y;
+
 		int64_t tmp = crtcX;
-		crtcX = g_nOutputHeight - crtcH - crtcY;
+		crtcX = g_nOutputHeight - imageH - crtcY;
 		crtcY = tmp;
 
 		tmp = crtcW;
@@ -1135,9 +1137,11 @@ drm_prepare_liftoff( struct drm_t *drm, const struct Composite_t *pComposite, co
 			uint64_t crtcH = srcHeight / pComposite->data.vScale[ i ].y;
 
 			if (g_bRotated) {
+				int64_t imageH = pPipeline->layerBindings[ i ].imageHeight / pComposite->data.vScale[ i ].y;
+
 				const int32_t x = crtcX;
 				const uint64_t w = crtcW;
-				crtcX = g_nOutputHeight - crtcH - crtcY;
+				crtcX = g_nOutputHeight - imageH - crtcY;
 				crtcY = x;
 				crtcW = crtcH;
 				crtcH = w;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -33,6 +33,9 @@ struct VulkanPipeline_t
 	{
 		int surfaceWidth;
 		int surfaceHeight;
+
+		int imageWidth;
+		int imageHeight;
 		
 		std::shared_ptr<CVulkanTexture> tex;
 		uint32_t fbid;

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -72,7 +72,8 @@ private:
 
 	int m_x = 0, m_y = 0;
 	int m_hotspotX = 0, m_hotspotY = 0;
-	int m_width = 0, m_height = 0;
+	int m_surfaceWidth = 0, m_surfaceHeight = 0;
+	int m_imageWidth = 0, m_imageHeight = 0;
 
 	std::shared_ptr<CVulkanTexture> m_texture;
 	bool m_dirty;


### PR DESCRIPTION
…dth for rotation offset

The surface width for the cursor is 256, but the image width is 64 which means we have a bunch of blank space, so we need to account for this in DRM code for the CRTC offsets.