### PR TITLE
Fixed pipewire stream stopping after a few seconds

### DIFF
--- a/src/pipewire.hpp
+++ b/src/pipewire.hpp
@@ -15,7 +15,6 @@ struct pipewire_state {
 	struct pw_stream *stream;
 	uint32_t stream_node_id;
 	bool streaming;
-	bool needs_buffer;
 	struct spa_video_info_raw video_info;
 	int stride;
 	uint64_t seq;


### PR DESCRIPTION
With the latest version of pipewire, the process callback is no longer automatically called. Instead, you should call pw_stream_trigger_process() when frames are ready, to have the processing callback happen.

Since the only processing we're doing is requesting a buffer, I'm calling that directly from the callback, since that is thread-safe for a single reader.