### PR TITLE
Add support for grabbing the keyboard

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "nested-unfocused-refresh", required_argument, nullptr, 'o' },
 	{ "borderless", no_argument, nullptr, 'b' },
 	{ "fullscreen", no_argument, nullptr, 'f' },
+	{ "grab", no_argument, nullptr, 'g' },
 	{ "force-grab-cursor", no_argument, nullptr, 0 },
 
 	// embedded mode options
@@ -154,6 +155,7 @@ const char usage[] =
 	"  -o, --nested-unfocused-refresh game refresh rate when unfocused\n"
 	"  -b, --borderless               make the window borderless\n"
 	"  -f, --fullscreen               make the window fullscreen\n"
+	"  -g, --grab                     grab the keyboard\n"
 	"  --force-grab-cursor            always use relative mouse mode instead of flipping dependent on cursor visibility.\n"
 	"\n"
 	"Embedded mode options:\n"
@@ -202,6 +204,7 @@ const char usage[] =
 	"  Super + I                      increase FSR sharpness by 1\n"
 	"  Super + O                      decrease FSR sharpness by 1\n"
 	"  Super + S                      take a screenshot\n"
+	"  Super + G                      toggle keyboard grab\n"
 	"";
 
 std::atomic< bool > g_bRun{true};
@@ -220,6 +223,8 @@ bool g_bFullscreen = false;
 bool g_bForceRelativeMouse = false;
 
 bool g_bIsNested = false;
+
+bool g_bGrabbed = false;
 
 GamescopeUpscaleFilter g_upscaleFilter = GamescopeUpscaleFilter::LINEAR;
 GamescopeUpscaleScaler g_upscaleScaler = GamescopeUpscaleScaler::AUTO;
@@ -450,6 +455,9 @@ int main(int argc, char **argv)
 				break;
 			case 'Y':
 				g_wantedUpscaleFilter = GamescopeUpscaleFilter::NIS;
+				break;
+			case 'g':
+				g_bGrabbed = true;
 				break;
 			case 0: // long options without a short option
 				opt_name = gamescope_options[opt_index].name;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -21,6 +21,8 @@ extern bool g_bOutputHDREnabled;
 
 extern bool g_bFullscreen;
 
+extern bool g_bGrabbed;
+
 enum class GamescopeUpscaleFilter : uint32_t
 {
     LINEAR = 0,

--- a/src/sdlwindow.cpp
+++ b/src/sdlwindow.cpp
@@ -115,6 +115,11 @@ void inputSDLThreadRun( void )
 		nSDLWindowFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
 
+	if ( g_bGrabbed == true )
+	{
+		nSDLWindowFlags |= SDL_WINDOW_KEYBOARD_GRABBED;
+	}
+
 	g_SDLWindow = SDL_CreateWindow( DEFAULT_TITLE,
 							   SDL_WINDOWPOS_UNDEFINED,
 							SDL_WINDOWPOS_UNDEFINED,
@@ -235,6 +240,15 @@ void inputSDLThreadRun( void )
 						case KEY_S:
 							take_screenshot();
 							break;
+						case KEY_G:
+							g_bGrabbed = !g_bGrabbed;
+							SDL_SetWindowKeyboardGrab( g_SDLWindow, g_bGrabbed ? SDL_TRUE : SDL_FALSE );
+							g_bUpdateSDLWindowTitle = true;
+
+							SDL_Event event;
+							event.type = g_unSDLUserEventID + USER_EVENT_TITLE;
+							SDL_PushEvent( &event );
+							break;
 						default:
 							handled = false;
 					}
@@ -293,8 +307,13 @@ void inputSDLThreadRun( void )
 					g_SDLWindowTitleLock.lock();
 					if ( g_bUpdateSDLWindowTitle )
 					{
+						std::string window_title = g_SDLWindowTitle;
 						g_bUpdateSDLWindowTitle = false;
-						SDL_SetWindowTitle( g_SDLWindow, g_SDLWindowTitle.c_str() );
+						if ( g_bGrabbed )
+						{
+							window_title += " (grabbed)";
+						}
+						SDL_SetWindowTitle( g_SDLWindow, window_title.c_str() );
 					}
 					g_SDLWindowTitleLock.unlock();
 				}


### PR DESCRIPTION
Add support to grab the keyboard in nested mode through either a flag (-g/--grab) or a keybinding (Super+G).  I also added " (grabbed)" to the title as an indication to the user when the keyboard is grabbed.

Note: This will NOT work when using XWayland