### PR TITLE
Wait for POLLIN instead of POLLOUT

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -511,7 +511,7 @@ retry:
 	assert( bFound == true );
 
 	gpuvis_trace_begin_ctx_printf( entry.commitID, "wait fence" );
-	struct pollfd fd = { entry.fence, POLLOUT, 0 };
+	struct pollfd fd = { entry.fence, POLLIN, 0 };
 	int ret = poll( &fd, 1, 100 );
 	if ( ret < 0 )
 	{


### PR DESCRIPTION
POLLIN waits for the buffer to be ready for reading, POLLOUT waits for writing.

In gamescope we're reading client buffers, so we need to use POLLIN.

We were using POLLOUT to workaround an amdgpu bug, but that got fixed in kernel 5.15, so shouldn't be necessary anymore.