### PR TITLE
Fix for the SDL / Libinput touch_id deviation. 

### DIFF
--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -8,9 +8,9 @@
 #include <memory>
 #include <mutex>
 #include <map>
+#include <set>
 
 #define WLSERVER_BUTTON_COUNT 4
-#define WLSERVER_TOUCH_COUNT 11 // Ten fingers + nose ought to be enough for anyone
 
 struct _XDisplay;
 struct xwayland_ctx_t;
@@ -94,7 +94,7 @@ struct wlserver_t {
 	double mouse_surface_cursory;
 	
 	bool button_held[ WLSERVER_BUTTON_COUNT ];
-	bool touch_down[ WLSERVER_TOUCH_COUNT ];
+	std::set <uint32_t> touch_down_ids;
 
 	struct {
 		char *name;


### PR DESCRIPTION
SDL touch_ids are not aggressively recycled like libinput. This leads for a bad check to see how many touches are 'down'.  Using a set of touch_ids to keep track so we can remove the deviation.

This issue is a kind of a sleeper as the touch events (only up and down) will fall back to click events of the touch_id is out of bounds. 

https://github.com/Plagman/gamescope/issues/682