### PR TITLE
Support for NVIDIA Image Scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ meson install -C build/ --skip-subprojects
 * **Super + F** : Toggle fullscreen
 * **Super + N** : Toggle integer scaling
 * **Super + U** : Toggle FSR upscaling
+* **Super + Y** : Toggle NIS upscaling
 * **Super + I** : Increase FSR sharpness by 1
 * **Super + O** : Decrease FSR sharpness by 1
 * **Super + S** : Take screenshot (currently goes to `/tmp/gamescope_$DATE.png`)
@@ -62,7 +63,8 @@ See `gamescope --help` for a full list of options.
 * `-w`, `-h`: set the resolution used by the game. If `-h` is specified but `-w` isn't, a 16:9 aspect ratio is assumed. Defaults to the values specified in `-W` and `-H`.
 * `-r`: set a frame-rate limit for the game. Specified in frames per second. Defaults to unlimited.
 * `-o`: set a frame-rate limit for the game when unfocused. Specified in frames per second. Defaults to unlimited.
-* `-U`: use AMD FidelityFX™ Super Resolution 1.0 for upscaling 
+* `-U`: use AMD FidelityFX™ Super Resolution 1.0 for upscaling
+* `-Y`: use NVIDIA Image Scaling v1.0.2 for upscaling
 * `-n`: use integer scaling.
 * `-b`: create a border-less window.
 * `-f`: create a full-screen window.

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,8 @@ shader_src = [
   'src/shaders/cs_easu.comp',
   'src/shaders/cs_easu_fp16.comp',
   'src/shaders/cs_gaussian_blur_horizontal.comp',
+  'src/shaders/cs_nis.comp',
+  'src/shaders/cs_nis_fp16.comp'
 ]
 
 spirv_shaders = glsl_generator.process(shader_src)

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -22,8 +22,15 @@ extern bool g_bFullscreen;
 
 extern bool g_bFilterGameWindow;
 
-extern bool g_fsrUpscale;
-extern int g_fsrSharpness;
+enum class GamescopeUpscaler : uint32_t
+{
+    BLIT = 0,
+    FSR,
+    NIS
+};
+
+extern GamescopeUpscaler g_upscaler;
+extern int g_upscalerSharpness;
 
 extern bool g_bBorderlessOutputWindow;
 

