### PR TITLE
mangoapp: send focusWindow pid

### DIFF
--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -45,5 +45,6 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
     mangoapp_msg_v1.fsrSharpness = g_fsrSharpness;
     mangoapp_msg_v1.app_frametime_ns = app_frametime_ns;
     mangoapp_msg_v1.latency_ns = latency_ns;
+    mangoapp_msg_v1.pid = focusWindow_pid;
     msgsnd(msgid, &mangoapp_msg_v1, sizeof(mangoapp_msg_v1) - sizeof(mangoapp_msg_v1.hdr.msg_type), IPC_NOWAIT);
 }

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -243,6 +243,8 @@ unsigned int g_BlurFadeDuration = 0;
 int g_BlurRadius = 5;
 unsigned int g_BlurFadeStartTime = 0;
 
+pid_t focusWindow_pid;
+
 bool steamcompmgr_window_should_limit_fps( win *w )
 {
 	return g_nSteamCompMgrTargetFPS != 0 && w && !w->isSteam && w->appID != 769 && !w->isOverlay && !w->isExternalOverlay;
@@ -2571,6 +2573,7 @@ determine_and_apply_focus()
 		focusedBaseAppId = global_focus.focusWindow->appID;
 		focusedAppId = global_focus.inputFocusWindow->appID;
 		focused_display = global_focus.focusWindow->ctx->xwayland_server->get_nested_display_name();
+		focusWindow_pid = global_focus.focusWindow->pid;
 	}
 
 	if ( global_focus.inputFocusWindow )

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -118,3 +118,4 @@ gamescope_xwayland_server_t *steamcompmgr_get_focused_server();
 struct wlr_surface *steamcompmgr_get_server_input_surface( size_t idx );
 
 extern uint64_t g_SteamCompMgrVBlankTime;
+extern pid_t focusWindow_pid;


### PR DESCRIPTION
This allows us to cross reference pid with the mangoapp layer and get what vulkan engine the focused app is using