### PR TITLE
Add --force-orientation option

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1285,19 +1285,14 @@ uint64_t get_drm_effective_orientation()
 	{
 		case PANEL_ORIENTATION_0:
 			return DRM_MODE_ROTATE_0;
-			break;
 		case PANEL_ORIENTATION_90:
 			return DRM_MODE_ROTATE_90;
-			break;
 		case PANEL_ORIENTATION_180:
 			return DRM_MODE_ROTATE_180;
-			break;
 		case PANEL_ORIENTATION_270:
 			return DRM_MODE_ROTATE_270;
-			break;
 		case PANEL_ORIENTATION_AUTO:
 			return g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0;
-			break;
 	}
 	abort(); //Should not happen unless something went terribly wrong
 }
@@ -1587,14 +1582,14 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 
 			drm_screen_type screenType = drm_get_screen_type(drm);
 
-		if ( screenType == DRM_SCREEN_TYPE_INTERNAL )
-		{
-			liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", get_drm_effective_orientation());
-		}
-		else
-		{
-			liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_0);
-		}
+			if ( screenType == DRM_SCREEN_TYPE_INTERNAL )
+			{
+				liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", get_drm_effective_orientation());
+			}
+			else
+			{
+				liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_0);
+			}
 
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_X", entry.layerState[i].crtcX);
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_Y", entry.layerState[i].crtcY);

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1299,6 +1299,7 @@ uint64_t get_drm_effective_orientation()
 			return g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0;
 			break;
 	}
+	abort(); //Should not happen unless something went terribly wrong
 }
 
 /* Prepares an atomic commit without using libliftoff */

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1302,25 +1302,33 @@ drm_prepare_basic( struct drm_t *drm, const struct FrameInfo_t *frameInfo )
 
 	drm->fbids_in_req.push_back( fb_id );
 
-	switch ( g_drmModeOrientation )
+	drm_screen_type screenType = drm_get_screen_type(drm);
+	if ( screenType == DRM_SCREEN_TYPE_INTERNAL )
 	{
-	case PANEL_ORIENTATION_0:
-		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_0);
-		break;
-	case PANEL_ORIENTATION_270:
-		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_270);
-		break;
-	case PANEL_ORIENTATION_90:
-		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_90);
-		break;
-	case PANEL_ORIENTATION_180:
-		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_180);
-		break;
-	/* we are keeping the original method used for by default to prevent a sudden break in compatibility for devices using this method.*/
-	case PANEL_ORIENTATION_AUTO:
-	default:
+		switch ( g_drmModeOrientation )
+		{
+		case PANEL_ORIENTATION_0:
+			add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_0);
+			break;
+		case PANEL_ORIENTATION_270:
+			add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_270);
+			break;
+		case PANEL_ORIENTATION_90:
+			add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_90);
+			break;
+		case PANEL_ORIENTATION_180:
+			add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_180);
+			break;
+		/* we are keeping the original method used for by default to prevent a sudden break in compatibility for devices using this method.*/
+		case PANEL_ORIENTATION_AUTO:
+		default:
+			add_plane_property(req, drm->primary, "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+			break;
+		}
+	}
+	else
+	{
 		add_plane_property(req, drm->primary, "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
-		break;
 	}
 
 	add_plane_property(req, drm->primary, "FB_ID", fb_id);
@@ -1571,25 +1579,34 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 			liftoff_layer_set_property( drm->lo_layers[ i ], "SRC_W", entry.layerState[i].srcW );
 			liftoff_layer_set_property( drm->lo_layers[ i ], "SRC_H", entry.layerState[i].srcH );
 
-			switch ( g_drmModeOrientation )
+			drm_screen_type screenType = drm_get_screen_type(drm);
+			if ( screenType == DRM_SCREEN_TYPE_INTERNAL )
 			{
-				case PANEL_ORIENTATION_0:
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_0);
-					break;
-				case PANEL_ORIENTATION_270:
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_270);
-					break;
-				case PANEL_ORIENTATION_90:
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_90);
-					break;
-				case PANEL_ORIENTATION_180:
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_180);
-					break;
-				case PANEL_ORIENTATION_AUTO:
-				default: /* We are using auto to ensure compatibility with devicess that used this method*/
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
-					break;
+				switch ( g_drmModeOrientation )
+				{
+					case PANEL_ORIENTATION_0:
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_0);
+						break;
+					case PANEL_ORIENTATION_270:
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_270);
+						break;
+					case PANEL_ORIENTATION_90:
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_90);
+						break;
+					case PANEL_ORIENTATION_180:
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_180);
+						break;
+					case PANEL_ORIENTATION_AUTO:
+					default: /* We are using auto to ensure compatibility with devicess that used this method*/
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+						break;
+				}
 			}
