### PR TITLE
Optimizations for pipewire capture

### DIFF
--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <libyuv/convert_from_argb.h>
 
 #include <atomic>
 #include <thread>
@@ -37,10 +38,15 @@ static void destroy_buffer(struct pipewire_buffer *buffer) {
 	assert(buffer->buffer == nullptr);
 
 	switch (buffer->type) {
-	case SPA_DATA_MemFd:
-		munmap(buffer->shm.data, buffer->shm.stride * buffer->video_info.size.height);
+	case SPA_DATA_MemFd: {
+		off_t size = buffer->shm.stride * buffer->video_info.size.height;
+		if (buffer->video_info.format == SPA_VIDEO_FORMAT_NV12) {
+			size += buffer->shm.stride * ((buffer->video_info.size.height + 1) / 2);
+		}
+		munmap(buffer->shm.data, size);
 		close(buffer->shm.fd);
 		break;
+	}
 	case SPA_DATA_DmaBuf:
 		break; // nothing to do
 	default:
@@ -70,25 +76,36 @@ static void calculate_capture_size()
 	}
 }
 
-static std::vector<const struct spa_pod *> build_format_params(struct spa_pod_builder *builder) {
+static void build_format_params(struct spa_pod_builder *builder, spa_video_format format, std::vector<const struct spa_pod *> &params)
+{
 	struct spa_rectangle size = SPA_RECTANGLE(s_nCaptureWidth, s_nCaptureHeight);
 	struct spa_rectangle min_requested_size = { 0, 0 };
 	struct spa_rectangle max_requested_size = { UINT32_MAX, UINT32_MAX };
 	struct spa_fraction framerate = SPA_FRACTION(0, 1);
 	uint64_t modifier = DRM_FORMAT_MOD_LINEAR;
 
-	std::vector<const struct spa_pod *> params;
-
 	struct spa_pod_frame obj_frame, choice_frame;
 	spa_pod_builder_push_object(builder, &obj_frame, SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat);
 	spa_pod_builder_add(builder,
 		SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
 		SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
-		SPA_FORMAT_VIDEO_format, SPA_POD_Id(SPA_VIDEO_FORMAT_BGRx),
+		SPA_FORMAT_VIDEO_format, SPA_POD_Id(format),
 		SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&size),
 		SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&framerate),
 		SPA_FORMAT_VIDEO_requested_size, SPA_POD_CHOICE_RANGE_Rectangle( &min_requested_size, &min_requested_size, &max_requested_size ),
 		0);
+	if (format == SPA_VIDEO_FORMAT_NV12) {
+		spa_pod_builder_add(builder,
+			SPA_FORMAT_VIDEO_colorMatrix, SPA_POD_CHOICE_ENUM_Id(3,
+							SPA_VIDEO_COLOR_MATRIX_BT601,
+							SPA_VIDEO_COLOR_MATRIX_BT601,
+							SPA_VIDEO_COLOR_MATRIX_BT709),
+			SPA_FORMAT_VIDEO_colorRange, SPA_POD_CHOICE_ENUM_Id(3,
+							SPA_VIDEO_COLOR_RANGE_16_235,
+							SPA_VIDEO_COLOR_RANGE_16_235,
+							SPA_VIDEO_COLOR_RANGE_0_255),
+			0);
+	}
 	spa_pod_builder_prop(builder, SPA_FORMAT_VIDEO_modifier, SPA_POD_PROP_FLAG_MANDATORY);
 	spa_pod_builder_push_choice(builder, &choice_frame, SPA_CHOICE_Enum, 0);
 	spa_pod_builder_long(builder, modifier); // default
