### PR TITLE
rendervulkan: Support blur for override redirect layer too

### DIFF
--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -24,6 +24,8 @@
 #define k_nMaxLayers 6
 #define k_nMaxYcbcrMask 16
 
+#define k_nMaxBlurLayers 2
+
 #define kMaxBlurRadius (37u / 2 + 1)
 
 enum BlurMode {

--- a/src/shaders/cs_composite_blur.comp
+++ b/src/shaders/cs_composite_blur.comp
@@ -39,23 +39,10 @@ void main() {
     vec2 uv = vec2(coord);
     vec3 outputValue = vec3(0.0f);
 
-    if (c_layerCount > 0) {
-        vec2 texSize = textureSize(s_sampler_extra, 0);
+    if (c_layerCount > 0)
+        outputValue = gaussian_blur(s_sampler_extra, 0, vec2(coord), c_blur_radius, true, true).rgb;
 
-        vec2 layer0coord = coord + u_offset[0];
-
-        if (layer0coord.x < 0.0f       || layer0coord.y < 0.0f ||
-            layer0coord.x >= texSize.x || layer0coord.y >= texSize.y) {
-            outputValue = vec3(0);
-        } else {
-            vec2 pos = coord + u_offset[0];
-            outputValue = gaussian_blur(s_sampler_extra, pos, c_blur_radius, true, true).rgb;
-        }
-        //outputValue = sampleLayer(s_samplers[0], 0, coord, true).rgb;
-    }
-
-
-    for (int i = 1; i < c_layerCount; i++) {
+    for (int i = c_blur_layer_count + 1; i < c_layerCount; i++) {
         vec4 layerColor = sampleLayer(i, uv);
         float opacity = u_opacity[i];
         float layerAlpha = opacity * layerColor.a;

--- a/src/shaders/cs_composite_blur_cond.comp
+++ b/src/shaders/cs_composite_blur_cond.comp
@@ -40,7 +40,7 @@ void main() {
 
     float finalRevAlpha = 1.0f;
 
-    for (int i = 1; i < c_layerCount; i++) {
+    for (int i = c_blur_layer_count + 1; i < c_layerCount; i++) {
         vec4 layerColor = sampleLayer(i, uv);
         float opacity = u_opacity[i];
         float layerAlpha = opacity * layerColor.a;
@@ -51,23 +51,17 @@ void main() {
 
     if (c_layerCount > 0) {
         if (finalRevAlpha < 0.95) {
-            vec2 texSize = textureSize(s_sampler_extra, 0);
-
-            vec2 layer0coord = (coord + u_offset[0]) * u_scale[0];
-
-            if (layer0coord.x < 0.0f       || layer0coord.y < 0.0f ||
-                layer0coord.x >= texSize.x || layer0coord.y >= texSize.y) {
-                
-            } else {
-                vec2 pos = coord + u_offset[0];
-                vec3 color0 = gaussian_blur(s_sampler_extra, pos, c_blur_radius, true, true).rgb;
-                outputValue += color0 * finalRevAlpha;
-            }
+            outputValue += gaussian_blur(s_sampler_extra, 0, vec2(coord), c_blur_radius, true, true).rgb * finalRevAlpha;
         } else {
-            outputValue = sampleLayer(0, uv).rgb;
+            outputValue = sampleLayer(0, uv).rgb * u_opacity[0];
+            for (int i = 1; i < c_blur_layer_count + 1; i++) {
+                vec4 layerColor = sampleLayer(i, uv);
+                float opacity = u_opacity[i];
+                float layerAlpha = opacity * layerColor.a;
+                outputValue = layerColor.rgb * opacity + outputValue * (1.0f - layerAlpha);
+            }
         }
     }
-
 
     outputValue = linearToSrgb(outputValue);
     imageStore(dst, ivec2(coord), vec4(outputValue, 0));

--- a/src/shaders/cs_gaussian_blur_horizontal.comp
+++ b/src/shaders/cs_gaussian_blur_horizontal.comp
@@ -27,12 +27,29 @@ void main()
     uvec2 coord = uvec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
     vec2 pos = coord;
 
-    vec3 outputValue;
-    if ((c_ycbcrMask & 1) != 0)
-        outputValue = gaussian_blur(s_ycbcr_samplers[0], pos, c_blur_radius, false, false).rgb;
-    else
-        outputValue = gaussian_blur(s_samplers[0], pos, c_blur_radius, false, true).rgb;
+    vec3 outputValue = vec3(0);
 
+    if (c_layerCount > 0) {
+        if ((c_ycbcrMask & 1) != 0)
+            outputValue = gaussian_blur(s_ycbcr_samplers[0], 0, pos, c_blur_radius, false, false).rgb * u_opacity[0];
+        else
+            outputValue = gaussian_blur(s_samplers[0], 0, pos, c_blur_radius, false, true).rgb * u_opacity[0];
+    }
+
+    for (int i = 1; i < c_layerCount; i++) {
+        vec4 layerColor;
+        // YCBCR technically has incorrect blending here but... meh.
+        if ((c_ycbcrMask & (1 << i)) != 0)
+            layerColor = srgbToLinear(gaussian_blur(s_ycbcr_samplers[i], i, pos, c_blur_radius, false, false));
+        else
+            layerColor = gaussian_blur(s_samplers[i], i, pos, c_blur_radius, false, true);
+
+        float opacity = u_opacity[i];
+        float layerAlpha = opacity * layerColor.a;
+        outputValue = layerColor.rgb * opacity + outputValue * (1.0f - layerAlpha);
+    }
+
+    outputValue = linearToSrgb(outputValue);
     imageStore(dst, ivec2(coord), vec4(outputValue, 0));
 }
 

--- a/src/shaders/descriptor_set.h
+++ b/src/shaders/descriptor_set.h
@@ -3,6 +3,7 @@ layout(constant_id = 0) const int  c_layerCount   = 1;
 layout(constant_id = 1) const uint c_ycbcrMask    = 0;
 layout(constant_id = 2) const bool c_compositing_debug = false;
 layout(constant_id = 3) const uint c_blur_radius = 11;
+layout(constant_id = 4) const int  c_blur_layer_count = 0;
 
 const int MaxLayers = 6;
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -314,26 +314,11 @@ static int g_nudgePipe[2] = {-1, -1};
 
 static LogScope xwm_log("xwm");
 
-// Right now there's a suuuper duper rare bug where if we change the zposes
-// from these values the overlay can render behind the base layer
-// or the override can render above the overlay which is very very wrong.
-// So for now, if we have both an override, just force composition
-// and keep these zpos values the same.
-#define WORKAROUND_ZPOS_BUG
-
-#ifdef WORKAROUND_ZPOS_BUG
-static const uint32_t g_zposBase = 0;
-static const uint32_t g_zposOverride = 0;
-static const uint32_t g_zposExternalOverlay = 1;
-static const uint32_t g_zposOverlay = 2;
-static const uint32_t g_zposCursor = 3;
-#else
 static const uint32_t g_zposBase = 0;
 static const uint32_t g_zposOverride = 1;
 static const uint32_t g_zposExternalOverlay = 2;
 static const uint32_t g_zposOverlay = 3;
 static const uint32_t g_zposCursor = 4;
-#endif
 
 // poor man's semaphore
 class sem
@@ -1724,12 +1709,6 @@ paint_all()
 #endif
 
 	bool bCapture = takeScreenshot || pw_buffer != nullptr;
-	
-#ifdef WORKAROUND_ZPOS_BUG
-	const bool bOverrideCompositeHack = override != nullptr;
-#else
-	const bool bOverrideCompositeHack = false;
-#endif
 
 	int nTargetRefresh = g_nSteamCompMgrTargetFPS && g_nDynamicRefreshRate && steamcompmgr_window_should_limit_fps( global_focus.focusWindow ) && !global_focus.overlayWindow
 		? g_nDynamicRefreshRate
@@ -1748,7 +1727,6 @@ paint_all()
 	bool bNeedsComposite = BIsNested();
 	bNeedsComposite |= alwaysComposite;
 	bNeedsComposite |= bCapture;
-	bNeedsComposite |= bOverrideCompositeHack;
 	bNeedsComposite |= bWasFirstFrame;
 	bNeedsComposite |= composite.useFSRLayer0;
 	bNeedsComposite |= composite.blurLayer0;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -314,12 +314,6 @@ static int g_nudgePipe[2] = {-1, -1};
 
 static LogScope xwm_log("xwm");
 
-static const uint32_t g_zposBase = 0;
-static const uint32_t g_zposOverride = 1;
-static const uint32_t g_zposExternalOverlay = 2;
-static const uint32_t g_zposOverlay = 3;
-static const uint32_t g_zposCursor = 4;
-
 // poor man's semaphore
 class sem
 {

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -29,6 +29,12 @@ struct win;
 struct xwayland_ctx_t;
 class gamescope_xwayland_server_t;
 
+static const uint32_t g_zposBase = 0;
+static const uint32_t g_zposOverride = 1;
+static const uint32_t g_zposExternalOverlay = 2;
+static const uint32_t g_zposOverlay = 3;
+static const uint32_t g_zposCursor = 4;
+
 class MouseCursor
 {
 public:


### PR DESCRIPTION
Essentially just shoves that into the horizontal pass and cleans it out of the normal composite when we go to do vertical and also makes the blur image the same size as the output, which should have been done anwyay to avoid harsh borders.

Closes #426

@DadSchoorse 