### PR TITLE
Fix IME generated keycodes to match expected values

### DIFF
--- a/src/ime.cpp
+++ b/src/ime.cpp
@@ -322,6 +322,9 @@ static uint32_t keycode_from_single_ch(struct wlserver_input_method *ime, uint32
 	case ' ':
 		keycode = KEY_SPACE;
 		break;
+	case '`':
+		keycode = KEY_GRAVE;
+		break;
 	default:
 		return keycode_from_ch(ime, ch);
 	}


### PR DESCRIPTION
This fixes the keycode always being '1' for the Steam Deck on-screen
keyboard. Emoji and non-US keys will still use the old code path.