### PR TITLE
Always use the newest external overlay window

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2324,7 +2324,7 @@ determine_and_apply_focus(xwayland_ctx_t *ctx, std::vector<win*>& vecGlobalPossi
 
 		if (w->isExternalOverlay)
 		{
-			if (w->opacity >= maxOpacityExternal)
+			if (w->opacity > maxOpacityExternal)
 			{
 				ctx->focus.externalOverlayWindow = w;
 				maxOpacityExternal = w->opacity;


### PR DESCRIPTION
Currently creating a new external overlay window will not show up until all others close or are killed.

With this change when the user starts a new external overlay it will take precedence until a newer one appears or it is closed or killed.

This will help alleviate a lot of bugs where overlays 'don't start' because another overlay is already in the slot and not drawing into it.