### PR TITLE
Fix some issues when running on the NVIDIA Vulkan driver

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 2-Clause License
 
 Copyright (c) 2013-2022, Valve Corporation
+Copyright (c) 2022, NVIDIA CORPORATION
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -35,6 +35,7 @@ struct crtc {
 	drmModeCrtc *crtc;
 	std::map<std::string, const drmModePropertyRes *> props;
 	std::map<std::string, uint64_t> initial_prop_values;
+	bool has_gamma_lut;
 
 	struct {
 		bool active;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -33,4 +33,5 @@ extern int g_nNewNice;
 
 extern int g_nXWaylandCount;
 
+void restore_fd_limit( void );
 bool BIsNested( void );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4368,6 +4368,9 @@ spawn_client( char **argv )
 			nice( g_nOldNice - g_nNewNice );
 		}
 
+		// Restore prior rlimit in case child uses select()
+		restore_fd_limit();
+
 		// Set modified LD_PRELOAD if needed
 		if ( pchCurrentPreload != nullptr )
 		{


### PR DESCRIPTION
* Raise the soft file descriptor limit for the process at startup. Each VkFence will consume a file descriptor on the NVIDIA Vulkan driver, and Gamescope creates 1024, equal to the usual default file descriptor limit, guaranteeing resource exhaustion.
* Don't attempt to use the GAMMA_LUT CRTC property when it is not supported.