@@ -96,14 +113,36 @@ static std::vector<const struct spa_pod *> build_format_params(struct spa_pod_bu
 	spa_pod_builder_pop(builder, &choice_frame);
 	params.push_back((const struct spa_pod *) spa_pod_builder_pop(builder, &obj_frame));
 
-	params.push_back((const struct spa_pod *) spa_pod_builder_add_object(builder,
-		SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
+	spa_pod_builder_push_object(builder, &obj_frame, SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat);
+	spa_pod_builder_add(builder,
 		SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
 		SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
-		SPA_FORMAT_VIDEO_format, SPA_POD_Id(SPA_VIDEO_FORMAT_BGRx),
+		SPA_FORMAT_VIDEO_format, SPA_POD_Id(format),
 		SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&size),
 		SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&framerate),
-		SPA_FORMAT_VIDEO_requested_size, SPA_POD_CHOICE_RANGE_Rectangle( &min_requested_size, &min_requested_size, &max_requested_size )));
+		SPA_FORMAT_VIDEO_requested_size, SPA_POD_CHOICE_RANGE_Rectangle( &min_requested_size, &min_requested_size, &max_requested_size ),
+		0);
+	if (format == SPA_VIDEO_FORMAT_NV12) {
+		spa_pod_builder_add(builder,
+			SPA_FORMAT_VIDEO_colorMatrix, SPA_POD_CHOICE_ENUM_Id(3,
+							SPA_VIDEO_COLOR_MATRIX_BT601,
+							SPA_VIDEO_COLOR_MATRIX_BT601,
+							SPA_VIDEO_COLOR_MATRIX_BT709),
+			SPA_FORMAT_VIDEO_colorRange, SPA_POD_CHOICE_ENUM_Id(3,
+							SPA_VIDEO_COLOR_RANGE_16_235,
+							SPA_VIDEO_COLOR_RANGE_16_235,
+							SPA_VIDEO_COLOR_RANGE_0_255),
+			0);
+	}
+	params.push_back((const struct spa_pod *) spa_pod_builder_pop(builder, &obj_frame));
+}
+
+static std::vector<const struct spa_pod *> build_format_params(struct spa_pod_builder *builder)
+{
+	std::vector<const struct spa_pod *> params;
+
+	build_format_params(builder, SPA_VIDEO_FORMAT_BGRx, params);
+	build_format_params(builder, SPA_VIDEO_FORMAT_NV12, params);
 
 	return params;
 }
