### PR TITLE
drm: Don't re-zero connector CRTCs we already have zero-ed.

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -491,6 +491,8 @@ static bool refresh_state( drm_t *drm )
 
 		conn->possible_crtcs = get_connector_possible_crtcs(drm, conn->connector);
 
+		conn->current.crtc_id = conn->initial_prop_values["CRTC_ID"];
+
 		drm_log.debugf("found new connector '%s'", conn->name);
 	}
 
@@ -1052,6 +1054,11 @@ int drm_commit(struct drm_t *drm, const struct FrameInfo_t *frameInfo )
 			drm->crtcs[i].pending = drm->crtcs[i].current;
 		}
 
+		for (auto &kv : drm->connectors) {
+			struct connector *conn = &kv.second;
+			conn->pending = conn->current;
+		}
+
 		// Undo refcount if the commit didn't actually work
 		for ( uint32_t i = 0; i < drm->fbids_in_req.size(); i++ )
 		{
@@ -1079,6 +1086,11 @@ int drm_commit(struct drm_t *drm, const struct FrameInfo_t *frameInfo )
 			if ( drm->pending.degamma_lut_id != drm->current.degamma_lut_id )
 				drmModeDestroyPropertyBlob(drm->fd, drm->current.degamma_lut_id);
 			drm->crtcs[i].current = drm->crtcs[i].pending;
+		}
+
+		for (auto &kv : drm->connectors) {
+			struct connector *conn = &kv.second;
+			conn->current = conn->pending;
 		}
 	}
 
@@ -1621,6 +1633,11 @@ int drm_prepare( struct drm_t *drm, bool async, const struct FrameInfo_t *frameI
 
 		for ( auto &kv : drm->connectors ) {
 			struct connector *conn = &kv.second;
+
+			if ( conn->current.crtc_id == 0 )
+				continue;
+
+			conn->pending.crtc_id = 0;
 			int ret = add_connector_property( drm->req, conn, "CRTC_ID", 0 );
 			if (ret < 0)
 				return ret;
@@ -1662,7 +1679,12 @@ int drm_prepare( struct drm_t *drm, bool async, const struct FrameInfo_t *frameI
 
 		// Then enable the one we've picked
 
-		int ret = add_connector_property(drm->req, drm->connector, "CRTC_ID", drm->crtc->id);
+		int ret = 0;
+
+		// Always set our CRTC_ID for the modeset, especially
+		// as we zero-ed it above.
+		drm->connector->pending.crtc_id = drm->crtc->id;
+		ret = add_connector_property(drm->req, drm->connector, "CRTC_ID", drm->crtc->id);
 		if (ret < 0)
 			return ret;
 
@@ -1749,6 +1771,11 @@ void drm_rollback( struct drm_t *drm )
 	for ( size_t i = 0; i < drm->crtcs.size(); i++ )
 	{
 		drm->crtcs[i].pending = drm->crtcs[i].current;
+	}
+
+	for (auto &kv : drm->connectors) {
+		struct connector *conn = &kv.second;
+		conn->pending = conn->current;
 	}
 }
 

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -86,6 +86,10 @@ struct connector {
 	char make_pnp[4];
 	char *make;
 	char *model;
+
+	struct {
+		uint32_t crtc_id;
+	} current, pending;
 };
 
 struct fb {


### PR DESCRIPTION
Fixes an issue where we would use an invalid connector because
the MST connector object got destroyed from our last CRTC set.

This avoids just using it again.