### PR TITLE
ime: add move_{up,down} actions

### DIFF
--- a/protocol/gamescope-input-method.xml
+++ b/protocol/gamescope-input-method.xml
@@ -45,7 +45,7 @@
     it.
   </description>
 
-  <interface name="gamescope_input_method_manager" version="1">
+  <interface name="gamescope_input_method_manager" version="2">
     <description summary="input method manager">
       The input method manager allows the client to become the input method on
       a chosen seat.
@@ -72,7 +72,7 @@
     </request>
   </interface>
 
-  <interface name="gamescope_input_method" version="1">
+  <interface name="gamescope_input_method" version="2">
     <description summary="input method">
       An input method object allows for clients to compose text.
 
@@ -162,6 +162,8 @@
       <entry name="delete_right" value="3" summary="delete one unit after the cursor"/>
       <entry name="move_left" value="4" summary="move the cursor to the left by one unit"/>
       <entry name="move_right" value="5" summary="move the cursor to the right by one unit"/>
+      <entry name="move_up" value="6" since="2" summary="move the cursor up by one unit"/>
+      <entry name="move_down" value="7" since="2" summary="move the cursor down by one unit"/>
     </enum>
 
     <request name="set_action">

--- a/src/ime.cpp
+++ b/src/ime.cpp
@@ -66,7 +66,7 @@ static uint32_t utf8_decode(const char **str_ptr)
 	return ret;
 }
 
-#define IME_MANAGER_VERSION 1
+#define IME_MANAGER_VERSION 2
 
 /* Some clients assume keycodes are coming from evdev and interpret them. Only
  * use keys that would normally produce characters for our emulated events. */
@@ -90,6 +90,8 @@ static std::unordered_map<enum gamescope_input_method_action, struct wlserver_in
 	{ GAMESCOPE_INPUT_METHOD_ACTION_DELETE_RIGHT, { KEY_DELETE, XKB_KEY_Delete } },
 	{ GAMESCOPE_INPUT_METHOD_ACTION_MOVE_LEFT, { KEY_LEFT, XKB_KEY_Left } },
 	{ GAMESCOPE_INPUT_METHOD_ACTION_MOVE_RIGHT, { KEY_RIGHT, XKB_KEY_Right } },
+	{ GAMESCOPE_INPUT_METHOD_ACTION_MOVE_UP, { KEY_UP, XKB_KEY_Up } },
+	{ GAMESCOPE_INPUT_METHOD_ACTION_MOVE_DOWN, { KEY_DOWN, XKB_KEY_Down } },
 };
 
 struct wlserver_input_method {


### PR DESCRIPTION
Closes: https://github.com/Plagman/gamescope/issues/616

Example client patch for [wl-ime-type](https://git.sr.ht/~emersion/wl-ime-type)'s `gamescope` branch:

```diff
diff --git a/main.c b/main.c
index 3db99a283f2f..dd5e5058e5a5 100644
--- a/main.c
+++ b/main.c
@@ -32,7 +32,7 @@ static const struct gamescope_input_method_listener ime_listener = {
 static void registry_handle_global(void *data, struct wl_registry *registry, uint32_t name, const char *iface, uint32_t version)
 {
 	if (strcmp(iface, gamescope_input_method_manager_interface.name) == 0) {
-		ime_manager = wl_registry_bind(registry, name, &gamescope_input_method_manager_interface, 1);
+		ime_manager = wl_registry_bind(registry, name, &gamescope_input_method_manager_interface, 2);
 	} else if (seat == NULL && strcmp(iface, wl_seat_interface.name) == 0) {
 		seat = wl_registry_bind(registry, name, &wl_seat_interface, 1);
 	}
@@ -55,6 +55,10 @@ static enum gamescope_input_method_action parse_action(const char *str)
 		return GAMESCOPE_INPUT_METHOD_ACTION_MOVE_LEFT;
 	} else if (strcmp(str, "move_right") == 0) {
 		return GAMESCOPE_INPUT_METHOD_ACTION_MOVE_RIGHT;
+	} else if (strcmp(str, "move_up") == 0) {
+		return GAMESCOPE_INPUT_METHOD_ACTION_MOVE_UP;
+	} else if (strcmp(str, "move_down") == 0) {
+		return GAMESCOPE_INPUT_METHOD_ACTION_MOVE_DOWN;
 	}
 	return GAMESCOPE_INPUT_METHOD_ACTION_NONE;
 }
diff --git a/protocol/gamescope-input-method.xml b/protocol/gamescope-input-method.xml
index 1d3f1f283f46..856c5e498f99 100644
--- a/protocol/gamescope-input-method.xml
+++ b/protocol/gamescope-input-method.xml
@@ -45,7 +45,7 @@
     it.
   </description>
 
-  <interface name="gamescope_input_method_manager" version="1">
+  <interface name="gamescope_input_method_manager" version="2">
     <description summary="input method manager">
       The input method manager allows the client to become the input method on
       a chosen seat.
@@ -72,7 +72,7 @@
     </request>
   </interface>
 
-  <interface name="gamescope_input_method" version="1">
+  <interface name="gamescope_input_method" version="2">
     <description summary="input method">
       An input method object allows for clients to compose text.
 
@@ -162,6 +162,8 @@
       <entry name="delete_right" value="3" summary="delete one unit after the cursor"/>
       <entry name="move_left" value="4" summary="move the cursor to the left by one unit"/>
       <entry name="move_right" value="5" summary="move the cursor to the right by one unit"/>
+      <entry name="move_up" value="6" since="2" summary="move the cursor up by one unit"/>
+      <entry name="move_down" value="7" since="2" summary="move the cursor down by one unit"/>
     </enum>
 
     <request name="set_action">
```