### PR TITLE
wlserver: explain why filter_global may need to handle NULL wlr_output

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -616,8 +616,8 @@ static bool filter_global(const struct wl_client *client, const struct wl_global
 	struct wlr_output *output = (struct wlr_output *) wl_global_get_user_data(global);
 	if (!output)
 	{
-		//assert(output);
-		wl_log.errorf("Global %p with interface %s had no userdata! Woah :(", global, wl_output_interface.name);
+		/* Can happen if the output has been destroyed, but the client hasn't
+		 * received the wl_registry.global_remove event yet. */
 		return false;
 	}
 


### PR DESCRIPTION
1. output plugged in, gamescope creates new wlr_output and sends a wl_registry.global event
2. client sees it, sends a wl_registry.bind request
3. output plugged out, gamescope sends a wl_registry.global_remove event and destroys the wlr_output
4. gamescope receives the wl_registry.bind request, but the wlr_output no longer exists
5. client receives the wl_registry.global_remove event