### PR TITLE
Use timeline semaphores for scratch cmd buffers

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <array>
 #include <thread>
-#include <vulkan/vulkan_core.h>
 
 #include "rendervulkan.hpp"
 #include "main.hpp"
@@ -1314,8 +1313,6 @@ retry:
 			vecEnabledDeviceExtensions.push_back( VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME );
 	}
 
-	vecEnabledDeviceExtensions.push_back( VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME );
-
 	vecEnabledDeviceExtensions.push_back( VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME );
 	vecEnabledDeviceExtensions.push_back( VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME );
 
@@ -2166,8 +2163,6 @@ static inline void submit_command_buffer( uint32_t handle, std::vector<std::shar
 
 void vulkan_garbage_collect( void )
 {
-	// If we ever made anything calling get_command_buffer() multi-threaded we'd have to rethink this
-	// Probably just differentiate "busy" and "submitted"
 	uint64_t currentSeqNo;
 	VkResult res = vkGetSemaphoreCounterValue(device, g_scratchTimelineSemaphore, &currentSeqNo);
 	assert( res == VK_SUCCESS );

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -39,7 +39,7 @@ const VkApplicationInfo appInfo = {
 	.applicationVersion = VK_MAKE_VERSION(1, 0, 0),
 	.pEngineName = "just some code",
 	.engineVersion = VK_MAKE_VERSION(1, 0, 0),
-	.apiVersion = VK_API_VERSION_1_1,
+	.apiVersion = VK_API_VERSION_1_2,
 };
 
 VkInstance instance;
@@ -940,12 +940,12 @@ bool vulkan_init_formats()
 	return true;
 }
 
-static bool is_vulkan_1_1_device(VkPhysicalDevice device)
+static bool is_vulkan_1_2_device(VkPhysicalDevice device)
 {
 	VkPhysicalDeviceProperties properties;
 	vkGetPhysicalDeviceProperties(device, &properties);
 
-	return properties.apiVersion >= VK_API_VERSION_1_1;
+	return properties.apiVersion >= VK_API_VERSION_1_2;
 }
 
 static VkPipeline compile_vk_pipeline(uint32_t layerCount, uint32_t ycbcrMask, uint32_t radius, ShaderType type, uint32_t blur_layer_count)
@@ -1093,7 +1093,7 @@ static bool init_device()
 retry:
 	for (uint32_t i = 0; i < physicalDeviceCount; ++i)
 	{
-		if (!is_vulkan_1_1_device(deviceHandles[i]))
+		if (!is_vulkan_1_2_device(deviceHandles[i]))
 			continue;
 
 		uint32_t queueFamilyCount = 0;


### PR DESCRIPTION
Fixes using 1000s of fences which exhausts FDs on NVIDIA.