+			else
+			{
+				liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+			}
+
 
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_X", entry.layerState[i].crtcX);
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_Y", entry.layerState[i].crtcY);

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -48,6 +48,8 @@ const char *g_sOutputName = nullptr;
 bool g_bSupportsAsyncFlips = false;
 
 enum drm_mode_generation g_drmModeGeneration = DRM_MODE_GENERATE_CVT;
+enum g_panel_orientation g_drmModeOrientation = PANEL_ORIENTATION_AUTO;
+
 
 static LogScope drm_log("drm");
 static LogScope drm_verbose_log("drm", LOG_SILENT);
@@ -1259,7 +1261,7 @@ void drm_lock_fbid( struct drm_t *drm, uint32_t fbid )
 void drm_unlock_fbid( struct drm_t *drm, uint32_t fbid )
 {
 	struct fb &fb = get_fb( *drm, fbid );
-	
+
 	assert( fb.held_refs > 0 );
 	if ( --fb.held_refs != 0 )
 		return;
@@ -1300,7 +1302,26 @@ drm_prepare_basic( struct drm_t *drm, const struct FrameInfo_t *frameInfo )
 
 	drm->fbids_in_req.push_back( fb_id );
 
-	add_plane_property(req, drm->primary, "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+	switch ( g_drmModeOrientation )
+	{
+	case PANEL_ORIENTATION_0:
+		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_0);
+		break;
+	case PANEL_ORIENTATION_270:
+		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_270);
+		break;
+	case PANEL_ORIENTATION_90:
+		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_90);
+		break;
+	case PANEL_ORIENTATION_180:
+		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_180);
+		break;
+	/* we are keeping the original method used for by default to prevent a sudden break in compatibility for devices using this method.*/
+	case PANEL_ORIENTATION_AUTO:
+	default:
+		add_plane_property(req, drm->primary, "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+		break;
+	}
 
 	add_plane_property(req, drm->primary, "FB_ID", fb_id);
 	add_plane_property(req, drm->primary, "CRTC_ID", drm->crtc->id);
@@ -1550,7 +1571,25 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 			liftoff_layer_set_property( drm->lo_layers[ i ], "SRC_W", entry.layerState[i].srcW );
 			liftoff_layer_set_property( drm->lo_layers[ i ], "SRC_H", entry.layerState[i].srcH );
 
-			liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+			switch ( g_drmModeOrientation )
+			{
+				case PANEL_ORIENTATION_0:
+					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_0);
+					break;
+				case PANEL_ORIENTATION_270:
+					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_270);
+					break;
+				case PANEL_ORIENTATION_90:
+					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_90);
+					break;
+				case PANEL_ORIENTATION_180:
+					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_180);
+					break;
+				case PANEL_ORIENTATION_AUTO:
+				default: /* We are using auto to ensure compatibility with devicess that used this method*/
+					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+					break;
+			}
 
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_X", entry.layerState[i].crtcX);
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_Y", entry.layerState[i].crtcY);
@@ -2050,7 +2089,7 @@ bool drm_update_color_mtx(struct drm_t *drm)
 		drm_ctm.matrix[i] = color.s31_32;
 	}
 
-	uint32_t blob_id = 0;	
+	uint32_t blob_id = 0;
 	if (drmModeCreatePropertyBlob(drm->fd, &drm_ctm,
 			sizeof(struct drm_color_ctm), &blob_id) != 0) {
 		drm_log.errorf_errno("Unable to create CTM property blob");
@@ -2128,7 +2167,7 @@ bool drm_update_gamma_lut(struct drm_t *drm)
 		gamma_lut[i].blue  = drm_calc_lut_value( b_exp, drm->pending.color_linear_gain[2], drm->pending.color_gain[2], drm->pending.gain_blend );
 	}
 
-	uint32_t blob_id = 0;	
+	uint32_t blob_id = 0;
 	if (drmModeCreatePropertyBlob(drm->fd, gamma_lut,
 			lut_entries * sizeof(struct drm_color_lut), &blob_id) != 0) {
 		drm_log.errorf_errno("Unable to create gamma LUT property blob");
@@ -2179,7 +2218,7 @@ bool drm_update_degamma_lut(struct drm_t *drm)
 		degamma_lut[i].blue  = drm_quantize_lut_value( safe_pow( input, drm->pending.color_degamma_exponent[screen_type][2] ) );
 	}
 
