### PR TITLE
drm: Fix crashes with MST connector removal

### DIFF
--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -37,6 +37,7 @@ extern "C" {
 #include <utility>
 #include <atomic>
 #include <map>
+#include <unordered_map>
 #include <mutex>
 #include <vector>
 
@@ -93,7 +94,7 @@ struct drm_t {
 
 	std::vector< struct plane > planes;
 	std::vector< struct crtc > crtcs;
-	std::map< uint32_t, struct connector > connectors;
+	std::unordered_map< uint32_t, struct connector > connectors;
 
 	std::map< uint32_t, drmModePropertyRes * > props;
 	


### PR DESCRIPTION
## [drm: Use unordered_map for connectors](https://github.com/Plagman/gamescope/commit/4232f1697f8a49b66f1f0abf1040f6ca30bf7f40)
When adding/removing from a normal map, the iterators become undefined, which means drm->connector can change randomly to the wrong connector or garbage memory.

## [drm: Handle race edgecase of MST connector removal](https://github.com/Plagman/gamescope/commit/e1f0e58c83d723471cfd698015714ade0ad6cebb)
Handles the race edgecase where out_of_date gets set, but we are
currently inside of drm_prepare on the steamcompmgr thread.

Additionally, I am not even confident that this udev event for
device changed/removal is even indicative of the connector drm
object destruction.
It seems to not be related at all, I can always hit this path with MST
after waiting a bit after the first modeset then forcing another.
Which shouldn't ever happen if it was indicative of the connector
object destruction.