### PR TITLE
mangoapp: fix msgsnd size arg

### DIFF
--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -45,5 +45,5 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
     mangoapp_msg_v1.fsrSharpness = g_fsrSharpness;
     mangoapp_msg_v1.app_frametime_ns = app_frametime_ns;
     mangoapp_msg_v1.latency_ns = latency_ns;
-    msgsnd(msgid, &mangoapp_msg_v1, sizeof(mangoapp_msg_v1), IPC_NOWAIT);
+    msgsnd(msgid, &mangoapp_msg_v1, sizeof(mangoapp_msg_v1) - sizeof(mangoapp_msg_v1.hdr.msg_type), IPC_NOWAIT);
 }


### PR DESCRIPTION
The size argument must not include the `long msg_type` field.

Fixes the following ASan error:

    =================================================================
    ==25745==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55cb6beea08a at pc 0x7f118e89525d bp
     0x7f117620a8a0 sp 0x7f117620a048
    READ of size 50 at 0x55cb6beea08a thread T10

        #0 0x7f118e89525c in __interceptor_msgsnd /usr/src/debug/gcc/libsanitizer/sanitizer_common/sanitizer_c
    ommon_interceptors.inc:3138
        #1 0x55cb6b6518ed in mangoapp_update(unsigned long, unsigned long, unsigned long) ../src/mangoapp.cpp:
    48
        #2 0x55cb6b484dde in imageWaitThreadMain() ../src/steamcompmgr.cpp:521
        #3 0x55cb6b538298 in void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) /usr
    /include/c++/11.2.0/bits/invoke.h:61
        #4 0x55cb6b5381b3 in std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) /u
    sr/include/c++/11.2.0/bits/invoke.h:96
        #5 0x55cb6b538063 in void std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_t
    uple<0ul>) /usr/include/c++/11.2.0/bits/std_thread.h:253
        #6 0x55cb6b537f23 in std::thread::_Invoker<std::tuple<void (*)()> >::operator()() /usr/include/c++/11.
    2.0/bits/std_thread.h:260
        #7 0x55cb6b537ae9 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run
    () /usr/include/c++/11.2.0/bits/std_thread.h:211
        #8 0x7f118e0a34d3 in execute_native_thread_routine /usr/src/debug/gcc/libstdc++-v3/src/c++11/thread.cc
    :82
        #9 0x7f118d3d75c1 in start_thread (/usr/lib/libc.so.6+0x8d5c1)
        #10 0x7f118d45c583 in __clone (/usr/lib/libc.so.6+0x112583)

    0x55cb6beea08a is located 0 bytes to the right of global variable 'mangoapp_msg_v1' defined in '../src/mangoapp.cpp:27:27' (0x55cb6beea060) of size 42

cc @flightlessmango