--- a/src/mangoapp.cpp
+++ b/src/mangoapp.cpp
@@ -42,7 +42,7 @@ void mangoapp_update( uint64_t visible_frametime, uint64_t app_frametime_ns, uin
 
     mangoapp_msg_v1.visible_frametime_ns = visible_frametime;
     mangoapp_msg_v1.fsrUpscale = g_bFSRActive;
-    mangoapp_msg_v1.fsrSharpness = g_fsrSharpness;
+    mangoapp_msg_v1.fsrSharpness = g_upscalerSharpness;
     mangoapp_msg_v1.app_frametime_ns = app_frametime_ns;
     mangoapp_msg_v1.latency_ns = latency_ns;
     mangoapp_msg_v1.pid = focusWindow_pid;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -146,6 +146,7 @@ struct vec2_t
 struct FrameInfo_t
 {
 	bool useFSRLayer0;
+	bool useNISLayer0;
 	BlurMode blurLayer0;
 	int blurRadius;
 

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -152,14 +152,22 @@ void inputSDLThreadRun( void )
 						case KEY_N:
 							g_bFilterGameWindow = !g_bFilterGameWindow;
 							break;
+						case KEY_B:
+							g_upscaler = GamescopeUpscaler::BLIT;
+							break;
 						case KEY_U:
-							g_fsrUpscale = !g_fsrUpscale;
+							g_upscaler = (g_upscaler == GamescopeUpscaler::FSR) ?
+								GamescopeUpscaler::BLIT : GamescopeUpscaler::FSR;
+							break;
+						case KEY_Y:
+							g_upscaler = (g_upscaler == GamescopeUpscaler::NIS) ? 
+								GamescopeUpscaler::BLIT : GamescopeUpscaler::NIS;
 							break;
 						case KEY_I:
-							g_fsrSharpness = std::min(20, g_fsrSharpness + 1);
+							g_upscalerSharpness = std::min(20, g_upscalerSharpness + 1);
 							break;
 						case KEY_O:
-							g_fsrSharpness = std::max(0, g_fsrSharpness - 1);
+							g_upscalerSharpness = std::max(0, g_upscalerSharpness - 1);
 							break;
 						case KEY_S:
 							take_screenshot();

--- a/src/shaders/NVIDIAImageScaling/NIS/NIS_Config.h
+++ b/src/shaders/NVIDIAImageScaling/NIS/NIS_Config.h
@@ -1,0 +1,535 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files(the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+#ifndef NIS_ALIGNED
+#if defined(_MSC_VER)
+#define NIS_ALIGNED(x) __declspec(align(x))
+#else
+#if defined(__GNUC__)
+#define NIS_ALIGNED(x) __attribute__ ((aligned(x)))
+#endif
+#endif
+#endif
+
+
+struct NIS_ALIGNED(256) NISConfig
+{
+    float kDetectRatio;
+    float kDetectThres;
+    float kMinContrastRatio;
+    float kRatioNorm;
+
+    float kContrastBoost;
+    float kEps;
+    float kSharpStartY;
+    float kSharpScaleY;
+
+    float kSharpStrengthMin;
+    float kSharpStrengthScale;
+    float kSharpLimitMin;
+    float kSharpLimitScale;
+
+    float kScaleX;
+    float kScaleY;
+    float kDstNormX;
+    float kDstNormY;
+
+    float kSrcNormX;
+    float kSrcNormY;
+
+    uint32_t kInputViewportOriginX;
+    uint32_t kInputViewportOriginY;
+    uint32_t kInputViewportWidth;
+    uint32_t kInputViewportHeight;
+
+    uint32_t kOutputViewportOriginX;
+    uint32_t kOutputViewportOriginY;
+    uint32_t kOutputViewportWidth;
+    uint32_t kOutputViewportHeight;
+
+    float reserved0;
+    float reserved1;
+};
+
+enum class NISHDRMode : uint32_t
+{
+    None = 0,
+    Linear = 1,
+    PQ = 2
+};
+
+enum class NISGPUArchitecture : uint32_t
+{
+    NVIDIA_Generic = 0,
+    AMD_Generic = 1,
+    Intel_Generic = 2,
+    NVIDIA_Generic_fp16 = 3
+};
+
+struct NISOptimizer
+{
+    bool isUpscaling;
+    NISGPUArchitecture gpuArch;
+
+    constexpr NISOptimizer(bool isUpscaling = true, NISGPUArchitecture gpuArch = NISGPUArchitecture::NVIDIA_Generic)
+        : isUpscaling(isUpscaling)
+        , gpuArch(gpuArch)
+    {}
+
+    constexpr uint32_t GetOptimalBlockWidth()
+    {
+        switch (gpuArch) {
+        case NISGPUArchitecture::NVIDIA_Generic:
+            return 32;
+        case NISGPUArchitecture::NVIDIA_Generic_fp16:
+            return 32;
+        case NISGPUArchitecture::AMD_Generic:
+            return 32;
+        case NISGPUArchitecture::Intel_Generic:
+            return 32;
+        }
+        return 32;
+    }
+
+    constexpr uint32_t GetOptimalBlockHeight()
+    {
+        switch (gpuArch) {
+        case NISGPUArchitecture::NVIDIA_Generic:
+            return isUpscaling ? 24 : 32;
+        case NISGPUArchitecture::NVIDIA_Generic_fp16:
+            return isUpscaling ? 32 : 32;
+        case NISGPUArchitecture::AMD_Generic:
+            return isUpscaling ? 24 : 32;
+        case NISGPUArchitecture::Intel_Generic:
+            return isUpscaling ? 24 : 32;
+        }
+        return isUpscaling ? 24 : 32;
+    }
+
+    constexpr uint32_t GetOptimalThreadGroupSize()
+    {
+        switch (gpuArch) {
+        case NISGPUArchitecture::NVIDIA_Generic:
+            return 128;
+        case NISGPUArchitecture::NVIDIA_Generic_fp16:
+            return 128;
+        case NISGPUArchitecture::AMD_Generic:
+            return 256;
+        case NISGPUArchitecture::Intel_Generic:
+            return 256;
+        }
+        return 256;
+    }
+};
+
+
+inline bool NVScalerUpdateConfig(NISConfig& config, float sharpness,
+    uint32_t inputViewportOriginX, uint32_t inputViewportOriginY,
+    uint32_t inputViewportWidth, uint32_t inputViewportHeight,
+    uint32_t inputTextureWidth, uint32_t inputTextureHeight,
+    uint32_t outputViewportOriginX, uint32_t outputViewportOriginY,
+    uint32_t outputViewportWidth, uint32_t outputViewportHeight,
+    uint32_t outputTextureWidth, uint32_t outputTextureHeight,
+    NISHDRMode hdrMode = NISHDRMode::None)
+{
+    // adjust params based on value from sharpness slider
+    sharpness = std::max<float>(std::min<float>(1.f, sharpness), 0.f);
+    float sharpen_slider = sharpness - 0.5f;   // Map 0 to 1 to -0.5 to +0.5
+
+    // Different range for 0 to 50% vs 50% to 100%
+    // The idea is to make sure sharpness of 0% map to no-sharpening,
+    // while also ensuring that sharpness of 100% doesn't cause too much over-sharpening.
+    const float MaxScale = (sharpen_slider >= 0.0f) ? 1.25f : 1.75f;
+    const float MinScale = (sharpen_slider >= 0.0f) ? 1.25f : 1.0f;
+    const float LimitScale = (sharpen_slider >= 0.0f) ? 1.25f : 1.0f;
+
+    float kDetectRatio = 2 * 1127.f / 1024.f;
+
+    // Params for SDR
+    float kDetectThres = 64.0f / 1024.0f;
+    float kMinContrastRatio = 2.0f;
+    float kMaxContrastRatio = 10.0f;
+
+    float kSharpStartY = 0.45f;
+    float kSharpEndY = 0.9f;
+    float kSharpStrengthMin = std::max<float>(0.0f, 0.4f + sharpen_slider * MinScale * 1.2f);
+    float kSharpStrengthMax = 1.6f + sharpen_slider * MaxScale * 1.8f;
+    float kSharpLimitMin = std::max<float>(0.1f, 0.14f + sharpen_slider * LimitScale * 0.32f);
+    float kSharpLimitMax = 0.5f + sharpen_slider * LimitScale * 0.6f;
+
+    if (hdrMode == NISHDRMode::Linear || hdrMode == NISHDRMode::PQ)
+    {
+        kDetectThres = 32.0f / 1024.0f;
+
+        kMinContrastRatio = 1.5f;
+        kMaxContrastRatio = 5.0f;
+
+        kSharpStrengthMin = std::max<float>(0.0f, 0.4f + sharpen_slider * MinScale * 1.1f);
+        kSharpStrengthMax = 2.2f + sharpen_slider * MaxScale * 1.8f;
+        kSharpLimitMin = std::max<float>(0.06f, 0.10f + sharpen_slider * LimitScale * 0.28f);
+        kSharpLimitMax = 0.6f + sharpen_slider * LimitScale * 0.6f;
+
+        if (hdrMode == NISHDRMode::PQ)
+        {
+            kSharpStartY = 0.35f;
+            kSharpEndY = 0.55f;
+        }
+        else
+        {
+            kSharpStartY = 0.3f;
+            kSharpEndY = 0.5f;
+        }
+    }
+
+    float kRatioNorm = 1.0f / (kMaxContrastRatio - kMinContrastRatio);
+    float kSharpScaleY = 1.0f / (kSharpEndY - kSharpStartY);
+    float kSharpStrengthScale = kSharpStrengthMax - kSharpStrengthMin;
+    float kSharpLimitScale = kSharpLimitMax - kSharpLimitMin;
+
+    config.kInputViewportWidth = inputViewportWidth == 0 ? inputTextureWidth : inputViewportWidth;
+    config.kInputViewportHeight = inputViewportHeight == 0 ? inputTextureHeight : inputViewportHeight;
+    config.kOutputViewportWidth = outputViewportWidth == 0 ? outputTextureWidth : outputViewportWidth;
+    config.kOutputViewportHeight = outputViewportHeight == 0 ? outputTextureHeight : outputViewportHeight;
+    if (config.kInputViewportWidth == 0 || config.kInputViewportHeight == 0 ||
+        config.kOutputViewportWidth == 0 || config.kOutputViewportHeight == 0)
+        return false;
+
+    config.kInputViewportOriginX = inputViewportOriginX;
+    config.kInputViewportOriginY = inputViewportOriginY;
+    config.kOutputViewportOriginX = outputViewportOriginX;
+    config.kOutputViewportOriginY = outputViewportOriginY;
+
+    config.kSrcNormX = 1.f / inputTextureWidth;
+    config.kSrcNormY = 1.f / inputTextureHeight;
+    config.kDstNormX = 1.f / outputTextureWidth;
+    config.kDstNormY = 1.f / outputTextureHeight;
+    config.kScaleX = config.kInputViewportWidth / float(config.kOutputViewportWidth);
+    config.kScaleY = config.kInputViewportHeight / float(config.kOutputViewportHeight);
+    config.kDetectRatio = kDetectRatio;
+    config.kDetectThres = kDetectThres;
+    config.kMinContrastRatio = kMinContrastRatio;
+    config.kRatioNorm = kRatioNorm;
+    config.kContrastBoost = 1.0f;
+    config.kEps = 1.0f / 255.0f;
+    config.kSharpStartY = kSharpStartY;
+    config.kSharpScaleY = kSharpScaleY;
+    config.kSharpStrengthMin = kSharpStrengthMin;
+    config.kSharpStrengthScale = kSharpStrengthScale;
+    config.kSharpLimitMin = kSharpLimitMin;
+    config.kSharpLimitScale = kSharpLimitScale;
+
+    if (config.kScaleX < 0.5f || config.kScaleX > 1.f || config.kScaleY < 0.5f || config.kScaleY > 1.f)
+        return false;
+    return true;
+}
+
+
+inline bool NVSharpenUpdateConfig(NISConfig& config, float sharpness,
+    uint32_t inputViewportOriginX, uint32_t inputViewportOriginY,
+    uint32_t inputViewportWidth, uint32_t inputViewportHeight,
+    uint32_t inputTextureWidth, uint32_t inputTextureHeight,
+    uint32_t outputViewportOriginX, uint32_t outputViewportOriginY,
+    NISHDRMode hdrMode = NISHDRMode::None)
+{
+    return NVScalerUpdateConfig(config, sharpness,
+            inputViewportOriginX, inputViewportOriginY, inputViewportWidth, inputViewportHeight, inputTextureWidth, inputTextureHeight,
+            outputViewportOriginX, outputViewportOriginY, inputViewportWidth, inputViewportHeight, inputTextureWidth, inputTextureHeight,
+            hdrMode);
+}
+
+namespace {
+    constexpr size_t kPhaseCount = 64;
+    constexpr size_t kFilterSize = 8;
+
+    constexpr float coef_scale[kPhaseCount][kFilterSize] = {
+        {0.0f,     0.0f,    1.0000f, 0.0f,     0.0f,    0.0f, 0.0f, 0.0f},
+        {0.0029f, -0.0127f, 1.0000f, 0.0132f, -0.0034f, 0.0f, 0.0f, 0.0f},
+        {0.0063f, -0.0249f, 0.9985f, 0.0269f, -0.0068f, 0.0f, 0.0f, 0.0f},
+        {0.0088f, -0.0361f, 0.9956f, 0.0415f, -0.0103f, 0.0005f, 0.0f, 0.0f},
+        {0.0117f, -0.0474f, 0.9932f, 0.0562f, -0.0142f, 0.0005f, 0.0f, 0.0f},
+        {0.0142f, -0.0576f, 0.9897f, 0.0713f, -0.0181f, 0.0005f, 0.0f, 0.0f},
+        {0.0166f, -0.0674f, 0.9844f, 0.0874f, -0.0220f, 0.0010f, 0.0f, 0.0f},
+        {0.0186f, -0.0762f, 0.9785f, 0.1040f, -0.0264f, 0.0015f, 0.0f, 0.0f},
+        {0.0205f, -0.0850f, 0.9727f, 0.1206f, -0.0308f, 0.0020f, 0.0f, 0.0f},
+        {0.0225f, -0.0928f, 0.9648f, 0.1382f, -0.0352f, 0.0024f, 0.0f, 0.0f},
+        {0.0239f, -0.1006f, 0.9575f, 0.1558f, -0.0396f, 0.0029f, 0.0f, 0.0f},
+        {0.0254f, -0.1074f, 0.9487f, 0.1738f, -0.0439f, 0.0034f, 0.0f, 0.0f},
+        {0.0264f, -0.1138f, 0.9390f, 0.1929f, -0.0488f, 0.0044f, 0.0f, 0.0f},
+        {0.0278f, -0.1191f, 0.9282f, 0.2119f, -0.0537f, 0.0049f, 0.0f, 0.0f},
+        {0.0288f, -0.1245f, 0.9170f, 0.2310f, -0.0581f, 0.0059f, 0.0f, 0.0f},
+        {0.0293f, -0.1294f, 0.9058f, 0.2510f, -0.0630f, 0.0063f, 0.0f, 0.0f},
+        {0.0303f, -0.1333f, 0.8926f, 0.2710f, -0.0679f, 0.0073f, 0.0f, 0.0f},
+        {0.0308f, -0.1367f, 0.8789f, 0.2915f, -0.0728f, 0.0083f, 0.0f, 0.0f},
+        {0.0308f, -0.1401f, 0.8657f, 0.3120f, -0.0776f, 0.0093f, 0.0f, 0.0f},
+        {0.0313f, -0.1426f, 0.8506f, 0.3330f, -0.0825f, 0.0103f, 0.0f, 0.0f},
+        {0.0313f, -0.1445f, 0.8354f, 0.3540f, -0.0874f, 0.0112f, 0.0f, 0.0f},
+        {0.0313f, -0.1460f, 0.8193f, 0.3755f, -0.0923f, 0.0122f, 0.0f, 0.0f},
+        {0.0313f, -0.1470f, 0.8022f, 0.3965f, -0.0967f, 0.0137f, 0.0f, 0.0f},
+        {0.0308f, -0.1479f, 0.7856f, 0.4185f, -0.1016f, 0.0146f, 0.0f, 0.0f},
+        {0.0303f, -0.1479f, 0.7681f, 0.4399f, -0.1060f, 0.0156f, 0.0f, 0.0f},
+        {0.0298f, -0.1479f, 0.7505f, 0.4614f, -0.1104f, 0.0166f, 0.0f, 0.0f},
+        {0.0293f, -0.1470f, 0.7314f, 0.4829f, -0.1147f, 0.0181f, 0.0f, 0.0f},
+        {0.0288f, -0.1460f, 0.7119f, 0.5049f, -0.1187f, 0.0190f, 0.0f, 0.0f},
+        {0.0278f, -0.1445f, 0.6929f, 0.5264f, -0.1226f, 0.0200f, 0.0f, 0.0f},
+        {0.0273f, -0.1431f, 0.6724f, 0.5479f, -0.1260f, 0.0215f, 0.0f, 0.0f},
+        {0.0264f, -0.1411f, 0.6528f, 0.5693f, -0.1299f, 0.0225f, 0.0f, 0.0f},
+        {0.0254f, -0.1387f, 0.6323f, 0.5903f, -0.1328f, 0.0234f, 0.0f, 0.0f},
+        {0.0244f, -0.1357f, 0.6113f, 0.6113f, -0.1357f, 0.0244f, 0.0f, 0.0f},
+        {0.0234f, -0.1328f, 0.5903f, 0.6323f, -0.1387f, 0.0254f, 0.0f, 0.0f},
+        {0.0225f, -0.1299f, 0.5693f, 0.6528f, -0.1411f, 0.0264f, 0.0f, 0.0f},
+        {0.0215f, -0.1260f, 0.5479f, 0.6724f, -0.1431f, 0.0273f, 0.0f, 0.0f},
+        {0.0200f, -0.1226f, 0.5264f, 0.6929f, -0.1445f, 0.0278f, 0.0f, 0.0f},
+        {0.0190f, -0.1187f, 0.5049f, 0.7119f, -0.1460f, 0.0288f, 0.0f, 0.0f},
+        {0.0181f, -0.1147f, 0.4829f, 0.7314f, -0.1470f, 0.0293f, 0.0f, 0.0f},
+        {0.0166f, -0.1104f, 0.4614f, 0.7505f, -0.1479f, 0.0298f, 0.0f, 0.0f},
+        {0.0156f, -0.1060f, 0.4399f, 0.7681f, -0.1479f, 0.0303f, 0.0f, 0.0f},
+        {0.0146f, -0.1016f, 0.4185f, 0.7856f, -0.1479f, 0.0308f, 0.0f, 0.0f},
+        {0.0137f, -0.0967f, 0.3965f, 0.8022f, -0.1470f, 0.0313f, 0.0f, 0.0f},
+        {0.0122f, -0.0923f, 0.3755f, 0.8193f, -0.1460f, 0.0313f, 0.0f, 0.0f},
+        {0.0112f, -0.0874f, 0.3540f, 0.8354f, -0.1445f, 0.0313f, 0.0f, 0.0f},
+        {0.0103f, -0.0825f, 0.3330f, 0.8506f, -0.1426f, 0.0313f, 0.0f, 0.0f},
+        {0.0093f, -0.0776f, 0.3120f, 0.8657f, -0.1401f, 0.0308f, 0.0f, 0.0f},
+        {0.0083f, -0.0728f, 0.2915f, 0.8789f, -0.1367f, 0.0308f, 0.0f, 0.0f},
+        {0.0073f, -0.0679f, 0.2710f, 0.8926f, -0.1333f, 0.0303f, 0.0f, 0.0f},
+        {0.0063f, -0.0630f, 0.2510f, 0.9058f, -0.1294f, 0.0293f, 0.0f, 0.0f},
+        {0.0059f, -0.0581f, 0.2310f, 0.9170f, -0.1245f, 0.0288f, 0.0f, 0.0f},
+        {0.0049f, -0.0537f, 0.2119f, 0.9282f, -0.1191f, 0.0278f, 0.0f, 0.0f},
+        {0.0044f, -0.0488f, 0.1929f, 0.9390f, -0.1138f, 0.0264f, 0.0f, 0.0f},
+        {0.0034f, -0.0439f, 0.1738f, 0.9487f, -0.1074f, 0.0254f, 0.0f, 0.0f},
+        {0.0029f, -0.0396f, 0.1558f, 0.9575f, -0.1006f, 0.0239f, 0.0f, 0.0f},
+        {0.0024f, -0.0352f, 0.1382f, 0.9648f, -0.0928f, 0.0225f, 0.0f, 0.0f},
+        {0.0020f, -0.0308f, 0.1206f, 0.9727f, -0.0850f, 0.0205f, 0.0f, 0.0f},
+        {0.0015f, -0.0264f, 0.1040f, 0.9785f, -0.0762f, 0.0186f, 0.0f, 0.0f},
+        {0.0010f, -0.0220f, 0.0874f, 0.9844f, -0.0674f, 0.0166f, 0.0f, 0.0f},
+        {0.0005f, -0.0181f, 0.0713f, 0.9897f, -0.0576f, 0.0142f, 0.0f, 0.0f},
+        {0.0005f, -0.0142f, 0.0562f, 0.9932f, -0.0474f, 0.0117f, 0.0f, 0.0f},
+        {0.0005f, -0.0103f, 0.0415f, 0.9956f, -0.0361f, 0.0088f, 0.0f, 0.0f},
+        {0.0f, -0.0068f, 0.0269f, 0.9985f, -0.0249f, 0.0063f, 0.0f, 0.0f},
+        {0.0f, -0.0034f, 0.0132f, 1.0000f, -0.0127f, 0.0029f, 0.0f, 0.0f}
+    };
+
+    constexpr float coef_usm[kPhaseCount][kFilterSize] = {
+        {0.0f,      -0.6001f, 1.2002f, -0.6001f,  0.0f,  0.0f, 0.0f, 0.0f},
+        {0.0029f, -0.6084f, 1.1987f, -0.5903f, -0.0029f, 0.0f, 0.0f, 0.0f},
+        {0.0049f, -0.6147f, 1.1958f, -0.5791f, -0.0068f, 0.0005f, 0.0f, 0.0f},
+        {0.0073f, -0.6196f, 1.1890f, -0.5659f, -0.0103f, 0.0f, 0.0f, 0.0f},
+        {0.0093f, -0.6235f, 1.1802f, -0.5513f, -0.0151f, 0.0f, 0.0f, 0.0f},
+        {0.0112f, -0.6265f, 1.1699f, -0.5352f, -0.0195f, 0.0005f, 0.0f, 0.0f},
+        {0.0122f, -0.6270f, 1.1582f, -0.5181f, -0.0259f, 0.0005f, 0.0f, 0.0f},
+        {0.0142f, -0.6284f, 1.1455f, -0.5005f, -0.0317f, 0.0005f, 0.0f, 0.0f},
+        {0.0156f, -0.6265f, 1.1274f, -0.4790f, -0.0386f, 0.0005f, 0.0f, 0.0f},
+        {0.0166f, -0.6235f, 1.1089f, -0.4570f, -0.0454f, 0.0010f, 0.0f, 0.0f},
+        {0.0176f, -0.6187f, 1.0879f, -0.4346f, -0.0532f, 0.0010f, 0.0f, 0.0f},
+        {0.0181f, -0.6138f, 1.0659f, -0.4102f, -0.0615f, 0.0015f, 0.0f, 0.0f},
+        {0.0190f, -0.6069f, 1.0405f, -0.3843f, -0.0698f, 0.0015f, 0.0f, 0.0f},
+        {0.0195f, -0.6006f, 1.0161f, -0.3574f, -0.0796f, 0.0020f, 0.0f, 0.0f},
+        {0.0200f, -0.5928f, 0.9893f, -0.3286f, -0.0898f, 0.0024f, 0.0f, 0.0f},
+        {0.0200f, -0.5820f, 0.9580f, -0.2988f, -0.1001f, 0.0029f, 0.0f, 0.0f},
+        {0.0200f, -0.5728f, 0.9292f, -0.2690f, -0.1104f, 0.0034f, 0.0f, 0.0f},
+        {0.0200f, -0.5620f, 0.8975f, -0.2368f, -0.1226f, 0.0039f, 0.0f, 0.0f},
+        {0.0205f, -0.5498f, 0.8643f, -0.2046f, -0.1343f, 0.0044f, 0.0f, 0.0f},
+        {0.0200f, -0.5371f, 0.8301f, -0.1709f, -0.1465f, 0.0049f, 0.0f, 0.0f},
+        {0.0195f, -0.5239f, 0.7944f, -0.1367f, -0.1587f, 0.0054f, 0.0f, 0.0f},
+        {0.0195f, -0.5107f, 0.7598f, -0.1021f, -0.1724f, 0.0059f, 0.0f, 0.0f},
+        {0.0190f, -0.4966f, 0.7231f, -0.0649f, -0.1865f, 0.0063f, 0.0f, 0.0f},
+        {0.0186f, -0.4819f, 0.6846f, -0.0288f, -0.1997f, 0.0068f, 0.0f, 0.0f},
+        {0.0186f, -0.4668f, 0.6460f, 0.0093f, -0.2144f, 0.0073f, 0.0f, 0.0f},
+        {0.0176f, -0.4507f, 0.6055f, 0.0479f, -0.2290f, 0.0083f, 0.0f, 0.0f},
+        {0.0171f, -0.4370f, 0.5693f, 0.0859f, -0.2446f, 0.0088f, 0.0f, 0.0f},
+        {0.0161f, -0.4199f, 0.5283f, 0.1255f, -0.2598f, 0.0098f, 0.0f, 0.0f},
+        {0.0161f, -0.4048f, 0.4883f, 0.1655f, -0.2754f, 0.0103f, 0.0f, 0.0f},
+        {0.0151f, -0.3887f, 0.4497f, 0.2041f, -0.2910f, 0.0107f, 0.0f, 0.0f},
+        {0.0142f, -0.3711f, 0.4072f, 0.2446f, -0.3066f, 0.0117f, 0.0f, 0.0f},
+        {0.0137f, -0.3555f, 0.3672f, 0.2852f, -0.3228f, 0.0122f, 0.0f, 0.0f},
+        {0.0132f, -0.3394f, 0.3262f, 0.3262f, -0.3394f, 0.0132f, 0.0f, 0.0f},
+        {0.0122f, -0.3228f, 0.2852f, 0.3672f, -0.3555f, 0.0137f, 0.0f, 0.0f},
+        {0.0117f, -0.3066f, 0.2446f, 0.4072f, -0.3711f, 0.0142f, 0.0f, 0.0f},
+        {0.0107f, -0.2910f, 0.2041f, 0.4497f, -0.3887f, 0.0151f, 0.0f, 0.0f},
+        {0.0103f, -0.2754f, 0.1655f, 0.4883f, -0.4048f, 0.0161f, 0.0f, 0.0f},
+        {0.0098f, -0.2598f, 0.1255f, 0.5283f, -0.4199f, 0.0161f, 0.0f, 0.0f},
+        {0.0088f, -0.2446f, 0.0859f, 0.5693f, -0.4370f, 0.0171f, 0.0f, 0.0f},
+        {0.0083f, -0.2290f, 0.0479f, 0.6055f, -0.4507f, 0.0176f, 0.0f, 0.0f},
+        {0.0073f, -0.2144f, 0.0093f, 0.6460f, -0.4668f, 0.0186f, 0.0f, 0.0f},
+        {0.0068f, -0.1997f, -0.0288f, 0.6846f, -0.4819f, 0.0186f, 0.0f, 0.0f},
+        {0.0063f, -0.1865f, -0.0649f, 0.7231f, -0.4966f, 0.0190f, 0.0f, 0.0f},
+        {0.0059f, -0.1724f, -0.1021f, 0.7598f, -0.5107f, 0.0195f, 0.0f, 0.0f},
+        {0.0054f, -0.1587f, -0.1367f, 0.7944f, -0.5239f, 0.0195f, 0.0f, 0.0f},
+        {0.0049f, -0.1465f, -0.1709f, 0.8301f, -0.5371f, 0.0200f, 0.0f, 0.0f},
+        {0.0044f, -0.1343f, -0.2046f, 0.8643f, -0.5498f, 0.0205f, 0.0f, 0.0f},
+        {0.0039f, -0.1226f, -0.2368f, 0.8975f, -0.5620f, 0.0200f, 0.0f, 0.0f},
+        {0.0034f, -0.1104f, -0.2690f, 0.9292f, -0.5728f, 0.0200f, 0.0f, 0.0f},
+        {0.0029f, -0.1001f, -0.2988f, 0.9580f, -0.5820f, 0.0200f, 0.0f, 0.0f},
+        {0.0024f, -0.0898f, -0.3286f, 0.9893f, -0.5928f, 0.0200f, 0.0f, 0.0f},
+        {0.0020f, -0.0796f, -0.3574f, 1.0161f, -0.6006f, 0.0195f, 0.0f, 0.0f},
+        {0.0015f, -0.0698f, -0.3843f, 1.0405f, -0.6069f, 0.0190f, 0.0f, 0.0f},
+        {0.0015f, -0.0615f, -0.4102f, 1.0659f, -0.6138f, 0.0181f, 0.0f, 0.0f},
+        {0.0010f, -0.0532f, -0.4346f, 1.0879f, -0.6187f, 0.0176f, 0.0f, 0.0f},
+        {0.0010f, -0.0454f, -0.4570f, 1.1089f, -0.6235f, 0.0166f, 0.0f, 0.0f},
+        {0.0005f, -0.0386f, -0.4790f, 1.1274f, -0.6265f, 0.0156f, 0.0f, 0.0f},
+        {0.0005f, -0.0317f, -0.5005f, 1.1455f, -0.6284f, 0.0142f, 0.0f, 0.0f},
+        {0.0005f, -0.0259f, -0.5181f, 1.1582f, -0.6270f, 0.0122f, 0.0f, 0.0f},
+        {0.0005f, -0.0195f, -0.5352f, 1.1699f, -0.6265f, 0.0112f, 0.0f, 0.0f},
+        {0.0f, -0.0151f, -0.5513f, 1.1802f, -0.6235f, 0.0093f, 0.0f, 0.0f},
+        {0.0f, -0.0103f, -0.5659f, 1.1890f, -0.6196f, 0.0073f, 0.0f, 0.0f},
+        {0.0005f, -0.0068f, -0.5791f, 1.1958f, -0.6147f, 0.0049f, 0.0f, 0.0f},
+        {0.0f, -0.0029f, -0.5903f, 1.1987f, -0.6084f, 0.0029f, 0.0f, 0.0f}
+    };
+
+    constexpr uint16_t coef_scale_fp16[kPhaseCount][kFilterSize] = {
+       { 0, 0, 15360, 0, 0, 0, 0, 0 },
+       { 6640, 41601, 15360, 8898, 39671, 0, 0, 0 },
+       { 7796, 42592, 15357, 9955, 40695, 0, 0, 0 },
+       { 8321, 43167, 15351, 10576, 41286, 4121, 0, 0 },
+       { 8702, 43537, 15346, 11058, 41797, 4121, 0, 0 },
+       { 9029, 43871, 15339, 11408, 42146, 4121, 0, 0 },
+       { 9280, 44112, 15328, 11672, 42402, 5145, 0, 0 },
+       { 9411, 44256, 15316, 11944, 42690, 5669, 0, 0 },
+       { 9535, 44401, 15304, 12216, 42979, 6169, 0, 0 },
+       { 9667, 44528, 15288, 12396, 43137, 6378, 0, 0 },
+       { 9758, 44656, 15273, 12540, 43282, 6640, 0, 0 },
+       { 9857, 44768, 15255, 12688, 43423, 6903, 0, 0 },
+       { 9922, 44872, 15235, 12844, 43583, 7297, 0, 0 },
+       { 10014, 44959, 15213, 13000, 43744, 7429, 0, 0 },
+       { 10079, 45048, 15190, 13156, 43888, 7691, 0, 0 },
+       { 10112, 45092, 15167, 13316, 44040, 7796, 0, 0 },
+       { 10178, 45124, 15140, 13398, 44120, 8058, 0, 0 },
+       { 10211, 45152, 15112, 13482, 44201, 8256, 0, 0 },
+       { 10211, 45180, 15085, 13566, 44279, 8387, 0, 0 },
+       { 10242, 45200, 15054, 13652, 44360, 8518, 0, 0 },
+       { 10242, 45216, 15023, 13738, 44440, 8636, 0, 0 },
+       { 10242, 45228, 14990, 13826, 44520, 8767, 0, 0 },
+       { 10242, 45236, 14955, 13912, 44592, 8964, 0, 0 },
+       { 10211, 45244, 14921, 14002, 44673, 9082, 0, 0 },
+       { 10178, 45244, 14885, 14090, 44745, 9213, 0, 0 },
+       { 10145, 45244, 14849, 14178, 44817, 9280, 0, 0 },
+       { 10112, 45236, 14810, 14266, 44887, 9378, 0, 0 },
+       { 10079, 45228, 14770, 14346, 44953, 9437, 0, 0 },
+       { 10014, 45216, 14731, 14390, 45017, 9503, 0, 0 },
+       { 9981, 45204, 14689, 14434, 45064, 9601, 0, 0 },
+       { 9922, 45188, 14649, 14478, 45096, 9667, 0, 0 },
+       { 9857, 45168, 14607, 14521, 45120, 9726, 0, 0 },
+       { 9791, 45144, 14564, 14564, 45144, 9791, 0, 0 },
+       { 9726, 45120, 14521, 14607, 45168, 9857, 0, 0 },
+       { 9667, 45096, 14478, 14649, 45188, 9922, 0, 0 },
+       { 9601, 45064, 14434, 14689, 45204, 9981, 0, 0 },
+       { 9503, 45017, 14390, 14731, 45216, 10014, 0, 0 },
+       { 9437, 44953, 14346, 14770, 45228, 10079, 0, 0 },
+       { 9378, 44887, 14266, 14810, 45236, 10112, 0, 0 },
+       { 9280, 44817, 14178, 14849, 45244, 10145, 0, 0 },
+       { 9213, 44745, 14090, 14885, 45244, 10178, 0, 0 },
+       { 9082, 44673, 14002, 14921, 45244, 10211, 0, 0 },
+       { 8964, 44592, 13912, 14955, 45236, 10242, 0, 0 },
+       { 8767, 44520, 13826, 14990, 45228, 10242, 0, 0 },
+       { 8636, 44440, 13738, 15023, 45216, 10242, 0, 0 },
+       { 8518, 44360, 13652, 15054, 45200, 10242, 0, 0 },
+       { 8387, 44279, 13566, 15085, 45180, 10211, 0, 0 },
+       { 8256, 44201, 13482, 15112, 45152, 10211, 0, 0 },
+       { 8058, 44120, 13398, 15140, 45124, 10178, 0, 0 },
+       { 7796, 44040, 13316, 15167, 45092, 10112, 0, 0 },
+       { 7691, 43888, 13156, 15190, 45048, 10079, 0, 0 },
+       { 7429, 43744, 13000, 15213, 44959, 10014, 0, 0 },
+       { 7297, 43583, 12844, 15235, 44872, 9922, 0, 0 },
+       { 6903, 43423, 12688, 15255, 44768, 9857, 0, 0 },
+       { 6640, 43282, 12540, 15273, 44656, 9758, 0, 0 },
+       { 6378, 43137, 12396, 15288, 44528, 9667, 0, 0 },
+       { 6169, 42979, 12216, 15304, 44401, 9535, 0, 0 },
+       { 5669, 42690, 11944, 15316, 44256, 9411, 0, 0 },
+       { 5145, 42402, 11672, 15328, 44112, 9280, 0, 0 },
+       { 4121, 42146, 11408, 15339, 43871, 9029, 0, 0 },
+       { 4121, 41797, 11058, 15346, 43537, 8702, 0, 0 },
+       { 4121, 41286, 10576, 15351, 43167, 8321, 0, 0 },
+       { 0, 40695, 9955, 15357, 42592, 7796, 0, 0 },
+       { 0, 39671, 8898, 15360, 41601, 6640, 0, 0 },
+    };
+
+    constexpr uint16_t coef_usm_fp16[kPhaseCount][kFilterSize] = {
+        { 0, 47309, 15565, 47309, 0, 0, 0, 0 },
+        { 6640, 47326, 15563, 47289, 39408, 0, 0, 0 },
+        { 7429, 47339, 15560, 47266, 40695, 4121, 0, 0 },
+        { 8058, 47349, 15554, 47239, 41286, 0, 0, 0 },
+        { 8387, 47357, 15545, 47209, 41915, 0, 0, 0 },
+        { 8636, 47363, 15534, 47176, 42238, 4121, 0, 0 },
+        { 8767, 47364, 15522, 47141, 42657, 4121, 0, 0 },
+        { 9029, 47367, 15509, 47105, 43023, 4121, 0, 0 },
+        { 9213, 47363, 15490, 47018, 43249, 4121, 0, 0 },
+        { 9280, 47357, 15472, 46928, 43472, 5145, 0, 0 },
+        { 9345, 47347, 15450, 46836, 43727, 5145, 0, 0 },
+        { 9378, 47337, 15427, 46736, 43999, 5669, 0, 0 },
+        { 9437, 47323, 15401, 46630, 44152, 5669, 0, 0 },
+        { 9470, 47310, 15376, 46520, 44312, 6169, 0, 0 },
+        { 9503, 47294, 15338, 46402, 44479, 6378, 0, 0 },
+        { 9503, 47272, 15274, 46280, 44648, 6640, 0, 0 },
+        { 9503, 47253, 15215, 46158, 44817, 6903, 0, 0 },
+        { 9503, 47231, 15150, 45972, 45017, 7165, 0, 0 },
+        { 9535, 47206, 15082, 45708, 45132, 7297, 0, 0 },
+        { 9503, 47180, 15012, 45432, 45232, 7429, 0, 0 },
+        { 9470, 47153, 14939, 45152, 45332, 7560, 0, 0 },
+        { 9470, 47126, 14868, 44681, 45444, 7691, 0, 0 },
+        { 9437, 47090, 14793, 44071, 45560, 7796, 0, 0 },
+        { 9411, 47030, 14714, 42847, 45668, 7927, 0, 0 },
+        { 9411, 46968, 14635, 8387, 45788, 8058, 0, 0 },
+        { 9345, 46902, 14552, 10786, 45908, 8256, 0, 0 },
+        { 9313, 46846, 14478, 11647, 46036, 8321, 0, 0 },
+        { 9247, 46776, 14394, 12292, 46120, 8453, 0, 0 },
+        { 9247, 46714, 14288, 12620, 46184, 8518, 0, 0 },
+        { 9147, 46648, 14130, 12936, 46248, 8570, 0, 0 },
+        { 9029, 46576, 13956, 13268, 46312, 8702, 0, 0 },
+        { 8964, 46512, 13792, 13456, 46378, 8767, 0, 0 },
+        { 8898, 46446, 13624, 13624, 46446, 8898, 0, 0 },
+        { 8767, 46378, 13456, 13792, 46512, 8964, 0, 0 },
+        { 8702, 46312, 13268, 13956, 46576, 9029, 0, 0 },
+        { 8570, 46248, 12936, 14130, 46648, 9147, 0, 0 },
+        { 8518, 46184, 12620, 14288, 46714, 9247, 0, 0 },
+        { 8453, 46120, 12292, 14394, 46776, 9247, 0, 0 },
+        { 8321, 46036, 11647, 14478, 46846, 9313, 0, 0 },
+        { 8256, 45908, 10786, 14552, 46902, 9345, 0, 0 },
+        { 8058, 45788, 8387, 14635, 46968, 9411, 0, 0 },
+        { 7927, 45668, 42847, 14714, 47030, 9411, 0, 0 },
+        { 7796, 45560, 44071, 14793, 47090, 9437, 0, 0 },
+        { 7691, 45444, 44681, 14868, 47126, 9470, 0, 0 },
+        { 7560, 45332, 45152, 14939, 47153, 9470, 0, 0 },
+        { 7429, 45232, 45432, 15012, 47180, 9503, 0, 0 },
+        { 7297, 45132, 45708, 15082, 47206, 9535, 0, 0 },
+        { 7165, 45017, 45972, 15150, 47231, 9503, 0, 0 },
+        { 6903, 44817, 46158, 15215, 47253, 9503, 0, 0 },
+        { 6640, 44648, 46280, 15274, 47272, 9503, 0, 0 },
+        { 6378, 44479, 46402, 15338, 47294, 9503, 0, 0 },
+        { 6169, 44312, 46520, 15376, 47310, 9470, 0, 0 },
+        { 5669, 44152, 46630, 15401, 47323, 9437, 0, 0 },
+        { 5669, 43999, 46736, 15427, 47337, 9378, 0, 0 },
+        { 5145, 43727, 46836, 15450, 47347, 9345, 0, 0 },
+        { 5145, 43472, 46928, 15472, 47357, 9280, 0, 0 },
+        { 4121, 43249, 47018, 15490, 47363, 9213, 0, 0 },
+        { 4121, 43023, 47105, 15509, 47367, 9029, 0, 0 },
+        { 4121, 42657, 47141, 15522, 47364, 8767, 0, 0 },
+        { 4121, 42238, 47176, 15534, 47363, 8636, 0, 0 },
+        { 0, 41915, 47209, 15545, 47357, 8387, 0, 0 },
+        { 0, 41286, 47239, 15554, 47349, 8058, 0, 0 },
+        { 4121, 40695, 47266, 15560, 47339, 7429, 0, 0 },
+        { 0, 39408, 47289, 15563, 47326, 6640, 0, 0 },
+    };
+}

--- a/src/shaders/NVIDIAImageScaling/NIS/NIS_Main.glsl
+++ b/src/shaders/NVIDIAImageScaling/NIS/NIS_Main.glsl
@@ -1,0 +1,93 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files(the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+#extension GL_GOOGLE_include_directive : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+
+#define NIS_GLSL 1
+
+#ifndef NIS_SCALER
+#define NIS_SCALER 1
+#endif
+
+layout(set=0,binding=0) uniform const_buffer
+{
+    float kDetectRatio;
+    float kDetectThres;
+    float kMinContrastRatio;
+    float kRatioNorm;
+
+    float kContrastBoost;
+    float kEps;
+    float kSharpStartY;
+    float kSharpScaleY;
+
+    float kSharpStrengthMin;
+    float kSharpStrengthScale;
+    float kSharpLimitMin;
+    float kSharpLimitScale;
+
+    float kScaleX;
+    float kScaleY;
+
+    float kDstNormX;
+    float kDstNormY;
+    float kSrcNormX;
+    float kSrcNormY;
+
+    uint kInputViewportOriginX;
+    uint kInputViewportOriginY;
+    uint kInputViewportWidth;
+    uint kInputViewportHeight;
+
+    uint kOutputViewportOriginX;
+    uint kOutputViewportOriginY;
+    uint kOutputViewportWidth;
+    uint kOutputViewportHeight;
+
+    float reserved0;
+    float reserved1;
+};
+
+layout(set=0,binding=1) uniform sampler samplerLinearClamp;
+layout(set=0,binding=2) uniform texture2D in_texture;
+layout(set=0,binding=3,rgba8_snorm) uniform image2D out_texture;
+
+#if NIS_SCALER
+layout(set=0,binding=4) uniform texture2D coef_scaler;
+layout(set=0,binding=5) uniform texture2D coef_usm;
+#endif
+
+#include "NIS_Scaler.h"
+
+layout(local_size_x=NIS_THREAD_GROUP_SIZE) in;
+void main()
+{
+    #if NIS_SCALER
+        NVScaler(gl_WorkGroupID.xy, gl_LocalInvocationID.x);
+    #else
+        NVSharpen(gl_WorkGroupID.xy, gl_LocalInvocationID.x);
+    #endif
+}

--- a/src/shaders/NVIDIAImageScaling/NIS/NIS_Main.hlsl
+++ b/src/shaders/NVIDIAImageScaling/NIS/NIS_Main.hlsl
@@ -1,0 +1,100 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files(the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#define NIS_HLSL 1
+
+#ifndef NIS_SCALER
+#define NIS_SCALER 1
+#endif
+
+#ifndef NIS_DXC
+#define NIS_DXC 0
+#endif
+
+#if NIS_DXC
+#define NIS_PUSH_CONSTANT    [[vk::push_constant]]
+#define NIS_BINDING(bindingIndex) [[vk::binding(bindingIndex, 0)]]
+#else
+#define NIS_PUSH_CONSTANT
+#define NIS_BINDING(bindingIndex)
+#endif
+
+
+NIS_BINDING(0) cbuffer cb : register(b0)
+{
+    float kDetectRatio;
+    float kDetectThres;
+    float kMinContrastRatio;
+    float kRatioNorm;
+
+    float kContrastBoost;
+    float kEps;
+    float kSharpStartY;
+    float kSharpScaleY;
+
+    float kSharpStrengthMin;
+    float kSharpStrengthScale;
+    float kSharpLimitMin;
+    float kSharpLimitScale;
+
+    float kScaleX;
+    float kScaleY;
+
+    float kDstNormX;
+    float kDstNormY;
+    float kSrcNormX;
+    float kSrcNormY;
+
+    uint kInputViewportOriginX;
+    uint kInputViewportOriginY;
+    uint kInputViewportWidth;
+    uint kInputViewportHeight;
+
+    uint kOutputViewportOriginX;
+    uint kOutputViewportOriginY;
+    uint kOutputViewportWidth;
+    uint kOutputViewportHeight;
+
+    float reserved0;
+    float reserved1;
+};
+
+NIS_BINDING(1) SamplerState samplerLinearClamp : register(s0);
+NIS_BINDING(2) Texture2D in_texture            : register(t0);
+NIS_BINDING(3) RWTexture2D<float4> out_texture : register(u0);
+#if NIS_SCALER
+NIS_BINDING(4) Texture2D coef_scaler           : register(t1);
+NIS_BINDING(5) Texture2D coef_usm              : register(t2);
+#endif
+
+
+
+#include "NIS_Scaler.h"
+
+[numthreads(NIS_THREAD_GROUP_SIZE, 1, 1)]
+void main(uint3 blockIdx : SV_GroupID, uint3 threadIdx : SV_GroupThreadID)
+{
+#if NIS_SCALER
+    NVScaler(blockIdx.xy, threadIdx.x);
+#else
+    NVSharpen(blockIdx.xy, threadIdx.x);
+#endif
+}

--- a/src/shaders/NVIDIAImageScaling/NIS/NIS_Scaler.h
+++ b/src/shaders/NVIDIAImageScaling/NIS/NIS_Scaler.h
@@ -1,0 +1,965 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files(the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+//---------------------------------------------------------------------------------
+// NVIDIA Image Scaling SDK  - v1.0.2
+//---------------------------------------------------------------------------------
+// The NVIDIA Image Scaling SDK provides a single spatial scaling and sharpening algorithm
+// for cross-platform support. The scaling algorithm uses a 6-tap scaling filter combined
+// with 4 directional scaling and adaptive sharpening filters, which creates nice smooth images
+// and sharp edges. In addition, the SDK provides a state-of-the-art adaptive directional sharpening algorithm
+// for use in applications where no scaling is required.
+//
+// The directional scaling and sharpening algorithm is named NVScaler while the adaptive-directional-sharpening-only
+// algorithm is named NVSharpen. Both algorithms are provided as compute shaders and
+// developers are free to integrate them in their applications. Note that if you integrate NVScaler, you
+// should NOT integrate NVSharpen, as NVScaler already includes a sharpening pass
+//
+// Pipeline Placement
+// ------------------
+// The call into the NVIDIA Image Scaling shaders must occur during the post-processing phase after tone-mapping.
+// Applying the scaling in linear HDR in-game color-space may result in a sharpening effect that is
+// either not visible or too strong. Since sharpening algorithms can enhance noisy or grainy regions, it is recommended
+// that certain effects such as film grain should occur after NVScaler or NVSharpen. Low-pass filters such as motion blur or
+// light bloom are recommended to be applied before NVScaler or NVSharpen to avoid sharpening attenuation.
+//
+// Color Space and Ranges
+// ----------------------
+// NVIDIA Image Scaling shaders can process color textures stored as either LDR or HDR with the following
+// restrictions:
+// 1) LDR
+//    - The range of color values must be in the [0, 1] range
+//    - The input color texture must be in display-referred color-space after tone mapping and OETF (gamma-correction)
+//      has been applied
+// 2) HDR PQ
+//    - The range of color values must be in the [0, 1] range
+//    - The input color texture must be in display-referred color-space after tone mapping with Rec.2020 PQ OETF applied
+// 3) HDR Linear
+//    - The recommended range of color values is [0, 12.5], where luminance value (as per BT. 709) of
+//      1.0 maps to brightness value of 80nits (sRGB peak) and 12.5 maps to 1000nits
+//    - The input color texture may have luminance values that are either linear and scene-referred or
+//      linear and display-referred (after tone mapping)
+//
+// If the input color texture sent to NVScaler/NVSharpen is in HDR format set NIS_HDR_MODE define to either
+// NIS_HDR_MODE_LINEAR (1) or NIS_HDR_MODE_PQ (2).
+//
+// Supported Texture Formats
+// -------------------------
+// Input and output formats:
+// Input and output formats are expected to be in the rages defined in previous section and should be
+// specified using non-integer data types such as DXGI_FORMAT_R8G8B8A8_UNORM.
+//
+// Coefficients formats:
+// The scaler coefficients and USM coefficients format should be specified using float4 type such as
+// DXGI_FORMAT_R32G32B32A32_FLOAT or DXGI_FORMAT_R16G16B16A16_FLOAT.
+//
+// Resource States, Buffers, and Sampler:
+// The game or application calling NVIDIA Image Scaling SDK shaders must ensure that the textures are in
+// the correct state.
+// - Input color textures must be in pixel shader read state. Shader Resource View (SRV) in DirectX
+// - The output texture must be in read/write state. Unordered Access View (UAV) in DirectX
+// - The coefficients texture for NVScaler must be in read state. Shader Resource View (SRV) in DirectX
+// - The configuration variables must be passed as constant buffer. Constant Buffer View (CBV) in DirectX
+// - The sampler for texture pixel sampling. Linear clamp SamplerState in Direct
+//
+// Adding NVIDIA Image Scaling SDK to a Project
+// --------------------------------------------
+// Include NIS_Scaler.h directly in your application or alternative use the provided NIS_Main.hlsl shader file.
+// Use NIS_Config.h to get the ideal shader dispatch values for your platform, to configure the algorithm constant
+// values (NVScalerUpdateConfig, and NVSharpenUpdateConfig), and to access the algorithm coefficients (coef_scale and coef_USM).
+//
+// Defines:
+// NIS_SCALER: default (1) NVScaler, (0) fast NVSharpen only, no upscaling
+// NIS_HDR_MODE: default (0) disabled, (1) Linear, (2) PQ
+// NIS_BLOCK_WIDTH: pixels per block width. Use GetOptimalBlockWidth query for your platform
+// NIS_BLOCK_HEIGHT: pixels per block height. Use GetOptimalBlockHeight query for your platform
+// NIS_THREAD_GROUP_SIZE: number of threads per group. Use GetOptimalThreadGroupSize query for your platform
+// NIS_USE_HALF_PRECISION: default (0) disabled, (1) enable half pression computation
+// NIS_HLSL: (1) enabled, (0) disabled
+// NIS_HLSL_6_2: default (0) HLSL v5, (1) HLSL v6.2 forces NIS_HLSL=1
+// NIS_GLSL: (1) enabled, (0) disabled
+// NIS_VIEWPORT_SUPPORT: default(0) disabled, (1) enable input/output viewport support
+//
+// Default NVScaler shader constants:
+// [NIS_BLOCK_WIDTH, NIS_BLOCK_HEIGHT, NIS_THREAD_GROUP_SIZE] = [32, 24, 256]
+//
+// Default NVSharpen shader constants:
+// [NIS_BLOCK_WIDTH, NIS_BLOCK_HEIGHT, NIS_THREAD_GROUP_SIZE] = [32, 32, 256]
+//---------------------------------------------------------------------------------
+
+// NVScaler enable by default. Set to 0 for NVSharpen only
+#ifndef NIS_SCALER
+#define NIS_SCALER 1
+#endif
+
+// HDR Modes
+#define NIS_HDR_MODE_NONE  0
+#define NIS_HDR_MODE_LINEAR  1
+#define NIS_HDR_MODE_PQ  2
+#ifndef NIS_HDR_MODE
+#define NIS_HDR_MODE NIS_HDR_MODE_NONE
+#endif
+#define kHDRCompressionFactor  0.282842712f
+
+// Viewport support
+#ifndef NIS_VIEWPORT_SUPPORT
+#define NIS_VIEWPORT_SUPPORT 0
+#endif
+
+// HLSL, GLSL
+#if NIS_HLSL==0 && !defined(NIS_GLSL)
+#define NIS_GLSL 1
+#endif
+#if NIS_HLSL_6_2 || (!NIS_GLSL && !NIS_HLSL)
+#if defined(NIS_HLSL)
+#undef NIS_HLSL
+#endif
+#define NIS_HLSL 1
+#endif
+#if NIS_HLSL && NIS_GLSL
+#undef NIS_GLSL
+#define NIS_GLSL 0
+#endif
+
+// Half precision
+#ifndef NIS_USE_HALF_PRECISION
+#define NIS_USE_HALF_PRECISION 0
+#endif
+
+#if NIS_HLSL
+// Generic type and function aliases for HLSL
+#define NVF float
+#define NVF2 float2
+#define NVF3 float3
+#define NVF4 float4
+#define NVI int
+#define NVI2 int2
+#define NVU uint
+#define NVU2 uint2
+#define NVB bool
+#if NIS_USE_HALF_PRECISION
+#if NIS_HLSL_6_2
+#define NVH float16_t
+#define NVH2 float16_t2
+#define NVH3 float16_t3
+#define NVH4 float16_t4
+#else
+#define NVH min16float
+#define NVH2 min16float2
+#define NVH3 min16float3
+#define NVH4 min16float4
+#endif // NIS_HLSL_6_2
+#else // FP32 types
+#define NVH NVF
+#define NVH2 NVF2
+#define NVH3 NVF3
+#define NVH4 NVF4
+#endif // NIS_USE_HALF_PRECISION
+#define NVSHARED groupshared
+#define NVTEX_LOAD(x, pos) x[pos]
+#define NVTEX_SAMPLE(x, sampler, pos) x.SampleLevel(sampler, pos, 0)
+#define NVTEX_SAMPLE_RED(x, sampler, pos) x.GatherRed(sampler, pos)
+#define NVTEX_SAMPLE_GREEN(x, sampler, pos) x.GatherGreen(sampler, pos)
+#define NVTEX_SAMPLE_BLUE(x, sampler, pos) x.GatherBlue(sampler, pos)
+#define NVTEX_STORE(x, pos, v) x[pos] = v
+#ifndef NIS_UNROLL
+#define NIS_UNROLL [unroll]
+#endif
+#endif // NIS_HLSL
+
+// Generic type and function aliases for GLSL
+#if NIS_GLSL
+#define NVF float
+#define NVF2 vec2
+#define NVF3 vec3
+#define NVF4 vec4
+#define NVI int
+#define NVI2 ivec2
+#define NVU uint
+#define NVU2 uvec2
+#define NVB bool
+#if NIS_USE_HALF_PRECISION
+#define NVH float16_t
+#define NVH2 f16vec2
+#define NVH3 f16vec3
+#define NVH4 f16vec4
+#else // FP32 types
+#define NVH NVF
+#define NVH2 NVF2
+#define NVH3 NVF3
+#define NVH4 NVF4
+#endif  // NIS_USE_HALF_PRECISION
+#define NVSHARED shared
+#define NVTEX_LOAD(x, pos) texelFetch(sampler2D(x, samplerLinearClamp), pos, 0)
+#define NVTEX_SAMPLE(x, sampler, pos) textureLod(sampler2D(x, sampler), pos, 0)
+#define NVTEX_SAMPLE_RED(x, sampler, pos) textureGather(sampler2D(x, sampler), pos, 0)
+#define NVTEX_SAMPLE_GREEN(x, sampler, pos) textureGather(sampler2D(x, sampler), pos, 1)
+#define NVTEX_SAMPLE_BLUE(x, sampler, pos) textureGather(sampler2D(x, sampler), pos, 2)
+#define NVTEX_STORE(x, pos, v) imageStore(x, NVI2(pos), v)
+#define saturate(x) clamp(x, 0, 1)
+#define lerp(a, b, x) mix(a, b, x)
+#define GroupMemoryBarrierWithGroupSync() groupMemoryBarrier(); barrier()
+#ifndef NIS_UNROLL
+#define NIS_UNROLL
+#endif
+#endif // NIS_GLSL
+
+// Texture gather
+#ifndef NIS_TEXTURE_GATHER
+#define NIS_TEXTURE_GATHER 0
+#endif
+
+// NIS Scaling
+#define NIS_SCALE_INT 1
+#define NIS_SCALE_FLOAT NVF(1.f)
+
+NVF getY(NVF3 rgba)
+{
+#if NIS_HDR_MODE == NIS_HDR_MODE_PQ
+    return NVF(0.262f) * rgba.x + NVF(0.678f) * rgba.y + NVF(0.0593f) * rgba.z;
+#elif NIS_HDR_MODE == NIS_HDR_MODE_LINEAR
+    return sqrt(NVF(0.2126f) * rgba.x + NVF(0.7152f) * rgba.y + NVF(0.0722f) * rgba.z) * kHDRCompressionFactor;
+#else
+    return NVF(0.2126f) * rgba.x + NVF(0.7152f) * rgba.y + NVF(0.0722f) * rgba.z;
+#endif
+}
+
+NVF getYLinear(NVF3 rgba)
+{
+    return NVF(0.2126f) * rgba.x + NVF(0.7152f) * rgba.y + NVF(0.0722f) * rgba.z;
+}
+
+#if NIS_SCALER
+NVF4 GetEdgeMap(NVF p[4][4], NVI i, NVI j)
+#else
+NVF4 GetEdgeMap(NVF p[5][5], NVI i, NVI j)
+#endif
+{
+    const NVF g_0 = abs(p[0 + i][0 + j] + p[0 + i][1 + j] + p[0 + i][2 + j] - p[2 + i][0 + j] - p[2 + i][1 + j] - p[2 + i][2 + j]);
+    const NVF g_45 = abs(p[1 + i][0 + j] + p[0 + i][0 + j] + p[0 + i][1 + j] - p[2 + i][1 + j] - p[2 + i][2 + j] - p[1 + i][2 + j]);
+    const NVF g_90 = abs(p[0 + i][0 + j] + p[1 + i][0 + j] + p[2 + i][0 + j] - p[0 + i][2 + j] - p[1 + i][2 + j] - p[2 + i][2 + j]);
+    const NVF g_135 = abs(p[1 + i][0 + j] + p[2 + i][0 + j] + p[2 + i][1 + j] - p[0 + i][1 + j] - p[0 + i][2 + j] - p[1 + i][2 + j]);
+
+    const NVF g_0_90_max = max(g_0, g_90);
+    const NVF g_0_90_min = min(g_0, g_90);
+    const NVF g_45_135_max = max(g_45, g_135);
+    const NVF g_45_135_min = min(g_45, g_135);
+
+    NVF e_0_90 = 0;
+    NVF e_45_135 = 0;
+
+    if (g_0_90_max + g_45_135_max == 0)
+    {
+        return NVF4(0, 0, 0, 0);
+    }
+
+    e_0_90 = min(g_0_90_max / (g_0_90_max + g_45_135_max), 1.0f);
+    e_45_135 = 1.0f - e_0_90;
+
+    NVB c_0_90 = (g_0_90_max > (g_0_90_min * kDetectRatio)) && (g_0_90_max > kDetectThres) && (g_0_90_max > g_45_135_min);
+    NVB c_45_135 = (g_45_135_max > (g_45_135_min * kDetectRatio)) && (g_45_135_max > kDetectThres) && (g_45_135_max > g_0_90_min);
+    NVB c_g_0_90 = g_0_90_max == g_0;
+    NVB c_g_45_135 = g_45_135_max == g_45;
+
+    NVF f_e_0_90 = (c_0_90 && c_45_135) ? e_0_90 : 1.0f;
+    NVF f_e_45_135 = (c_0_90 && c_45_135) ? e_45_135 : 1.0f;
+
+    NVF weight_0 = (c_0_90 && c_g_0_90) ? f_e_0_90 : 0.0f;
+    NVF weight_90 = (c_0_90 && !c_g_0_90) ? f_e_0_90 : 0.0f;
+    NVF weight_45 = (c_45_135 && c_g_45_135) ? f_e_45_135 : 0.0f;
+    NVF weight_135 = (c_45_135 && !c_g_45_135) ? f_e_45_135 : 0.0f;
+
+    return NVF4(weight_0, weight_90, weight_45, weight_135);
+}
+
+#if NIS_SCALER
+
+#ifndef NIS_BLOCK_WIDTH
+#define NIS_BLOCK_WIDTH 32
+#endif
+#ifndef NIS_BLOCK_HEIGHT
+#define NIS_BLOCK_HEIGHT 24
+#endif
+#ifndef NIS_THREAD_GROUP_SIZE
+#define NIS_THREAD_GROUP_SIZE 256
+#endif
+#define kPhaseCount  64
+#define kFilterSize  6
+#define kSupportSize 6
+#define kPadSize     kSupportSize
+// 'Tile' is the region of source luminance values that we load into shPixelsY.
+// It is the area of source pixels covered by the destination 'Block' plus a
+// 3 pixel border of support pixels.
+#define kTilePitch              (NIS_BLOCK_WIDTH + kPadSize)
+#define kTileSize               (kTilePitch * (NIS_BLOCK_HEIGHT + kPadSize))
+// 'EdgeMap' is the region of source pixels for which edge map vectors are derived.
+// It is the area of source pixels covered by the destination 'Block' plus a
+// 1 pixel border.
+#define kEdgeMapPitch           (NIS_BLOCK_WIDTH + 2)
+#define kEdgeMapSize            (kEdgeMapPitch * (NIS_BLOCK_HEIGHT + 2))
+
+NVSHARED NVF shPixelsY[kTileSize];
+NVSHARED NVH shCoefScaler[kPhaseCount][kFilterSize];
+NVSHARED NVH shCoefUSM[kPhaseCount][kFilterSize];
+NVSHARED NVH4 shEdgeMap[kEdgeMapSize];
+
+void LoadFilterBanksSh(NVI i0, NVI di) {
+    // Load up filter banks to shared memory
+    // The work is spread over (kPhaseCount * 2) threads
+    for (NVI i = i0; i < kPhaseCount * 2; i += di)
+    {
+        NVI phase = i >> 1;
+        NVI vIdx = i & 1;
+
+        NVH4 v = NVH4(NVTEX_LOAD(coef_scaler, NVI2(vIdx, phase)));
+        NVI filterOffset = vIdx * 4;
+        shCoefScaler[phase][filterOffset + 0] = v.x;
+        shCoefScaler[phase][filterOffset + 1] = v.y;
+        if (vIdx == 0)
+        {
+            shCoefScaler[phase][2] = v.z;
+            shCoefScaler[phase][3] = v.w;
+        }
+
+        v = NVH4(NVTEX_LOAD(coef_usm, NVI2(vIdx, phase)));
+        shCoefUSM[phase][filterOffset + 0] = v.x;
+        shCoefUSM[phase][filterOffset + 1] = v.y;
+        if (vIdx == 0)
+        {
+            shCoefUSM[phase][2] = v.z;
+            shCoefUSM[phase][3] = v.w;
+        }
+    }
+}
+
+
+NVF CalcLTI(NVF p0, NVF p1, NVF p2, NVF p3, NVF p4, NVF p5, NVI phase_index)
+{
+    const NVB selector = (phase_index <= kPhaseCount / 2);
+    NVF sel = selector ? p0 : p3;
+    const NVF a_min = min(min(p1, p2), sel);
+    const NVF a_max = max(max(p1, p2), sel);
+    sel = selector ? p2 : p5;
+    const NVF b_min = min(min(p3, p4), sel);
+    const NVF b_max = max(max(p3, p4), sel);
+
+    const NVF a_cont = a_max - a_min;
+    const NVF b_cont = b_max - b_min;
+
+    const NVF cont_ratio = max(a_cont, b_cont) / (min(a_cont, b_cont) + kEps);
+    return (1.0f - saturate((cont_ratio - kMinContrastRatio) * kRatioNorm)) * kContrastBoost;
+}
+
+NVF4 GetInterpEdgeMap(const NVF4 edge[2][2], NVF phase_frac_x, NVF phase_frac_y)
+{
+    NVF4 h0 = lerp(edge[0][0], edge[0][1], phase_frac_x);
+    NVF4 h1 = lerp(edge[1][0], edge[1][1], phase_frac_x);
+    return lerp(h0, h1, phase_frac_y);
+}
+
+NVF EvalPoly6(const NVF pxl[6], NVI phase_int)
+{
+    NVF y = 0.f;
+    {
+        NIS_UNROLL
+        for (NVI i = 0; i < 6; ++i)
+        {
+            y += shCoefScaler[phase_int][i] * pxl[i];
+        }
+    }
+    NVF y_usm = 0.f;
+    {
+        NIS_UNROLL
+        for (NVI i = 0; i < 6; ++i)
+        {
+            y_usm += shCoefUSM[phase_int][i] * pxl[i];
+        }
+    }
+
+    // let's compute a piece-wise ramp based on luma
+    const NVF y_scale = 1.0f - saturate((y * (1.0f / NIS_SCALE_FLOAT) - kSharpStartY) * kSharpScaleY);
+
+    // scale the ramp to sharpen as a function of luma
+    const NVF y_sharpness = y_scale * kSharpStrengthScale + kSharpStrengthMin;
+
+    y_usm *= y_sharpness;
+
+    // scale the ramp to limit USM as a function of luma
+    const NVF y_sharpness_limit = (y_scale * kSharpLimitScale + kSharpLimitMin) * y;
+
+    y_usm = min(y_sharpness_limit, max(-y_sharpness_limit, y_usm));
+    // reduce ringing
+    y_usm *= CalcLTI(pxl[0], pxl[1], pxl[2], pxl[3], pxl[4], pxl[5], phase_int);
+
+    return y + y_usm;
+}
+
+NVF FilterNormal(const NVF p[6][6], NVI phase_x_frac_int, NVI phase_y_frac_int)
+{
+    NVF h_acc = 0.0f;
+    NIS_UNROLL
+    for (NVI j = 0; j < 6; ++j)
+    {
+        NVF v_acc = 0.0f;
+        NIS_UNROLL
+        for (NVI i = 0; i < 6; ++i)
+        {
+            v_acc += p[i][j] * shCoefScaler[phase_y_frac_int][i];
+        }
+        h_acc += v_acc * shCoefScaler[phase_x_frac_int][j];
+    }
+
+    // let's return the sum unpacked -> we can accumulate it later
+    return h_acc;
+}
+
+NVF AddDirFilters(NVF p[6][6], NVF phase_x_frac, NVF phase_y_frac, NVI phase_x_frac_int, NVI phase_y_frac_int, NVF4 w)
+{
+    NVF f = 0;
+    if (w.x > 0.0f)
+    {
+        // 0 deg filter
+        NVF interp0Deg[6];
+        {
+            NIS_UNROLL
+                for (NVI i = 0; i < 6; ++i)
+                {
+                    interp0Deg[i] = lerp(p[i][2], p[i][3], phase_x_frac);
+                }
+        }
+        f += EvalPoly6(interp0Deg, phase_y_frac_int) * w.x;
+    }
+    if (w.y > 0.0f)
+    {
+        // 90 deg filter
+        NVF interp90Deg[6];
+        {
+            NIS_UNROLL
+                for (NVI i = 0; i < 6; ++i)
+                {
+                    interp90Deg[i] = lerp(p[2][i], p[3][i], phase_y_frac);
+                }
+        }
+
+        f += EvalPoly6(interp90Deg, phase_x_frac_int) * w.y;
+    }
+    if (w.z > 0.0f)
+    {
+        //45 deg filter
+        NVF pphase_b45 = 0.5f + 0.5f * (phase_x_frac - phase_y_frac);
+
+        NVF temp_interp45Deg[7];
+        temp_interp45Deg[1] = lerp(p[2][1], p[1][2], pphase_b45);
+        temp_interp45Deg[3] = lerp(p[3][2], p[2][3], pphase_b45);
+        temp_interp45Deg[5] = lerp(p[4][3], p[3][4], pphase_b45);
+        {
+            pphase_b45 = pphase_b45 - 0.5f;
+            NVF a = (pphase_b45 >= 0.f) ? p[0][2] : p[2][0];
+            NVF b = (pphase_b45 >= 0.f) ? p[1][3] : p[3][1];
+            NVF c = (pphase_b45 >= 0.f) ? p[2][4] : p[4][2];
+            NVF d = (pphase_b45 >= 0.f) ? p[3][5] : p[5][3];
+            temp_interp45Deg[0] = lerp(p[1][1], a, abs(pphase_b45));
+            temp_interp45Deg[2] = lerp(p[2][2], b, abs(pphase_b45));
+            temp_interp45Deg[4] = lerp(p[3][3], c, abs(pphase_b45));
+            temp_interp45Deg[6] = lerp(p[4][4], d, abs(pphase_b45));
+        }
+
+        NVF interp45Deg[6];
+        NVF pphase_p45 = phase_x_frac + phase_y_frac;
+        if (pphase_p45 >= 1)
+        {
+            NIS_UNROLL
+                for (NVI i = 0; i < 6; i++)
+                {
+                    interp45Deg[i] = temp_interp45Deg[i + 1];
+                }
+            pphase_p45 = pphase_p45 - 1;
+        }
+        else
+        {
+            NIS_UNROLL
+                for (NVI i = 0; i < 6; i++)
+                {
+                    interp45Deg[i] = temp_interp45Deg[i];
+                }
+        }
+
+        f += EvalPoly6(interp45Deg, NVI(pphase_p45 * 64)) * w.z;
+    }
+    if (w.w > 0.0f)
+    {
+        //135 deg filter
+        NVF pphase_b135 = 0.5f * (phase_x_frac + phase_y_frac);
+
+        NVF temp_interp135Deg[7];
+        temp_interp135Deg[1] = lerp(p[3][1], p[4][2], pphase_b135);
+        temp_interp135Deg[3] = lerp(p[2][2], p[3][3], pphase_b135);
+        temp_interp135Deg[5] = lerp(p[1][3], p[2][4], pphase_b135);
+        {
+            pphase_b135 = pphase_b135 - 0.5f;
+            NVF a = (pphase_b135 >= 0.f) ? p[5][2] : p[3][0];
+            NVF b = (pphase_b135 >= 0.f) ? p[4][3] : p[2][1];
+            NVF c = (pphase_b135 >= 0.f) ? p[3][4] : p[1][2];
+            NVF d = (pphase_b135 >= 0.f) ? p[2][5] : p[0][3];
+            temp_interp135Deg[0] = lerp(p[4][1], a, abs(pphase_b135));
+            temp_interp135Deg[2] = lerp(p[3][2], b, abs(pphase_b135));
+            temp_interp135Deg[4] = lerp(p[2][3], c, abs(pphase_b135));
+            temp_interp135Deg[6] = lerp(p[1][4], d, abs(pphase_b135));
+        }
+
+        NVF interp135Deg[6];
+        NVF pphase_p135 = 1 + (phase_x_frac - phase_y_frac);
+        if (pphase_p135 >= 1)
+        {
+            NIS_UNROLL
+                for (NVI i = 0; i < 6; ++i)
+                {
+                    interp135Deg[i] = temp_interp135Deg[i + 1];
+                }
+            pphase_p135 = pphase_p135 - 1;
+        }
+        else
+        {
+            NIS_UNROLL
+                for (NVI i = 0; i < 6; ++i)
+                {
+                    interp135Deg[i] = temp_interp135Deg[i];
+                }
+        }
+
+        f += EvalPoly6(interp135Deg, NVI(pphase_p135 * 64)) * w.w;
+    }
+    return f;
+}
+
+
+//-----------------------------------------------------------------------------------------------
+// NVScaler
+//-----------------------------------------------------------------------------------------------
+void NVScaler(NVU2 blockIdx, NVU threadIdx)
+{
+    // Figure out the range of pixels from input image that would be needed to be loaded for this thread-block
+    NVI dstBlockX = NVI(NIS_BLOCK_WIDTH * blockIdx.x);
+    NVI dstBlockY = NVI(NIS_BLOCK_HEIGHT * blockIdx.y);
+
+    const NVI srcBlockStartX = NVI(floor((dstBlockX + 0.5f) * kScaleX - 0.5f));
+    const NVI srcBlockStartY = NVI(floor((dstBlockY + 0.5f) * kScaleY - 0.5f));
+    const NVI srcBlockEndX = NVI(ceil((dstBlockX + NIS_BLOCK_WIDTH + 0.5f) * kScaleX - 0.5f));
+    const NVI srcBlockEndY = NVI(ceil((dstBlockY + NIS_BLOCK_HEIGHT + 0.5f) * kScaleY - 0.5f));
+
+    NVI numTilePixelsX = srcBlockEndX - srcBlockStartX + kSupportSize - 1;
+    NVI numTilePixelsY = srcBlockEndY - srcBlockStartY + kSupportSize - 1;
+
+    // round-up load region to even size since we're loading in 2x2 batches
+    numTilePixelsX += numTilePixelsX & 0x1;
+    numTilePixelsY += numTilePixelsY & 0x1;
+    const NVI numTilePixels = numTilePixelsX * numTilePixelsY;
+
+    // calculate the equivalent values for the edge map
+    const NVI numEdgeMapPixelsX = numTilePixelsX - kSupportSize + 2;
+    const NVI numEdgeMapPixelsY = numTilePixelsY - kSupportSize + 2;
+    const NVI numEdgeMapPixels = numEdgeMapPixelsX * numEdgeMapPixelsY;
+
+    // fill in input luma tile (shPixelsY) in batches of 2x2 pixels
+    // we use texture gather to get extra support necessary
+    // to compute 2x2 edge map outputs too
+    {
+        for (NVU i = threadIdx * 2; i < NVU(numTilePixels) >> 1; i += NIS_THREAD_GROUP_SIZE * 2)
+        {
+            NVU py = (i / numTilePixelsX) * 2;
+            NVU px = i % numTilePixelsX;
+
+            // 0.5 to be in the center of texel
+            // - (kSupportSize - 1) / 2 to shift by the kernel support size
+            NVF kShift = 0.5f - (kSupportSize - 1) / 2;
+#if NIS_VIEWPORT_SUPPORT
+            const NVF tx = (srcBlockStartX + px + kInputViewportOriginX + kShift) * kSrcNormX;
+            const NVF ty = (srcBlockStartY + py + kInputViewportOriginY + kShift) * kSrcNormY;
+#else
+            const NVF tx = (srcBlockStartX + px + kShift) * kSrcNormX;
+            const NVF ty = (srcBlockStartY + py + kShift) * kSrcNormY;
+#endif
+            NVF p[2][2];
+#if NIS_TEXTURE_GATHER
+            {
+                const NVF4 sr = NVTEX_SAMPLE_RED(in_texture, samplerLinearClamp, NVF2(tx, ty));
+                const NVF4 sg = NVTEX_SAMPLE_GREEN(in_texture, samplerLinearClamp, NVF2(tx, ty));
+                const NVF4 sb = NVTEX_SAMPLE_BLUE(in_texture, samplerLinearClamp, NVF2(tx, ty));
+
+                p[0][0] = getY(NVF3(sr.w, sg.w, sb.w));
+                p[0][1] = getY(NVF3(sr.z, sg.z, sb.z));
+                p[1][0] = getY(NVF3(sr.x, sg.x, sb.x));
+                p[1][1] = getY(NVF3(sr.y, sg.y, sb.y));
+            }
+#else
+            NIS_UNROLL
+            for (NVI j = 0; j < 2; j++)
+            {
+                NIS_UNROLL
+                for (NVI k = 0; k < 2; k++)
+                {
+                    const NVF4 px = NVTEX_SAMPLE(in_texture, samplerLinearClamp, NVF2(tx + k * kSrcNormX, ty + j * kSrcNormY));
+                    p[j][k] = getY(px.xyz);
+                }
+            }
+#endif
+            const NVU idx = py * kTilePitch + px;
+            shPixelsY[idx] = NVH(p[0][0]);
+            shPixelsY[idx + 1] = NVH(p[0][1]);
+            shPixelsY[idx + kTilePitch] = NVH(p[1][0]);
+            shPixelsY[idx + kTilePitch + 1] = NVH(p[1][1]);
+        }
+    }
+    GroupMemoryBarrierWithGroupSync();
+    {
+        // fill in the edge map of 2x2 pixels
+        for (NVU i = threadIdx * 2; i < NVU(numEdgeMapPixels) >> 1; i += NIS_THREAD_GROUP_SIZE * 2)
+        {
+            NVU py = (i / numEdgeMapPixelsX) * 2;
+            NVU px = i % numEdgeMapPixelsX;
+
+            const NVU edgeMapIdx = py * kEdgeMapPitch + px;
+
+            NVU tileCornerIdx = (py+1) * kTilePitch + px + 1;
+            NVF p[4][4];
+            NIS_UNROLL
+            for (NVI j = 0; j < 4; j++)
+            {
+                NIS_UNROLL
+                for (NVI k = 0; k < 4; k++)
+                {
+                    p[j][k] = shPixelsY[tileCornerIdx + j * kTilePitch + k];
+                }
+            }
+
+            shEdgeMap[edgeMapIdx] = NVH4(GetEdgeMap(p, 0, 0));
+            shEdgeMap[edgeMapIdx + 1] = NVH4(GetEdgeMap(p, 0, 1));
+            shEdgeMap[edgeMapIdx + kEdgeMapPitch] = NVH4(GetEdgeMap(p, 1, 0));
+            shEdgeMap[edgeMapIdx + kEdgeMapPitch + 1] = NVH4(GetEdgeMap(p, 1, 1));
+        }
+    }
+    LoadFilterBanksSh(NVI(threadIdx), NIS_THREAD_GROUP_SIZE);
+    GroupMemoryBarrierWithGroupSync();
+
+    // output coord within a tile
+    const NVI2 pos = NVI2(NVU(threadIdx) % NVU(NIS_BLOCK_WIDTH), NVU(threadIdx) / NVU(NIS_BLOCK_WIDTH));
+    // x coord inside the output image
+    const NVI dstX = dstBlockX + pos.x;
+    // x coord inside the input image
+    const NVF srcX = (0.5f + dstX) * kScaleX - 0.5f;
+    // nearest integer part
+    const NVI px = NVI(floor(srcX) - srcBlockStartX);
+    // fractional part
+    const NVF fx = srcX - floor(srcX);
+    // discretized phase
+    const NVI fx_int = NVI(fx * kPhaseCount);
+
+    for (NVI k = 0; k < NIS_BLOCK_WIDTH * NIS_BLOCK_HEIGHT / NIS_THREAD_GROUP_SIZE; ++k)
+    {
+        // y coord inside the output image
+        const NVI dstY = dstBlockY + pos.y + k * (NIS_THREAD_GROUP_SIZE / NIS_BLOCK_WIDTH);
+        // y coord inside the input image
+        const NVF srcY = (0.5f + dstY) * kScaleY - 0.5f;
+#if NIS_VIEWPORT_SUPPORT
+        if (srcX > kInputViewportWidth || srcY > kInputViewportHeight ||
+            dstX > kOutputViewportWidth || dstY > kOutputViewportHeight)
+        {
+            return;
+        }
+#endif
+        // nearest integer part
+        const NVI py = NVI(floor(srcY) - srcBlockStartY);
+        // fractional part
+        const NVF fy = srcY - floor(srcY);
+        // discretized phase
+        const NVI fy_int = NVI(fy * kPhaseCount);
+
+        // generate weights for directional filters
+        const NVI startEdgeMapIdx = py * kEdgeMapPitch + px;
+        NVF4 edge[2][2];
+        NIS_UNROLL
+        for (NVI i = 0; i < 2; i++)
+        {
+            NIS_UNROLL
+            for (NVI j = 0; j < 2; j++)
+            {
+                // need to shift edge map sampling since it's a 2x2 centered inside 6x6 grid
+                edge[i][j] = shEdgeMap[startEdgeMapIdx + (i * kEdgeMapPitch) + j];
+            }
+        }
+        const NVF4 w = GetInterpEdgeMap(edge, fx, fy) * NIS_SCALE_INT;
+
+        // load 6x6 support to regs
+        const NVI startTileIdx = py * kTilePitch + px;
+        NVF p[6][6];
+        {
+            NIS_UNROLL
+            for (NVI i = 0; i < 6; ++i)
+            {
+                NIS_UNROLL
+                for (NVI j = 0; j < 6; ++j)
+                {
+                    p[i][j] = shPixelsY[startTileIdx + i * kTilePitch + j];
+                }
+            }
+        }
+
+        // weigth for luma
+        const NVF baseWeight = NIS_SCALE_FLOAT - w.x - w.y - w.z - w.w;
+
+        // final luma is a weighted product of directional & normal filters
+        NVF opY = 0;
+
+        // get traditional scaler filter output
+        opY += FilterNormal(p, fx_int, fy_int) * baseWeight;
+
+        // get directional filter bank output
+        opY += AddDirFilters(p, fx, fy, fx_int, fy_int, w);
+
+        // do bilinear tap for chroma upscaling
+#if NIS_VIEWPORT_SUPPORT
+        NVF4 op = NVTEX_SAMPLE(in_texture, samplerLinearClamp, NVF2((srcX + kInputViewportOriginX + 0.5f) * kSrcNormX, (srcY + kInputViewportOriginY + 0.5f) * kSrcNormY));
+#else
+        NVF4 op = NVTEX_SAMPLE(in_texture, samplerLinearClamp, NVF2((srcX + 0.5f) * kSrcNormX, (srcY + 0.5f) * kSrcNormY));
+#endif
+#if NIS_HDR_MODE == NIS_HDR_MODE_LINEAR
+        const NVF kEps = 1e-4f;
+        const NVF kNorm = 1.0f / (NIS_SCALE_FLOAT * kHDRCompressionFactor);
+        const NVF opYN = max(opY, 0.0f) * kNorm;
+        const NVF corr = (opYN * opYN + kEps) / (max(getYLinear(NVF3(op.x, op.y, op.z)), 0.0f) + kEps);
+        op.x *= corr;
+        op.y *= corr;
+        op.z *= corr;
+#else
+        const NVF corr = opY * (1.0f / NIS_SCALE_FLOAT) - getY(NVF3(op.x, op.y, op.z));
+        op.x += corr;
+        op.y += corr;
+        op.z += corr;
+#endif
+
+#if NIS_VIEWPORT_SUPPORT
+        NVTEX_STORE(out_texture, NVU2(dstX + kOutputViewportOriginX, dstY + kOutputViewportOriginY), op);
+#else
+        NVTEX_STORE(out_texture, NVU2(dstX, dstY), op);
+#endif
+    }
+}
+#else
+
+#ifndef NIS_BLOCK_WIDTH
+#define NIS_BLOCK_WIDTH 32
+#endif
+#ifndef NIS_BLOCK_HEIGHT
+#define NIS_BLOCK_HEIGHT 32
+#endif
+#ifndef NIS_THREAD_GROUP_SIZE
+#define NIS_THREAD_GROUP_SIZE 256
+#endif
+
+#define kSupportSize 5
+#define kNumPixelsX  (NIS_BLOCK_WIDTH + kSupportSize + 1)
+#define kNumPixelsY  (NIS_BLOCK_HEIGHT + kSupportSize + 1)
+
+NVSHARED NVF shPixelsY[kNumPixelsY][kNumPixelsX];
+
+NVF CalcLTIFast(const NVF y[5])
+{
+    const NVF a_min = min(min(y[0], y[1]), y[2]);
+    const NVF a_max = max(max(y[0], y[1]), y[2]);
+
+    const NVF b_min = min(min(y[2], y[3]), y[4]);
+    const NVF b_max = max(max(y[2], y[3]), y[4]);
+
+    const NVF a_cont = a_max - a_min;
+    const NVF b_cont = b_max - b_min;
+
+    const NVF cont_ratio = max(a_cont, b_cont) / (min(a_cont, b_cont) + kEps);
+    return (1.0f - saturate((cont_ratio - kMinContrastRatio) * kRatioNorm)) * kContrastBoost;
+}
+
+NVF EvalUSM(const NVF pxl[5], const NVF sharpnessStrength, const NVF sharpnessLimit)
+{
+    // USM profile
+    NVF y_usm = -0.6001f * pxl[1] + 1.2002f * pxl[2] - 0.6001f * pxl[3];
+    // boost USM profile
+    y_usm *= sharpnessStrength;
+    // clamp to the limit
+    y_usm = min(sharpnessLimit, max(-sharpnessLimit, y_usm));
+    // reduce ringing
+    y_usm *= CalcLTIFast(pxl);
+
+    return y_usm;
+}
+
+NVF4 GetDirUSM(const NVF p[5][5])
+{
+    // sharpness boost & limit are the same for all directions
+    const NVF scaleY = 1.0f - saturate((p[2][2] - kSharpStartY) * kSharpScaleY);
+    // scale the ramp to sharpen as a function of luma
+    const NVF sharpnessStrength = scaleY * kSharpStrengthScale + kSharpStrengthMin;
+    // scale the ramp to limit USM as a function of luma
+    const NVF sharpnessLimit = (scaleY * kSharpLimitScale + kSharpLimitMin) * p[2][2];
+
+    NVF4 rval;
+    // 0 deg filter
+    NVF interp0Deg[5];
+    {
+        for (NVI i = 0; i < 5; ++i)
+        {
+            interp0Deg[i] = p[i][2];
+        }
+    }
+
+    rval.x = EvalUSM(interp0Deg, sharpnessStrength, sharpnessLimit);
+
+    // 90 deg filter
+    NVF interp90Deg[5];
+    {
+        for (NVI i = 0; i < 5; ++i)
+        {
+            interp90Deg[i] = p[2][i];
+        }
+    }
+
+    rval.y = EvalUSM(interp90Deg, sharpnessStrength, sharpnessLimit);
+
+    //45 deg filter
+    NVF interp45Deg[5];
+    interp45Deg[0] = p[1][1];
+    interp45Deg[1] = lerp(p[2][1], p[1][2], 0.5f);
+    interp45Deg[2] = p[2][2];
+    interp45Deg[3] = lerp(p[3][2], p[2][3], 0.5f);
+    interp45Deg[4] = p[3][3];
+
+    rval.z = EvalUSM(interp45Deg, sharpnessStrength, sharpnessLimit);
+
+    //135 deg filter
+    NVF interp135Deg[5];
+    interp135Deg[0] = p[3][1];
+    interp135Deg[1] = lerp(p[3][2], p[2][1], 0.5f);
+    interp135Deg[2] = p[2][2];
+    interp135Deg[3] = lerp(p[2][3], p[1][2], 0.5f);
+    interp135Deg[4] = p[1][3];
+
+    rval.w = EvalUSM(interp135Deg, sharpnessStrength, sharpnessLimit);
+    return rval;
+}
+
+//-----------------------------------------------------------------------------------------------
+// NVSharpen
+//-----------------------------------------------------------------------------------------------
+void NVSharpen(NVU2 blockIdx, NVU threadIdx)
+{
+    const NVI dstBlockX = NVI(NIS_BLOCK_WIDTH * blockIdx.x);
+    const NVI dstBlockY = NVI(NIS_BLOCK_HEIGHT * blockIdx.y);
+
+    // fill in input luma tile in batches of 2x2 pixels
+    // we use texture gather to get extra support necessary
+    // to compute 2x2 edge map outputs too
+    const NVF kShift = 0.5f - kSupportSize / 2;
+
+    for (NVI i = NVI(threadIdx) * 2; i < kNumPixelsX * kNumPixelsY / 2; i += NIS_THREAD_GROUP_SIZE * 2)
+    {
+        NVU2 pos = NVU2(NVU(i) % NVU(kNumPixelsX), NVU(i) / NVU(kNumPixelsX) * 2);
+        NIS_UNROLL
+        for (NVI dy = 0; dy < 2; dy++)
+        {
+            NIS_UNROLL
+            for (NVI dx = 0; dx < 2; dx++)
+            {
+#if NIS_VIEWPORT_SUPPORT
+                const NVF tx = (dstBlockX + pos.x + kInputViewportOriginX + dx + kShift) * kSrcNormX;
+                const NVF ty = (dstBlockY + pos.y + kInputViewportOriginY + dy + kShift) * kSrcNormY;
+#else
+                const NVF tx = (dstBlockX + pos.x + dx + kShift) * kSrcNormX;
+                const NVF ty = (dstBlockY + pos.y + dy + kShift) * kSrcNormY;
+#endif
+                const NVF4 px = NVTEX_SAMPLE(in_texture, samplerLinearClamp, NVF2(tx, ty));
+                shPixelsY[pos.y + dy][pos.x + dx] = getY(px.xyz);
+            }
+        }
+    }
+
+    GroupMemoryBarrierWithGroupSync();
+
+    for (NVI k = NVI(threadIdx); k < NIS_BLOCK_WIDTH * NIS_BLOCK_HEIGHT; k += NIS_THREAD_GROUP_SIZE)
+    {
+        const NVI2 pos = NVI2(NVU(k) % NVU(NIS_BLOCK_WIDTH), NVU(k) / NVU(NIS_BLOCK_WIDTH));
+
+        // load 5x5 support to regs
+        NVF p[5][5];
+        NIS_UNROLL
+        for (NVI i = 0; i < 5; ++i)
+        {
+            NIS_UNROLL
+            for (NVI j = 0; j < 5; ++j)
+            {
+                p[i][j] = shPixelsY[pos.y + i][pos.x + j];
+            }
+        }
+
+        // get directional filter bank output
+        NVF4 dirUSM = GetDirUSM(p);
+
+        // generate weights for directional filters
+        NVF4 w = GetEdgeMap(p, kSupportSize / 2 - 1, kSupportSize / 2 - 1);
+
+        // final USM is a weighted sum filter outputs
+        const NVF usmY = (dirUSM.x * w.x + dirUSM.y * w.y + dirUSM.z * w.z + dirUSM.w * w.w);
+
+        // do bilinear tap and correct rgb texel so it produces new sharpened luma
+        const NVI dstX = dstBlockX + pos.x;
+        const NVI dstY = dstBlockY + pos.y;
+
+#if NIS_VIEWPORT_SUPPORT
+        if (dstX > kOutputViewportWidth || dstY > kOutputViewportHeight)
+        {
+            return;
+        }
+#endif
+
+#if NIS_VIEWPORT_SUPPORT
+        NVF4 op = NVTEX_SAMPLE(in_texture, samplerLinearClamp, NVF2((dstX + kInputViewportOriginX + 0.5f) * kSrcNormX, (dstY + kInputViewportOriginY + 0.5f) * kSrcNormY));
+#else
+        NVF4 op = NVTEX_SAMPLE(in_texture, samplerLinearClamp, NVF2((dstX + 0.5f) * kSrcNormX, (dstY + 0.5f) * kSrcNormY));
+#endif
+#if NIS_HDR_MODE == NIS_HDR_MODE_LINEAR
+        const NVF kEps = 1e-4f * kHDRCompressionFactor * kHDRCompressionFactor;
+        NVF newY = p[2][2] + usmY;
+        newY = max(newY, 0.0f);
+        const NVF oldY = p[2][2];
+        const NVF corr = (newY * newY + kEps) / (oldY * oldY + kEps);
+        op.x *= corr;
+        op.y *= corr;
+        op.z *= corr;
+#else
+        op.x += usmY;
+        op.y += usmY;
+        op.z += usmY;
+#endif
+#if NIS_VIEWPORT_SUPPORT
+        NVTEX_STORE(out_texture, NVU2(dstX + kOutputViewportOriginX, dstY + kOutputViewportOriginY), op);
+#else
+        NVTEX_STORE(out_texture, NVU2(dstX, dstY), op);
+#endif
+    }
+}
+#endif

--- a/src/shaders/NVIDIAImageScaling/README.md
+++ b/src/shaders/NVIDIAImageScaling/README.md
@@ -1,0 +1,413 @@
+# NVIDIA Image Scaling SDK v1.0.2
+
+The MIT License(MIT)
+
+Copyright(c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files(the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+## Introduction
+
+The NVIDIA Image Scaling SDK provides a single spatial scaling and sharpening algorithm
+for cross-platform support. The scaling algorithm uses a 6-tap scaling filter combined
+with 4 directional scaling and adaptive sharpening filters, which creates nice smooth images
+and sharp edges. In addition, the SDK provides a state-of-the-art adaptive directional sharpening algorithm for use in
+applications where no scaling is required.\
+The directional scaling and sharpening algorithm is named NVScaler while the adaptive-directional-sharpening-only
+algorithm is named NVSharpen. Both algorithms are provided as compute shaders and
+developers are free to integrate them in their applications. Note that if you integrate NVScaler, you
+should NOT integrate NVSharpen, as NVScaler already includes a sharpening pass
+
+
+
+## Pipeline Placement
+
+The call into the NVIDIA Image Scaling shaders must occur during the post-processing phase after tone-mapping.
+Applying the scaling in linear HDR in-game color-space may result in a sharpening effect that is
+either not visible or too strong. Since sharpening algorithms can enhance noisy or grainy regions, it is recommended
+that certain effects such as film grain should occur after NVScaler or NVSharpen. Low-pass filters such as motion blur or
+light bloom are recommended to be applied before NVScaler or NVSharpen to avoid sharpening attenuation.
+
+
+
+## Color Space and Ranges
+
+NVIDIA Image Scaling shaders can process color textures stored as either LDR or HDR with the following
+restrictions:
+
+1) LDR
+   - The range of color values must be in the [0, 1] range
+   - The input color texture must be in display-referred color-space after tone mapping and OETF (gamma-correction)
+     has been applied
+2) HDR PQ
+   - The range of color values must be in the [0, 1] range
+   - The input color texture must be in display-referred color-space after tone mapping with Rec.2020 PQ OETF applied
+3) HDR Linear
+   - The recommended range of color values is [0, 12.5], where luminance value (as per BT. 709) of
+     1.0 maps to brightness value of 80nits (sRGB peak) and 12.5 maps to 1000nits
+   - The input color texture may have luminance values that are either linear and scene-referred or
+     linear and display-referred (after tone mapping)
+
+If the input color texture sent to NVScaler/NVSharpen is in HDR format set NIS_HDR_MODE define to either NIS_HDR_MODE_LINEAR (1) or NIS_HDR_MODE_PQ (2).
+
+
+
+## Supported Texture Formats
+
+### Input and output formats:
+
+Input and output formats are expected to be in the rages defined in previous section and should be
+specified using non-integer data types such as DXGI_FORMAT_R8G8B8A8_UNORM.
+
+### Coefficients formats:
+
+The scaler coefficients and USM coefficients format should be specified using float4 type such as
+DXGI_FORMAT_R32G32B32A32_FLOAT or DXGI_FORMAT_R16G16B16A16_FLOAT.
+The coefficients are included in NIS_Config.h file:
+
+fp32 format: coef_scaler, coef_USM
+
+fp16 format: coef_scaler_fp16, coef_USM_fp16
+
+
+### Resource States, Buffers, and Sampler:
+
+The game or application calling NVIDIA Image Scaling SDK shaders must ensure that the textures are in
+the correct state.
+
+- Input color textures must be in pixel shader read state. Shader Resource View (SRV) in DirectX
+- The output texture must be in read/write state. Unordered Access View (UAV) in DirectX
+- The coefficients texture for NVScaler must be in read state. Shader Resource View (SRV) in DirectX
+- The configuration variables must be passed as constant buffer. Constant Buffer View (CBV) in DirectX
+- The sampler for texture pixel sampling must use linear filter interpolation and clamp to edge addressing mode
+
+
+
+## Adding NVIDIA Image Scaling SDK to a Project
+
+Include NIS_Scaler.h directly in your application or alternative use the provided NIS_Main.hlsl or NIS_Main.glsl shader files.
+Use NIS_Config.h to get the ideal shader dispatch values for your platform, to configure the algorithm constant
+values (NVScalerUpdateConfig, and NVSharpenUpdateConfig), and to access the algorithm coefficients (coef_scale, coef_USM, coef_scale_fp16, coef_USM_fp16).
+
+- Device\
+  NIS_Scaler.h    : HLSL shader file\
+  NIS_Main.hlsl   : Main HLSL shader example (can be replaced by your own) \
+  NIS_Main.glsl   : Main GLSL shader example (can ge replaced by your own)
+
+- Host Configuration\
+  NIS_Config.h    : Configuration structure
+
+
+### Defines:
+
+**NIS_SCALER**: default (**1**) NVScaler, (0) fast NVSharpen only, no upscaling\
+**NIS_HDR_MODE**: default(**0**) disabled, (1) Linear, (2) PQ\
+**NIS_BLOCK_WIDTH**: pixels per block width. Use GetOptimalBlockWidth query for your platform\
+**NIS_BLOCK_HEIGHT**: pixels per block height. Use GetOptimalBlockHeight query for your platform\
+**NIS_THREAD_GROUP_SIZE**: number of threads per group. Use GetOptimalThreadGroupSize query for your platform\
+**NIS_USE_HALF_PRECISION**: default(**0**) disabled, (1) enable half pression computation\
+**NIS_HLSL**: default (**1**) enabled, (0) disabled\
+**NIS_HLSL_6_2**: default (**0**) HLSL v5, (1) HLSL v6.2 forces NIS_HLSL=1\
+**NIS_GLSL**: default (**0**) disabled, (1) enabled\
+**NIS_VIEWPORT_SUPPORT**: default(**0**) disabled, (1) enable input/output viewport support\
+
+
+*Default NVScaler shader constants:*
+
+[**NIS_BLOCK_WIDTH**, **NIS_BLOCK_HEIGHT**, **NIS_THREAD_GROUP_SIZE**] = [32, 24, 256]
+
+*Default NVSharpen shader constants:*
+
+[**NIS_BLOCK_WIDTH**, **NIS_BLOCK_HEIGHT**, **NIS_THREAD_GROUP_SIZE**] = [32, 32, 256]
+
+
+*Defines for HLSL with DXC bindings:*
+
+**NIS_DXC**: (0) disabled, (1) enable HLSL DXC Vulkan support
+
+## Optimal shader settings
+
+To get optimal performance of NVScaler and NVSharpen for current and future hardware, it is recommended that the following API is used to obtain the values for NIS_BLOCK_WIDTH, NIS_BLOCK_HEIGHT, and NIS_THREAD_GROUP_SIZE. These values can be used to compile permutations of NVScaler and NVSharpen offline.
+
+```
+enum class NISGPUArchitecture : uint32_t
+{
+    NVIDIA_Generic = 0,
+    AMD_Generic = 1,
+    Intel_Generic = 2,
+    NVIDIA_Generic_fp16 = 3,
+};
+```
+
+```
+struct NISOptimizer
+{
+    bool isUpscaling;
+    NISGPUArchitecture gpuArch;
+
+    NISOptimizer(bool isUpscaling = true,
+                 NISGPUArchitecture gpuArch = NISGPUArchitecture::NVIDIA_Generic);
+    uint32_t GetOptimalBlockWidth();
+    uint32_t GetOptimalBlockHeight();
+    uint32_t GetOptimalThreadGroupSize();
+};
+```
+
+
+
+## HDR shader settings
+
+Use the following enum values for setting NIS_HDR_MODE
+
+```
+enum class NISHDRMode : uint32_t
+{
+    None = 0,
+    Linear = 1,
+    PQ = 2
+};
+```
+
+
+
+## Integration of NVScaler
+The integration instructions in this section can be applied with minimal changes to your own DX11, DX12, or Vulkan application, using HLSL or GLSL.
+
+### Compile the NIS_Main.hlsl shader
+
+NIS_SCALER should be set to 1, and the isUpscaling argument should set to true.
+
+```
+bool isUpscaling = true;
+// Note: NISOptimizer is optional and these values can be cached offline
+NISOptimizer opt(isUpscaling, NISGPUArchitecture::NVIDIA_Generic);
+uint32_t blockWidth = opt.GetOptimalBlockWidth();
+uint32_t blockHeight = opt.GetOptimalBlockHeight();
+uint32_t threadGroupSize = opt.GetOptimalThreadGroupSize();
+
+Defines defines;
+defines.add("NIS_SCALER", isUpscaling);
+defines.add("NIS_HDR_MODE", hdrMode);
+defines.add("NIS_BLOCK_WIDTH", blockWidth);
+defines.add("NIS_BLOCK_HEIGHT", blockHeight);
+defines.add("NIS_THREAD_GROUP_SIZE", threadGroupSize);
+NVScalerCS = CompileComputeShader(device, "NIS_Main.hlsl”, &defines);
+```
+
+### Create NVIDIA Image Scaling SDK configuration constant buffer
+
+```
+struct NISConfig
+{
+    float kDetectRatio;
+    float kDetectThres;
+    float kMinContrastRatio;
+    float kRatioNorm;
+    ...
+};
+
+NISConfig config;
+createConstBuffer(&config, &csBuffer);
+```
+
+### Create SRV textures for the scaler and USM phase coefficients
+
+```
+const int rowPitch = kFilterSize * sizeof(float);  // use for fp32: float, fp16: uint16_t
+const int coeffSize = rowPitch * kPhaseCount;
+
+// Since we are using RGBA format the texture width = kFilterSize / 4
+createTexture2D(kFilterSize / 4, kPhaseCount, DXGI_FORMAT_R32G32B32A32_FLOAT, D3D11_USAGE_DEFAULT, coef_scaler, rowPitch, coeffSize, &scalerTex);
+createTexture2D(kFilterSize / 4, kPhaseCount, DXGI_FORMAT_R32G32B32A32_FLOAT, D3D11_USAGE_DEFAULT, coef_usm, rowPitch, coeffSize, &usmTex);
+
+createSRV(scalerTex.Get(), DXGI_FORMAT_R32G32B32A32_FLOAT, &scalerSRV);
+createSRV(usmTex.Get(), DXGI_FORMAT_R32G32B32A32_FLOAT, &usmSRV);
+```
+
+### Create Sampler
+
+```
+createLinearClampSampler(&linearClampSampler);
+```
+
+### Update NVIDIA Image Scaling SDK NVScaler configuration and constant buffer
+
+Use the following API call to update the NVIDIA Image Scaling SDK configuration
+
+```
+void NVScalerUpdateConfig(NISConfig& config,
+    float sharpness,
+    uint32_t inputViewportOriginX, uint32_t inputViewportOriginY,
+    uint32_t inputViewportWidth, uint32_t inputViewportHeight,
+    uint32_t inputTextureWidth, uint32_t inputTextureHeight,
+    uint32_t outputViewportOriginX, uint32_t outputViewportOriginY,
+    uint32_t outputViewportWidth, uint32_t outputViewportHeight,
+    uint32_t outputTextureWidth, uint32_t outputTextureHeight,
+    NISHDRMode hdrMode = NISHDRMode::None
+);
+```
+
+Update the constant buffer whenever the input size, sharpness, or scale changes
+
+```
+NVScalerUpdateConfig(m_config, sharpness,
+                0, 0, inputWidth, inputHeight, inputWidth, inputHeight,
+                0, 0, outputWidth, outputHeight, outputWidth, outputHeight,
+                NISHDRMode::None);
+
+updateConstBuffer(&config, csBuffer.Get());
+```
+
+### A simple DX11 NVScaler dispatch example
+
+```
+context->CSSetShaderResources(0, 1, input); // SRV
+context->CSSetShaderResource (1, 1, scalerSRV.GetAddressOf());
+context->CSSetShaderResource (2, 1, usmSRV.GetAddressOf());
+context->CSSetUnorderedAccessViews(0, 1, output, nullptr);
+context->CSSetSamplers(0, 1, linearClampSampler.GetAddressOf());
+context->CSSetConstantBuffers(0, 1, csBuffer.GetAddressOf());
+context->CSSetShader(NVScalerCS.Get(), nullptr, 0);
+
+context->Dispatch(UINT(std::ceil(outputWidth / float(blockWidth))),
+                  UINT(std::ceil(outputHeight / float(blockHeight))), 1);
+```
+
+
+
+## Integration of NVSharpen
+
+If your application requires upscaling and sharpening do not use NVSharpen use NVScaler instead. Since NVScaler performs both operations, upscaling and sharpening, in one step, it performs faster and produces better image quality.
+
+### Compile the NIS_Main.hlsl shader
+
+NIS_SCALER should be set to 0 and the optimizer isUpscaling argument should be set to false.
+
+```
+bool isUpscaling = false;
+// Note: NISOptimizer is optional and these values can be cached offline
+NISOptimizer opt(isUpscaling, NISGPUArchitecture::NVIDIA_Generic);
+uint32_t blockWidth = opt.GetOptimalBlockWidth();
+uint32_t blockHeight = opt.GetOptimalBlockHeight();
+uint32_t threadGroupSize = opt.GetOptimalThreadGroupSize();
+
+Defines defines;
+defines.add("NIS_DIRSCALER", isUpscaling);
+defines.add("NIS_HDR_MODE", hdrMode);
+defines.add("NIS_BLOCK_WIDTH", blockWidth);
+defines.add("NIS_BLOCK_HEIGHT", blockHeight);
+defines.add("NIS_THREAD_GROUP_SIZE", threadGroupSize);
+NVSharpenCS = CompileComputeShader(device, "NIS_Main.hlsl”, &defines);
+```
+
+### Create NVIDIA Image Scaling SDK NVSharpen configuration constant buffer
+
+```
+struct NISConfig
+{
+    float kDetectRatio;
+    float kDetectThres;
+    float kMinContrastRatio;
+    float kRatioNorm;
+    ...
+};
+
+NISConfig config;
+createConstBuffer(&config, &csBuffer);
+```
+
+### Create Sampler
+
+```
+createLinearClampSampler(&linearClampSampler);
+```
+
+### Update NVIDIA Image Scaling SDK NVSharpen configuration and constant buffer
+
+Use the following API call to update the NVIDIA Image Scaling SDK configuration. Since NVSharpen is a sharpening algorithm only the sharpness and input size are required. For upscaling with sharpening use NVScaler since it performs both operations at the same time.
+
+```
+void NVSharpenUpdateConfig(NISConfig& config, float sharpness,
+    uint32_t inputViewportOriginX, uint32_t inputViewportOriginY,
+    uint32_t inputViewportWidth, uint32_t inputViewportHeight,
+    uint32_t inputTextureWidth, uint32_t inputTextureHeight,
+    uint32_t outputViewportOriginX, uint32_t outputViewportOriginY,
+    NISHDRMode hdrMode = NISHDRMode::None
+);
+
+```
+
+Update the constant buffer whenever the input size or sharpness changes.
+
+```
+NVSharpenUpdateConfig(m_config, sharpness,
+                      0, 0, inputWidth, inputHeight, inputWidth, inputHeight,
+                      0, 0, NISHDRMode::None);
+
+updateConstBuffer(&config, csBuffer.Get());
+```
+
+### A simple DX11 NVSharpen dispatch example
+
+```
+context->CSSetShaderResources(0, 1, input);
+context->CSSetUnorderedAccessViews(0, 1, output, nullptr);
+context->CSSetSamplers(0, 1, linearClampSampler.GetAddressOf());
+context->CSSetConstantBuffers(0, 1, csBuffer.GetAddressOf());
+context->CSSetShader(NVSharpenCS.Get(), nullptr, 0);
+
+context->Dispatch(UINT(std::ceil(outputWidth / float(blockWidth))),
+                  UINT(std::ceil(outputHeight / float(blockHeight))), 1);
+```
+
+
+
+## Samples
+
+### Dependencies
+
+- Visual Studio 2019 : https://visualstudio.microsoft.com/downloads/
+- Windows 10 SDK : https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
+- CMake 3.16 : https://cmake.org/download/
+
+for building the Vulkan sample:
+- Vulkan SDK 1.2.189.2 : https://vulkan.lunarg.com/
+
+### Build
+
+For the DirectX11 and DirectX12 samples use the following:
+
+```
+$> cd samples
+$> mkdir build
+$> cd build
+$> cmake ..
+```
+
+for building the Vulkan sample:
+
+```
+$> cd samples
+$> mkdir build
+$> cd build
+$> cmake .. -DNIS_VK_SAMPLE=ON
+```
+
+Open the solution with Visual Studio 2019. Right-click the sample project and select "Set as Startup Project" before building the project. For Linux, only the VK sample will be generated.

--- a/src/shaders/NVIDIAImageScaling/licence.txt
+++ b/src/shaders/NVIDIAImageScaling/licence.txt
@@ -1,0 +1,20 @@
+// The MIT License(MIT)
+// 
+// Copyright(c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files(the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions :
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/shaders/cs_nis.comp
+++ b/src/shaders/cs_nis.comp
@@ -1,0 +1,67 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+#extension GL_GOOGLE_include_directive : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+
+#define NIS_GLSL 1
+#define NIS_SCALER 1
+
+#include "descriptor_set.h"
+
+layout(std430, push_constant) uniform const_buffer
+{
+    float kDetectRatio;
+    float kDetectThres;
+    float kMinContrastRatio;
+    float kRatioNorm;
+
+    float kContrastBoost;
+    float kEps;
+    float kSharpStartY;
+    float kSharpScaleY;
+
+    float kSharpStrengthMin;
+    float kSharpStrengthScale;
+    float kSharpLimitMin;
+    float kSharpLimitScale;
+
+    float kScaleX;
+    float kScaleY;
+
+    float kDstNormX;
+    float kDstNormY;
+    float kSrcNormX;
+    float kSrcNormY;
+
+    uint kInputViewportOriginX;
+    uint kInputViewportOriginY;
+    uint kInputViewportWidth;
+    uint kInputViewportHeight;
+
+    uint kOutputViewportOriginX;
+    uint kOutputViewportOriginY;
+    uint kOutputViewportWidth;
+    uint kOutputViewportHeight;
+
+    float reserved0;
+    float reserved1;
+};
+
+// These are the names the NIS shader uses to access the data needed to do the upscaling
+#define in_texture s_samplers[0]
+#define out_texture dst
+
+// Gamescope is using combined image samplers so no need to specify a sampler
+#define sampler2D(x, sampler) (x)
+
+#include "NVIDIAImageScaling/NIS/NIS_Scaler.h"
+
+layout(local_size_x=NIS_THREAD_GROUP_SIZE,
+       local_size_y = 1,
+       local_size_z = 1) in;
+void main()
+{
+    NVScaler(gl_WorkGroupID.xy, gl_LocalInvocationID.x);
+}

--- a/src/shaders/cs_nis_fp16.comp
+++ b/src/shaders/cs_nis_fp16.comp
@@ -1,0 +1,68 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+#extension GL_GOOGLE_include_directive : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+
+#define NIS_GLSL 1
+#define NIS_USE_HALF_PRECISION 1
+#define NIS_SCALER 1
+
+#include "descriptor_set.h"
+
+layout(std430, push_constant) uniform const_buffer
+{
+    float kDetectRatio;
+    float kDetectThres;
+    float kMinContrastRatio;
+    float kRatioNorm;
+
+    float kContrastBoost;
+    float kEps;
+    float kSharpStartY;
+    float kSharpScaleY;
+
+    float kSharpStrengthMin;
+    float kSharpStrengthScale;
+    float kSharpLimitMin;
+    float kSharpLimitScale;
+
+    float kScaleX;
+    float kScaleY;
+
+    float kDstNormX;
+    float kDstNormY;
+    float kSrcNormX;
+    float kSrcNormY;
+
+    uint kInputViewportOriginX;
+    uint kInputViewportOriginY;
+    uint kInputViewportWidth;
+    uint kInputViewportHeight;
+
+    uint kOutputViewportOriginX;
+    uint kOutputViewportOriginY;
+    uint kOutputViewportWidth;
+    uint kOutputViewportHeight;
+
+    float reserved0;
+    float reserved1;
+};
+
+// These are the names the NIS shader uses to access the data needed to do the upscaling
+#define in_texture s_samplers[0]
+#define out_texture dst
+
+// Gamescope is using combined image samplers so no need to specify a sampler
+#define sampler2D(x, sampler) (x)
+
+#include "NVIDIAImageScaling/NIS/NIS_Scaler.h"
+
+layout(local_size_x=NIS_THREAD_GROUP_SIZE,
+       local_size_y = 1,
+       local_size_z = 1) in;
+void main()
+{
+    NVScaler(gl_WorkGroupID.xy, gl_LocalInvocationID.x);
+}

--- a/src/shaders/descriptor_set.h
+++ b/src/shaders/descriptor_set.h
@@ -11,3 +11,8 @@ layout(binding = 0, rgba8) writeonly uniform image2D dst;
 layout(binding = 1) uniform sampler2D s_samplers[MaxLayers];
 layout(binding = 2) uniform sampler2D s_ycbcr_samplers[MaxLayers];
 layout(binding = 3) uniform sampler2D s_sampler_extra;
+
+#if defined(NIS_SCALER)
+layout(binding = 4) uniform sampler2D coef_scaler;
+layout(binding = 5) uniform sampler2D coef_usm;
+#endif

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1616,7 +1616,9 @@ paint_all()
 				// Just draw focused window as normal, be it Steam or the game
 				paint_window(w, w, &frameInfo, global_focus.cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders, 1.0f, override);
 
-				frameInfo.useFSRLayer0 = g_fsrUpscale && frameInfo.layers[0].scale.x < 1.0f && frameInfo.layers[0].scale.y < 1.0f;
+				bool needsScaling = frameInfo.layers[0].scale.x < 1.0f && frameInfo.layers[0].scale.y < 1.0f;
+				frameInfo.useFSRLayer0 = g_upscaler == GamescopeUpscaler::FSR && needsScaling;
+				frameInfo.useNISLayer0 = g_upscaler == GamescopeUpscaler::NIS && needsScaling;
 			}
 			update_touch_scaling( &frameInfo );
 		}
@@ -1710,6 +1712,7 @@ paint_all()
 		}
 
 		frameInfo.useFSRLayer0 = false;
+		frameInfo.useNISLayer0 = false;
 	}
 
 	g_bFSRActive = frameInfo.useFSRLayer0;
@@ -1750,6 +1753,7 @@ paint_all()
 	bNeedsComposite |= bCapture;
 	bNeedsComposite |= bWasFirstFrame;
 	bNeedsComposite |= frameInfo.useFSRLayer0;
+	bNeedsComposite |= frameInfo.useNISLayer0;
 	bNeedsComposite |= frameInfo.blurLayer0;
 	bNeedsComposite |= bNeedsNearest;
 	bNeedsComposite |= bDrewCursor;
@@ -3875,30 +3879,35 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 		case 0:
 			g_bFilterGameWindow = true;
 			g_bIntegerScale = false;
-			g_fsrUpscale = false;
+			g_upscaler = GamescopeUpscaler::BLIT;
 			break;
 		case 1:
 			g_bFilterGameWindow = false;
 			g_bIntegerScale = false;
-			g_fsrUpscale = false;
+			g_upscaler = GamescopeUpscaler::BLIT;
 			break;
 		case 2:
 			g_bFilterGameWindow = false;
 			g_bIntegerScale = true;
-			g_fsrUpscale = false;
+			g_upscaler = GamescopeUpscaler::BLIT;
 			break;
 		case 3:
 			g_bFilterGameWindow = true;
 			g_bIntegerScale = false;
-			g_fsrUpscale = true;
+			g_upscaler = GamescopeUpscaler::FSR;
+			break;
+		case 4:
+			g_bFilterGameWindow = true;
+			g_bIntegerScale = false;
+			g_upscaler = GamescopeUpscaler::NIS;
 			break;
 		}
 		hasRepaint = true;
 	}
