### PR TITLE
sdlwindow: Handle SDL_WINDOWEVENT_CLOSE

### DIFF
--- a/src/main.hpp
+++ b/src/main.hpp
@@ -3,7 +3,6 @@
 #include <getopt.h>
 
 #include <atomic>
-#include <thread>
 
 extern const char *gamescope_optstring;
 extern const struct option *gamescope_options;
@@ -33,7 +32,5 @@ extern int g_nOldNice;
 extern int g_nNewNice;
 
 extern int g_nXWaylandCount;
-
-extern pthread_t g_mainThread;
 
 bool BIsNested( void );

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -3,6 +3,7 @@
 #include <getopt.h>
 
 #include <atomic>
+#include <thread>
 
 extern const char *gamescope_optstring;
 extern const struct option *gamescope_options;
@@ -32,5 +33,7 @@ extern int g_nOldNice;
 extern int g_nNewNice;
 
 extern int g_nXWaylandCount;
+
+extern pthread_t g_mainThread;
 
 bool BIsNested( void );

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -2,7 +2,6 @@
 
 #include <thread>
 #include <mutex>
-#include <signal.h>
 
 #include <linux/input-event-codes.h>
 

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -186,7 +186,8 @@ void inputSDLThreadRun( void )
 				switch( event.window.event )
 				{
 					case SDL_WINDOWEVENT_CLOSE:
-						pthread_kill( g_mainThread, SIGINT );
+						g_bRun = false;
+						nudge_steamcompmgr();
 						break;
 					default:
 						break;

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -2,6 +2,7 @@
 
 #include <thread>
 #include <mutex>
+#include <signal.h>
 
 #include <linux/input-event-codes.h>
 
@@ -184,6 +185,9 @@ void inputSDLThreadRun( void )
 			case SDL_WINDOWEVENT:
 				switch( event.window.event )
 				{
+					case SDL_WINDOWEVENT_CLOSE:
+						pthread_kill( g_mainThread, SIGINT );
+						break;
 					default:
 						break;
 					case SDL_WINDOWEVENT_MOVED:


### PR DESCRIPTION
https://github.com/Plagman/gamescope/issues/105

Kill the thread on an SDL_WINDOWEVENT_CLOSE in order to handle Alt+F4 events