-	uint32_t blob_id = 0;	
+	uint32_t blob_id = 0;
 	if (drmModeCreatePropertyBlob(drm->fd, degamma_lut,
 			lut_entries * sizeof(struct drm_color_lut), &blob_id) != 0) {
 		drm_log.errorf_errno("Unable to create degamma LUT property blob");

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1333,7 +1333,7 @@ drm_prepare_basic( struct drm_t *drm, const struct FrameInfo_t *frameInfo )
 	}
 	else
 	{
-		add_plane_property(req, drm->primary, "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_0);
 	}
 
 	add_plane_property(req, drm->primary, "FB_ID", fb_id);
@@ -1592,7 +1592,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 		}
 		else
 		{
-			liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? : DRM_MODE_ROTATE_0);
+			liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_0);
 		}
 
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_X", entry.layerState[i].crtcX);

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1279,32 +1279,28 @@ void drm_unlock_fbid( struct drm_t *drm, uint32_t fbid )
 }
 
 /* Handle the orientation of the display */
-		uint64_t get_drm_effective_orientation()
+uint64_t get_drm_effective_orientation()
+{
+	switch ( g_drmModeOrientation )
 	{
-
-			switch ( g_drmModeOrientation )
-		{
-				case PANEL_ORIENTATION_0:
-				return DRM_MODE_ROTATE_0;
-				break;
-
-				case PANEL_ORIENTATION_90:
-				return DRM_MODE_ROTATE_90;
-				break;
-
-				case PANEL_ORIENTATION_180:
-				return DRM_MODE_ROTATE_180;
-				break;
-
-				case PANEL_ORIENTATION_270:
-				return DRM_MODE_ROTATE_270;
-				break;
-
-				case PANEL_ORIENTATION_AUTO:
-				return g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0;
-				break;
-		}
+		case PANEL_ORIENTATION_0:
+			return DRM_MODE_ROTATE_0;
+			break;
+		case PANEL_ORIENTATION_90:
+			return DRM_MODE_ROTATE_90;
+			break;
+		case PANEL_ORIENTATION_180:
+			return DRM_MODE_ROTATE_180;
+			break;
+		case PANEL_ORIENTATION_270:
+			return DRM_MODE_ROTATE_270;
+			break;
+		case PANEL_ORIENTATION_AUTO:
+			return g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0;
+			break;
 	}
+}
+
 /* Prepares an atomic commit without using libliftoff */
 static int
 drm_prepare_basic( struct drm_t *drm, const struct FrameInfo_t *frameInfo )
@@ -1591,13 +1587,9 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 			drm_screen_type screenType = drm_get_screen_type(drm);
 
 		if ( screenType == DRM_SCREEN_TYPE_INTERNAL )
-			
 		{
 			liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", get_drm_effective_orientation());
-
 		}
-
-
 		else
 		{
 			liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? : DRM_MODE_ROTATE_0);
@@ -2198,7 +2190,7 @@ bool drm_update_degamma_lut(struct drm_t *drm)
 	if ( !drm->crtc->has_degamma_lut )
 		return true;
 
