### PR TITLE
build: use hwdata's pkg-config file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,7 @@ cap_dep = dependency('libcap')
 sdl_dep = dependency('SDL2')
 pipewire_dep = dependency('libpipewire-0.3', required: get_option('pipewire'))
 librt_dep = cppc.find_library('rt', required : get_option('pipewire'))
+hwdata_dep = dependency('hwdata')
 
 stb_dep = dependency('stb')
 
@@ -111,6 +112,7 @@ liftoff_dep = dependency(
 
 add_project_arguments(
   '-DHAVE_PIPEWIRE=@0@'.format(pipewire_dep.found().to_int()),
+  '-DHWDATA_PNP_IDS="@0@"'.format(hwdata_dep.get_variable('pkgdatadir') / 'pnp.ids'),
   language: 'cpp',
 )
 

--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -772,8 +772,7 @@ static bool setup_best_connector(struct drm_t *drm, bool force)
 
 void load_pnps(void)
 {
-	// TODO: use hwdata's pkg-config file once they ship one
-	const char *filename = "/usr/share/hwdata/pnp.ids";
+	const char *filename = HWDATA_PNP_IDS;
 	FILE *f = fopen(filename, "r");
 	if (!f) {
 		drm_log.infof("failed to open PNP IDs file at '%s'", filename);


### PR DESCRIPTION
Ensures the system has the proper dependency, and avoids hardcoding the path.

Need to wait for SteamOS to ship hwdata 0.362.