### PR TITLE
Drop reference to last known overlay window

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2290,6 +2290,7 @@ determine_and_apply_focus(xwayland_ctx_t *ctx, std::vector<win*>& vecGlobalPossi
 	ctx->focus.overlayWindow = nullptr;
 	ctx->focus.notificationWindow = nullptr;
 	ctx->focus.overrideWindow = nullptr;
+	ctx->focus.externalOverlayWindow = nullptr;
 
 	unsigned int maxOpacity = 0;
 	unsigned int maxOpacityExternal = 0;


### PR DESCRIPTION
Once external overlay windows set their XAtom `GAMESCOPE_EXTERNAL_OVERLAY` to 0 they should be removed from the pool of known external overlays, but reference is kept until they are closed and is never replaced as all current overlays use maximum opacity.

This change is untested and written in a coffee break.

This is in an attempt to fix https://github.com/flightlessmango/MangoHud/issues/775 and https://github.com/trigg/Discover/issues/253