-	enum drm_screen_type screen_type = drm->pending.screen_type;		
+	enum drm_screen_type screen_type = drm->pending.screen_type;
 
 	if (drm->pending.color_degamma_exponent[screen_type][0] == drm->current.color_degamma_exponent[screen_type][0] &&
 		drm->pending.color_degamma_exponent[screen_type][1] == drm->current.color_degamma_exponent[screen_type][1] &&

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -245,4 +245,6 @@ drm_screen_type drm_get_screen_type(struct drm_t *drm);
 char *find_drm_node_by_devid(dev_t devid);
 int drm_get_default_refresh(struct drm_t *drm);
 
+uint64_t get_drm_effective_orientation();
+
 extern bool g_bSupportsAsyncFlips;

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -98,7 +98,7 @@ struct fb {
 	uint32_t id;
 	/* Client buffer, if any */
 	struct wlr_buffer *buf;
-	/* A FB is held if it's being used by steamcompmgr 
+	/* A FB is held if it's being used by steamcompmgr
 	 * doesn't need to be atomic as it's only ever
 	 * modified/read from the steamcompmgr thread */
 	int held_refs;
@@ -120,19 +120,19 @@ struct drm_t {
 	std::unordered_map< uint32_t, struct connector > connectors;
 
 	std::map< uint32_t, drmModePropertyRes * > props;
-	
+
 	struct plane *primary;
 	struct crtc *crtc;
 	struct connector *connector;
 	int crtc_index;
 	int kms_in_fence_fd;
 	int kms_out_fence_fd;
-	
+
 	struct wlr_drm_format_set primary_formats;
-	
+
 	drmModeAtomicReq *req;
 	uint32_t flags;
-	
+
 	struct liftoff_device *lo_device;
 	struct liftoff_output *lo_output;
 	struct liftoff_layer *lo_layers[ k_nMaxLayers ];
@@ -170,16 +170,16 @@ struct drm_t {
 	std::vector < uint32_t > fbids_queued;
 	/* FBs currently on screen */
 	std::vector < uint32_t > fbids_on_screen;
-	
+
 	std::unordered_map< uint32_t, struct fb > fb_map;
 	std::mutex fb_map_mutex;
-	
+
 	std::mutex free_queue_lock;
 	std::vector< uint32_t > fbid_unlock_queue;
 	std::vector< uint32_t > fbid_free_queue;
-	
+
 	std::mutex flip_lock;
-	
+
 	std::atomic < uint64_t > flipcount;
 
 	std::atomic < bool > paused;
@@ -206,7 +206,16 @@ enum drm_mode_generation {
 	DRM_MODE_GENERATE_FIXED,
 };
 
+enum g_panel_orientation {
+	PANEL_ORIENTATION_0,	/* NORMAL */
+	PANEL_ORIENTATION_270,	/* RIGHT */
+	PANEL_ORIENTATION_90,	/* LEFT */
+	PANEL_ORIENTATION_180,	/* UPSIDE DOWN */
+	PANEL_ORIENTATION_AUTO,
+};
+
 extern enum drm_mode_generation g_drmModeGeneration;
+extern enum g_panel_orientation g_drmModeOrientation;
 
 bool init_drm(struct drm_t *drm, int width, int height, int refresh);
 void finish_drm(struct drm_t *drm);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,7 +219,7 @@ static enum drm_mode_generation parse_drm_mode_generation(const char *str)
 	}
 }
 
-static enum g_panel_orientation force_orientation (const char *str)
+static enum g_panel_orientation force_orientation(const char *str)
 {
 	if (strcmp(str, "normal") == 0) {
 		return PANEL_ORIENTATION_0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "composite-debug", no_argument, nullptr, 0 },
 	{ "disable-xres", no_argument, nullptr, 'x' },
 	{ "fade-out-duration", required_argument, nullptr, 0 },
+	{ "force-orientation", required_argument, nullptr, 0 },
 
 	{} // keep last
 };
@@ -107,6 +108,7 @@ const char usage[] =
 	"  -e, --steam                    enable Steam integration\n"
 	"  --xwayland-count               create N xwayland servers\n"
 	"  --prefer-vk-device             prefer Vulkan device for compositing (ex: 1002:7300)\n"
+	"  --force-orientation             rotate the display (left, right, normal, upsidedown)\n"
 	"\n"
 	"Nested mode options:\n"
 	"  -o, --nested-unfocused-refresh game refresh rate when unfocused\n"
@@ -213,6 +215,22 @@ static enum drm_mode_generation parse_drm_mode_generation(const char *str)
 		return DRM_MODE_GENERATE_FIXED;
 	} else {
 		fprintf( stderr, "gamescope: invalid value for --generate-drm-mode\n" );
+		exit(1);
+	}
+}
+
+static enum g_panel_orientation force_orientation (const char *str)
+{
+	if (strcmp(str, "normal") == 0) {
+		return PANEL_ORIENTATION_0;
+	} else if (strcmp(str, "right") == 0) {
+		return PANEL_ORIENTATION_270;
+	} else if (strcmp(str, "left") == 0) {
+		return PANEL_ORIENTATION_90;
+	} else if (strcmp(str, "upsidedown") == 0) {
+		return PANEL_ORIENTATION_180;
+	} else {
+		fprintf( stderr, "gamescope: invalid value for --force-orientation\n" );
 		exit(1);
 	}
 }