@@ -157,13 +196,32 @@ static void copy_buffer(struct pipewire_state *state, struct pipewire_buffer *bu
 	case SPA_DATA_MemFd:
 		chunk->offset = 0;
 		chunk->size = state->video_info.size.height * buffer->shm.stride;
+		if (state->video_info.format == SPA_VIDEO_FORMAT_NV12) {
+			chunk->size += ((state->video_info.size.height + 1)/2 * buffer->shm.stride);
+		}
 		chunk->stride = buffer->shm.stride;
 
 		if (!needs_reneg) {
+#if 1
+			if (state->video_info.format == SPA_VIDEO_FORMAT_NV12) {
+				libyuv::ARGBToNV12( (uint8_t *) tex->mappedData(), tex->rowPitch(), buffer->shm.data, buffer->shm.stride, buffer->shm.data + tex->height() * buffer->shm.stride, buffer->shm.stride, tex->width(), tex->height() );
+			} else {
+				int bpp = 4;
+				for (uint32_t i = 0; i < tex->height(); i++) {
+					memcpy(buffer->shm.data + i * buffer->shm.stride, (uint8_t *) tex->mappedData() + i * tex->rowPitch(), bpp * tex->width());
+				}
+			}
+#else
 			int bpp = 4;
-			for (uint32_t i = 0; i < tex->height(); i++) {
+			uint32_t height = tex->height();
+			if (state->video_info.format == SPA_VIDEO_FORMAT_NV12) {
+				bpp = 1;
+				height += (height + 1) / 2;
+			}
+			for (uint32_t i = 0; i < height; i++) {
 				memcpy(buffer->shm.data + i * buffer->shm.stride, (uint8_t *) tex->mappedData() + i * tex->rowPitch(), bpp * tex->width());
 			}
+#endif
 		}
 		break;
 	case SPA_DATA_DmaBuf:
@@ -197,7 +255,7 @@ static void dispatch_nudge(struct pipewire_state *state, int fd)
 	if (s_nCaptureWidth != state->video_info.size.width || s_nCaptureHeight != state->video_info.size.height) {
 		pwr_log.debugf("renegotiating stream params (size: %dx%d)", s_nCaptureWidth, s_nCaptureHeight);
 
-		uint8_t buf[1024];
+		uint8_t buf[4096];
 		struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
 		std::vector<const struct spa_pod *> format_params = build_format_params(&builder);
 		int ret = pw_stream_update_params(state->stream, format_params.data(), format_params.size());
@@ -260,7 +318,6 @@ static void stream_handle_param_changed(void *data, uint32_t id, const struct sp
 		return;
 
 	struct spa_rectangle requested_size = { 0, 0 };
-	int bpp = 4;
 	int ret = spa_format_video_raw_parse_with_requested_size(param, &state->video_info, &requested_size);
 	if (ret < 0) {
 		pwr_log.errorf("spa_format_video_raw_parse failed");
@@ -270,18 +327,25 @@ static void stream_handle_param_changed(void *data, uint32_t id, const struct sp
 	s_nRequestedHeight = requested_size.height;
 	calculate_capture_size();
 
+	int bpp = 4;
+	if (state->video_info.format == SPA_VIDEO_FORMAT_NV12) {
+		bpp = 1;
+	}
 	state->shm_stride = SPA_ROUND_UP_N(state->video_info.size.width * bpp, 4);
 
 	const struct spa_pod_prop *modifier_prop = spa_pod_find_prop(param, nullptr, SPA_FORMAT_VIDEO_modifier);
 	state->dmabuf = modifier_prop != nullptr;
 
-	pwr_log.debugf("format changed (size: %dx%d, dmabuf: %d)", state->video_info.size.width, state->video_info.size.height, state->dmabuf);
+	pwr_log.debugf("format changed (format: %d, size: %dx%d, dmabuf: %d)", state->video_info.format, state->video_info.size.width, state->video_info.size.height, state->dmabuf);
 
 	uint8_t buf[1024];
 	struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
 
 	int buffers = 4;
 	int shm_size = state->shm_stride * state->video_info.size.height;
+	if (state->video_info.format == SPA_VIDEO_FORMAT_NV12) {
+		shm_size += ((state->video_info.size.height + 1) / 2) * state->shm_stride;
+	}
 	int data_type = state->dmabuf ? (1 << SPA_DATA_DmaBuf) : (1 << SPA_DATA_MemFd);
 
 	const struct spa_pod *buffers_param =
@@ -355,7 +419,39 @@ static void stream_handle_add_buffer(void *user_data, struct pw_buffer *pw_buffe
 	bool is_dmabuf = (spa_data->type & (1 << SPA_DATA_DmaBuf)) != 0;
 	bool is_memfd = (spa_data->type & (1 << SPA_DATA_MemFd)) != 0;
 
-	buffer->texture = vulkan_acquire_screenshot_texture(s_nCaptureWidth, s_nCaptureHeight, is_dmabuf);
+	EStreamColorspace colorspace = k_EStreamColorspace_Unknown;
+	if (state->video_info.format == SPA_VIDEO_FORMAT_NV12) {
+		switch (state->video_info.color_matrix) {
+		case SPA_VIDEO_COLOR_MATRIX_BT601:
+			switch (state->video_info.color_range) {
+			case SPA_VIDEO_COLOR_RANGE_16_235:
+				colorspace = k_EStreamColorspace_BT601;
+				break;
+			case SPA_VIDEO_COLOR_RANGE_0_255:
+				colorspace = k_EStreamColorspace_BT601_Full;
+				break;
+			default:
+				break;
+			}
+			break;
+		case SPA_VIDEO_COLOR_MATRIX_BT709:
+			switch (state->video_info.color_range) {
+			case SPA_VIDEO_COLOR_RANGE_16_235:
+				colorspace = k_EStreamColorspace_BT709;
+				break;
+			case SPA_VIDEO_COLOR_RANGE_0_255:
+				colorspace = k_EStreamColorspace_BT709_Full;
+				break;
+			default:
+				break;
+			}
+			break;
+		default:
+			break;
+		}
+	}
+
+	buffer->texture = vulkan_acquire_screenshot_texture(s_nCaptureWidth, s_nCaptureHeight, is_dmabuf, colorspace);
 	assert(buffer->texture != nullptr);
 
 	if (is_dmabuf) {
@@ -384,6 +480,9 @@ static void stream_handle_add_buffer(void *user_data, struct pw_buffer *pw_buffe
 		}
 
 		off_t size = state->shm_stride * state->video_info.size.height;
+		if (state->video_info.format == SPA_VIDEO_FORMAT_NV12) {
+			size += state->shm_stride * ((state->video_info.size.height + 1) / 2);
+		}
 		if (ftruncate(fd, size) != 0) {
 			pwr_log.errorf_errno("ftruncate failed");
 			close(fd);
@@ -545,7 +644,7 @@ bool init_pipewire(void)
 	s_nOutputHeight = g_nOutputHeight;
 	calculate_capture_size();
 
-	uint8_t buf[1024];
+	uint8_t buf[4096];
 	struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
 	std::vector<const struct spa_pod *> format_params = build_format_params(&builder);
 

--- a/src/pipewire_requested_size.hpp
+++ b/src/pipewire_requested_size.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+enum {
+	SPA_FORMAT_VIDEO_requested_size = 0x70000
+};
+
+static inline int
+spa_format_video_raw_parse_with_requested_size(const struct spa_pod *format, struct spa_video_info_raw *info, spa_rectangle *requested_size)
+{
+        return spa_pod_parse_object(format,
+                SPA_TYPE_OBJECT_Format, NULL,
+                SPA_FORMAT_VIDEO_format,                SPA_POD_Id(&info->format),
+                SPA_FORMAT_VIDEO_modifier,              SPA_POD_OPT_Long(&info->modifier),
+                SPA_FORMAT_VIDEO_size,                  SPA_POD_Rectangle(&info->size),
+                SPA_FORMAT_VIDEO_framerate,             SPA_POD_Fraction(&info->framerate),
+                SPA_FORMAT_VIDEO_maxFramerate,          SPA_POD_OPT_Fraction(&info->max_framerate),
+                SPA_FORMAT_VIDEO_views,                 SPA_POD_OPT_Int(&info->views),
+                SPA_FORMAT_VIDEO_interlaceMode,         SPA_POD_OPT_Id(&info->interlace_mode),
+                SPA_FORMAT_VIDEO_pixelAspectRatio,      SPA_POD_OPT_Fraction(&info->pixel_aspect_ratio),
+                SPA_FORMAT_VIDEO_multiviewMode,         SPA_POD_OPT_Id(&info->multiview_mode),
+                SPA_FORMAT_VIDEO_multiviewFlags,        SPA_POD_OPT_Id(&info->multiview_flags),
+                SPA_FORMAT_VIDEO_chromaSite,            SPA_POD_OPT_Id(&info->chroma_site),
+                SPA_FORMAT_VIDEO_colorRange,            SPA_POD_OPT_Id(&info->color_range),
+                SPA_FORMAT_VIDEO_colorMatrix,           SPA_POD_OPT_Id(&info->color_matrix),
+                SPA_FORMAT_VIDEO_transferFunction,      SPA_POD_OPT_Id(&info->transfer_function),
+                SPA_FORMAT_VIDEO_colorPrimaries,        SPA_POD_OPT_Id(&info->color_primaries),
+                SPA_FORMAT_VIDEO_requested_size,        SPA_POD_OPT_Rectangle(requested_size));
+}
+

--- a/src/pipewire_requested_size.hpp
+++ b/src/pipewire_requested_size.hpp
@@ -4,6 +4,10 @@ enum {
 	SPA_FORMAT_VIDEO_requested_size = 0x70000
 };
 
+enum {
+	SPA_META_requested_size_scale = 0x70000
+};
+
 static inline int
 spa_format_video_raw_parse_with_requested_size(const struct spa_pod *format, struct spa_video_info_raw *info, spa_rectangle *requested_size)
 {

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -2908,7 +2908,7 @@ void vulkan_garbage_collect( void )
 	g_device.garbageCollect();
 }
 
-std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable)
+std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable, EStreamColorspace colorspace)
 {
 	for (auto& pScreenshotImage : g_output.pScreenshotImages)
 	{
@@ -2930,7 +2930,7 @@ std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width
 			assert( bSuccess );
 		}
 
-		if (pScreenshotImage.use_count() > 1 || width != pScreenshotImage->width() || height != pScreenshotImage->height())
+		if (pScreenshotImage.use_count() > 1 || width != pScreenshotImage->width() || height != pScreenshotImage->height() /* || colorspace != pScreenshotImage->colorspace() */)
 			continue;
 
 		return pScreenshotImage;

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1617,8 +1617,8 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
 
 void CVulkanCmdBuffer::copyImage(std::shared_ptr<CVulkanTexture> src, std::shared_ptr<CVulkanTexture> dst)
 {
-	assert(src->width() == dst->width());
-	assert(src->height() == dst->height());
+	//assert(src->width() == dst->width());
+	//assert(src->height() == dst->height());
 	m_textureRefs.emplace(src.get(), src);
 	m_textureRefs.emplace(dst.get(), dst);
 	prepareSrcImage(src.get());
@@ -2868,7 +2868,7 @@ void vulkan_garbage_collect( void )
 	g_device.garbageCollect();
 }
 
-std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(bool exportable)
+std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable)
 {
 	for (auto& pScreenshotImage : g_output.pScreenshotImages)
 	{
@@ -2884,12 +2884,12 @@ std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(bool exportabl
 				screenshotImageFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire
 			}
 
-			bool bSuccess = pScreenshotImage->BInit( currentOutputWidth, currentOutputHeight, VulkanFormatToDRM(g_output.outputFormat), screenshotImageFlags );
+			bool bSuccess = pScreenshotImage->BInit( width, height, VulkanFormatToDRM(g_output.outputFormat), screenshotImageFlags );
 
 			assert( bSuccess );
 		}
 
-		if (pScreenshotImage.use_count() > 1)
+		if (pScreenshotImage.use_count() > 1 || width != pScreenshotImage->width() || height != pScreenshotImage->height())
 			continue;
 
 		return pScreenshotImage;

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -229,7 +229,7 @@ std::shared_ptr<CVulkanTexture> vulkan_create_texture_from_wlr_buffer( struct wl
 
 bool vulkan_composite( const struct FrameInfo_t *frameInfo, std::shared_ptr<CVulkanTexture> pScreenshotTexture );
 std::shared_ptr<CVulkanTexture> vulkan_get_last_output_image( void );
-std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable);
+std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable = false, EStreamColorspace colorspace = k_EStreamColorspace_Unknown);
 
 void vulkan_present_to_window( void );
 

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -229,7 +229,7 @@ std::shared_ptr<CVulkanTexture> vulkan_create_texture_from_wlr_buffer( struct wl
 
 bool vulkan_composite( const struct FrameInfo_t *frameInfo, std::shared_ptr<CVulkanTexture> pScreenshotTexture );
 std::shared_ptr<CVulkanTexture> vulkan_get_last_output_image( void );
-std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(bool exportable);
+std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable);
 
 void vulkan_present_to_window( void );
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1880,7 +1880,7 @@ paint_all(bool async)
 #endif
 		if ( bCapture && pCaptureTexture == nullptr )
 		{
-			pCaptureTexture = vulkan_acquire_screenshot_texture(g_nOutputWidth, g_nOutputHeight, false);
+			pCaptureTexture = vulkan_acquire_screenshot_texture(g_nOutputWidth, g_nOutputHeight);
 		}
 
 		bool bResult = vulkan_composite( &frameInfo, pCaptureTexture );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1880,7 +1880,7 @@ paint_all(bool async)
 #endif
 		if ( bCapture && pCaptureTexture == nullptr )
 		{
-			pCaptureTexture = vulkan_acquire_screenshot_texture(false);
+			pCaptureTexture = vulkan_acquire_screenshot_texture(g_nOutputWidth, g_nOutputHeight, false);
 		}
 
 		bool bResult = vulkan_composite( &frameInfo, pCaptureTexture );


### PR DESCRIPTION
These commits extend the pipewire protocol to allow the client to request a maximum capture size and scale the capture down appropriately. Doing the scaling on the capture side is more efficient than doing a separate scaling pass once the buffer is captured.

A follow-up PR will add NV12 capture support.