### PR TITLE
wlserver: Expose base wl_output to non-xwayland server clients

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -624,7 +624,14 @@ static bool filter_global(const struct wl_client *client, const struct wl_global
 		if (server->get_client() == client)
 			return server->get_output() == output;
 	}
-	return false;
+
+	if (wlserver.wlr.xwayland_servers.empty())
+		return false;
+
+	gamescope_xwayland_server_t *server = wlserver.wlr.xwayland_servers[0].get();
+	/* If we aren't an xwayland server, then only expose the first wl_output
+	 * that's associated with from server 0. */
+	return server->get_output() == output;
 }
 
 bool wlsession_init( void ) {


### PR DESCRIPTION
Steam also wants to read the wl_output global itself (outside of X stuff).