@@ -371,6 +389,8 @@ int main(int argc, char **argv)
 					g_nTouchClickMode = g_nDefaultTouchClickMode;
 				} else if (strcmp(opt_name, "generate-drm-mode") == 0) {
 					g_drmModeGeneration = parse_drm_mode_generation( optarg );
+				} else if (strcmp(opt_name, "force-orientation") == 0) {
+					g_drmModeOrientation = force_orientation( optarg );
 				} else if (strcmp(opt_name, "sharpness") == 0 ||
 						   strcmp(opt_name, "fsr-sharpness") == 0) {
 					g_upscalerSharpness = atoi( optarg );
@@ -533,7 +553,7 @@ int main(int argc, char **argv)
 		fprintf( stderr, "Failed to initialize wlserver\n" );
 		return 1;
 	}
-	
+
 	gamescope_xwayland_server_t *base_server = wlserver_get_xwayland_server(0);
 
 	setenv("DISPLAY", base_server->get_nested_display_name(), 1);

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1080,9 +1080,7 @@ void wlserver_touchmotion( double x, double y, int touch_id, uint32_t time )
 		double tx = 0;
 		double ty = 0;
 
-		get_effective_touchscreen_orientation(&x, &y);
-		tx = x;
-		ty = y;
+		get_effective_touchscreen_orientation(&tx, &ty);
 
 		tx *= g_nOutputWidth;
 		ty *= g_nOutputHeight;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -68,6 +68,7 @@ struct wlserver_content_override {
 enum wlserver_touch_click_mode g_nDefaultTouchClickMode = WLSERVER_TOUCH_CLICK_LEFT;
 enum wlserver_touch_click_mode g_nTouchClickMode = g_nDefaultTouchClickMode;
 
+
 static struct wl_list pending_surfaces = {0};
 
 static void wlserver_x11_surface_info_set_wlr( struct wlserver_x11_surface_info *surf, struct wlr_surface *wlr_surf );
@@ -1046,18 +1047,38 @@ void wlserver_touchmotion( double x, double y, int touch_id, uint32_t time )
 {
 	if ( wlserver.mouse_focus_surface != NULL )
 	{
-		double tx = g_bRotated ? y : x;
-		double ty = g_bRotated ? 1.0 - x : y;
-
+		double tx = 0;
+		double ty = 0;
+		switch ( g_drmModeOrientation )
+		{
+			case PANEL_ORIENTATION_0:
+				tx = x;
+				ty = y;
+				break;
+			case PANEL_ORIENTATION_90:
+				tx = 1.0 - y;
+				ty = x;
+				break;
+			case PANEL_ORIENTATION_180:
+				tx = 1.0 - x;
+				ty = 1.0 - y;
+				break;
+			case PANEL_ORIENTATION_270:
+				tx = y;
+				ty = 1.0 - x;
+				break;
+			case PANEL_ORIENTATION_AUTO:
+			default: /* we are using the "auto" enum case to ensure compatibility for devices that were already using this*/
+				tx = g_bRotated ? y : x;
+				ty = g_bRotated ? 1.0 - x : y;
+				break;
+		}
 		tx *= g_nOutputWidth;
 		ty *= g_nOutputHeight;
-
 		tx += focusedWindowOffsetX;
 		ty += focusedWindowOffsetY;
-
 		tx *= focusedWindowScaleX;
 		ty *= focusedWindowScaleY;
-
 		wlserver.mouse_surface_cursorx = tx;
 		wlserver.mouse_surface_cursory = ty;
 
@@ -1085,18 +1106,38 @@ void wlserver_touchdown( double x, double y, int touch_id, uint32_t time )
 {
 	if ( wlserver.mouse_focus_surface != NULL )
 	{
-		double tx = g_bRotated ? y : x;
-		double ty = g_bRotated ? 1.0 - x : y;
-
+		double tx = 0;
+		double ty = 0;
+		switch ( g_drmModeOrientation )
+		{
+			case PANEL_ORIENTATION_0:
+				tx = x;
+				ty = y;
+				break;
+			case PANEL_ORIENTATION_90:
+				tx = 1.0 - y;
+				ty = x;
+				break;
+			case PANEL_ORIENTATION_180:
+				tx =  1.0 - x;
+				ty =  1.0 - y;
+				break;
+			case PANEL_ORIENTATION_270:
+				tx = y;
+				ty = 1.0 - x;
+				break;
+			case PANEL_ORIENTATION_AUTO:
+			default: /* we are using the "auto" enum case to ensure compatibility for devices that were already using this*/
+				tx = g_bRotated ? y : x;
+				ty = g_bRotated ? 1.0 - x : y;
+				break;
+		}
 		tx *= g_nOutputWidth;
 		ty *= g_nOutputHeight;
-
 		tx += focusedWindowOffsetX;
 		ty += focusedWindowOffsetY;
-
 		tx *= focusedWindowScaleX;
 		ty *= focusedWindowScaleY;
-
 		wlserver.mouse_surface_cursorx = tx;
 		wlserver.mouse_surface_cursory = ty;
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1044,7 +1044,7 @@ bool wlserver_surface_is_async( struct wlr_surface *surf )
 }
 
 /* Handle the orientation of the touch inputs */
-void get_effective_touchscreen_orientation(double *x, double *y )
+static void apply_touchscreen_orientation(double *x, double *y )
 {
 	double tx = 0;
 	double ty = 0;
@@ -1080,7 +1080,7 @@ void wlserver_touchmotion( double x, double y, int touch_id, uint32_t time )
 		double tx = x;
 		double ty = y;
 
-		get_effective_touchscreen_orientation(&tx, &ty);
+		apply_touchscreen_orientation(&tx, &ty);
 
 		tx *= g_nOutputWidth;
 		ty *= g_nOutputHeight;
@@ -1118,7 +1118,7 @@ void wlserver_touchdown( double x, double y, int touch_id, uint32_t time )
 		double tx = x;
 		double ty = y;
 
-		get_effective_touchscreen_orientation(&tx, &ty);
+		apply_touchscreen_orientation(&tx, &ty);
 
 		tx *= g_nOutputWidth;
 		ty *= g_nOutputHeight;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1044,42 +1044,34 @@ bool wlserver_surface_is_async( struct wlr_surface *surf )
 }
 
 /* Handle the orientation of the touch inputs */
-
 void get_effective_touchscreen_orientation(double *x, double *y )
+{
+	double tx = 0;
+	double ty = 0;
+
+	switch ( get_drm_effective_orientation() )
 	{
-		double tx,ty;
-
-			switch ( g_drmModeOrientation )
-		{
-				case PANEL_ORIENTATION_0:
-				tx = *x;
-				ty = *y;
-				break;
-
-				case PANEL_ORIENTATION_90:
-				tx = 1.0 - *y;
-				ty = *x;
-				break;
-
-				case PANEL_ORIENTATION_180:
-				tx = 1.0 - *x;
-				ty = 1.0 - *y;
-				break;
-
-				case PANEL_ORIENTATION_270:
-				tx = *y;
-				ty = 1.0 - *x;
-				break;
-
-				case PANEL_ORIENTATION_AUTO:
-				tx = g_bRotated ? *y : *x;
-				ty = g_bRotated ? 1.0 - *x : *y;
-				break;
-		}
-
-		*x = tx;
-		*y = ty;
+		case DRM_MODE_ROTATE_0:
+			tx = *x;
+			ty = *y;
+			break;
+		case DRM_MODE_ROTATE_90:
+			tx = 1.0 - *y;
+			ty = *x;
+			break;
+		case DRM_MODE_ROTATE_180:
+			tx = 1.0 - *x;
+			ty = 1.0 - *y;
+			break;
+		case DRM_MODE_ROTATE_270:
+			tx = *y;
+			ty = 1.0 - *x;
+			break;
 	}
+
+	*x = tx;
+	*y = ty;
+}
 
 void wlserver_touchmotion( double x, double y, int touch_id, uint32_t time )
 {
@@ -1125,12 +1117,10 @@ void wlserver_touchdown( double x, double y, int touch_id, uint32_t time )
 {
 	if ( wlserver.mouse_focus_surface != NULL )
 	{
-		double tx = 0;
-		double ty = 0;
+		double tx = x;
+		double ty = y;
 
-		get_effective_touchscreen_orientation(&x, &y);
-		tx = x;
-		ty = y;
+		get_effective_touchscreen_orientation(&tx, &ty);
 
 		tx *= g_nOutputWidth;
 		ty *= g_nOutputHeight;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1077,8 +1077,8 @@ void wlserver_touchmotion( double x, double y, int touch_id, uint32_t time )
 {
 	if ( wlserver.mouse_focus_surface != NULL )
 	{
-		double tx = 0;
-		double ty = 0;
+		double tx = x;
+		double ty = y;
 
 		get_effective_touchscreen_orientation(&tx, &ty);
 


### PR DESCRIPTION
The default behavior without the --force-orientation argument will remain the same to ensure compatibility is not broken. For devices that require Gamescope to be rotated, such as the One Xplayer this is now possible with these changes. 

Ideally in the future we'll want to make use of the kernel quirks, but for now this should be fine.