-	if ( ev->atom == ctx->atoms.gamescopeFSRSharpness )
+	if ( ev->atom == ctx->atoms.gamescopeFSRSharpness || ev->atom == ctx->atoms.gamescopeSharpness )
 	{
-		g_fsrSharpness = (int)clamp( get_prop( ctx, ctx->root, ctx->atoms.gamescopeFSRSharpness, 2 ), 0u, 20u );
-		if ( g_fsrUpscale )
+		g_upscalerSharpness = (int)clamp( get_prop( ctx, ctx->root, ev->atom, 2 ), 0u, 20u );
+		if ( g_upscaler != GamescopeUpscaler::BLIT )
 			hasRepaint = true;
 	}
 	if ( ev->atom == ctx->atoms.gamescopeColorLinearGain )
@@ -4874,6 +4883,7 @@ void init_xwayland_ctx(gamescope_xwayland_server_t *xwayland_server)
 
 	ctx->atoms.gamescopeScalingFilter = XInternAtom( ctx->dpy, "GAMESCOPE_SCALING_FILTER", false );
 	ctx->atoms.gamescopeFSRSharpness = XInternAtom( ctx->dpy, "GAMESCOPE_FSR_SHARPNESS", false );
+	ctx->atoms.gamescopeSharpness = XInternAtom( ctx->dpy, "GAMESCOPE_SHARPNESS", false );
 
 	ctx->atoms.gamescopeColorLinearGain = XInternAtom( ctx->dpy, "GAMESCOPE_COLOR_LINEARGAIN", false );
 	ctx->atoms.gamescopeColorGain = XInternAtom( ctx->dpy, "GAMESCOPE_COLOR_GAIN", false );

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -117,6 +117,7 @@ struct xwayland_ctx_t
 
 		Atom gamescopeScalingFilter;
 		Atom gamescopeFSRSharpness;
+		Atom gamescopeSharpness;
 
 		Atom gamescopeColorLinearGain;
 		Atom gamescopeColorGain;


### PR DESCRIPTION
This PR adds support for selecting NVIDIA Image Scaling as the Gamescope upscaler implementation. It can be enabled by passing the -Y or --nis-upscaling option to Gamescope.