### PR TITLE
add the ability to use inverse tone mapping on apps that output SDR

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,9 @@ const struct option *gamescope_options = (struct option[]){
 	{ "hdr-enabled", no_argument, nullptr, 0 },
 	{ "hdr-sdr-content-nits", required_argument, nullptr, 0 },
 	{ "hdr-wide-gammut-for-sdr", no_argument, nullptr, 0 },
+	{ "hdr-itm-enable", no_argument, nullptr, 0 },
+	{ "hdr-itm-sdr-nits", required_argument, nullptr, 0 },
+	{ "hdr-itm-target-nits", required_argument, nullptr, 0 },
 	{ "hdr-debug-force-support", no_argument, nullptr, 0 },
 	{ "hdr-debug-force-output", no_argument, nullptr, 0 },
 	{ "hdr-debug-heatmap", no_argument, nullptr, 0 },
@@ -148,7 +151,12 @@ const char usage[] =
 	"  --hdr-enabled                  enable HDR output (needs Gamescope WSI layer enabled for support from clients)\n"
 	"                                 If this is not set, and there is a HDR client, it will be tonemapped SDR.\n"
 	"  --hdr-wide-gammut-for-sdr      treat SDR sRGB content as having Rec.2020 primaries. Makes colors more vivid at cost of 'correctness'.\n"
-	"  --hdr-sdr-content-nits		  set the luminance of SDR content in nits. Default: 400 nits.\n"
+	"  --hdr-sdr-content-nits         set the luminance of SDR content in nits. Default: 400 nits.\n"
+	"  --hdr-itm-enable               enable SDR->HDR inverse tone mapping. only works for SDR input.\n"
+	"  --hdr-itm-sdr-nits             set the luminance of SDR content in nits used as the input for the inverse tone mapping process.\n"
+	"                                 Default: 100 nits, Max: 1000 nits\n"
+	"  --hdr-itm-target-nits          set the target luminace of the inverse tone mapping process.\n"
+	"                                 Default: 1000 nits, Max: 10000 nits\n"
 	"\n"
 	"Nested mode options:\n"
 	"  -o, --nested-unfocused-refresh game refresh rate when unfocused\n"

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3156,6 +3156,9 @@ std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width
 
 float g_flLinearToNits = 400.0f;
 float g_flNitsToLinear = 1.0f / 100.0f;
+bool g_bHDRItmEnable = false;
+float g_flHDRItmSdrNits = 100.f;
+float g_flHDRItmTargetNits = 1000.f;
 
 struct BlitPushData_t
 {
@@ -3168,6 +3171,9 @@ struct BlitPushData_t
 
 	float linearToNits;
 	float nitsToLinear;
+	bool itmEnable;
+	float itmSdrNits;
+	float itmTargetNits;
 
 	explicit BlitPushData_t(const struct FrameInfo_t *frameInfo)
 	{
@@ -3183,6 +3189,9 @@ struct BlitPushData_t
 
 		linearToNits = g_flLinearToNits;
 		nitsToLinear = g_flNitsToLinear;
+		itmEnable = g_bHDRItmEnable;
+		itmSdrNits = g_flHDRItmSdrNits;
+		itmTargetNits = g_flHDRItmTargetNits;
 	}
 
 	explicit BlitPushData_t(float blit_scale) {
@@ -3194,6 +3203,9 @@ struct BlitPushData_t
 
 		linearToNits = g_flLinearToNits;
 		nitsToLinear = g_flNitsToLinear;
+		itmEnable = g_bHDRItmEnable;
+		itmSdrNits = g_flHDRItmSdrNits;
+		itmTargetNits = g_flHDRItmTargetNits;
 	}
 };
 
@@ -3253,6 +3265,9 @@ struct RcasPushData_t
 
     float linearToNits;
     float nitsToLinear;
+    bool itmEnable;
+    float itmSdrNits;
+    float itmTargetNits;
 
 	RcasPushData_t(const struct FrameInfo_t *frameInfo, float sharpness)
 	{
@@ -3266,6 +3281,9 @@ struct RcasPushData_t
 		u_c1 = tmp.x;
 		linearToNits = g_flLinearToNits;
 		nitsToLinear = g_flNitsToLinear;
+		itmEnable = g_bHDRItmEnable;
+		itmSdrNits = g_flHDRItmSdrNits;
+		itmTargetNits = g_flHDRItmTargetNits;
 		for (uint32_t i = 1; i < k_nMaxLayers; i++)
 		{
 			u_scale[i - 1] = frameInfo->layers[i].scale;

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -177,6 +177,7 @@ struct PipelineInfo_t
 	uint32_t colorspaceMask;
 	bool st2084Output;
 	bool forceWideGammut;
+	bool itmEnable;
 
 	bool operator==(const PipelineInfo_t& o) const {
 		return
@@ -187,7 +188,8 @@ struct PipelineInfo_t
 		compositeDebug == o.compositeDebug &&
 		colorspaceMask == o.colorspaceMask &&
 		st2084Output == o.st2084Output &&
-		forceWideGammut == o.forceWideGammut;
+		forceWideGammut == o.forceWideGammut &&
+		itmEnable == o.itmEnable;
 	}
 };
 
@@ -211,6 +213,7 @@ namespace std
 			hash = hash_combine(hash, k.colorspaceMask);
 			hash = hash_combine(hash, k.st2084Output);
 			hash = hash_combine(hash, k.forceWideGammut);
+			hash = hash_combine(hash, k.itmEnable);
 			return hash;
 		}
 	};
@@ -492,7 +495,7 @@ public:
 	bool BInit();
 
 	VkSampler sampler(SamplerState key);
-	VkPipeline pipeline(ShaderType type, uint32_t layerCount = 1, uint32_t ycbcrMask = 0, uint32_t blur_layers = 0, uint32_t colorspace_mask = 0, bool st2084_output = false, bool force_wide_gammut = false);
+	VkPipeline pipeline(ShaderType type, uint32_t layerCount = 1, uint32_t ycbcrMask = 0, uint32_t blur_layers = 0, uint32_t colorspace_mask = 0, bool st2084_output = false, bool force_wide_gammut = false, bool itm_enable = false);
 	int32_t findMemoryType( VkMemoryPropertyFlags properties, uint32_t requiredTypeBits );
 	std::unique_ptr<CVulkanCmdBuffer> commandBuffer();
 	uint64_t submit( std::unique_ptr<CVulkanCmdBuffer> cmdBuf);
@@ -538,7 +541,7 @@ private:
 	bool createPools();
 	bool createShaders();
 	bool createScratchResources();
-	VkPipeline compilePipeline(uint32_t layerCount, uint32_t ycbcrMask, ShaderType type, uint32_t blur_layer_count, uint32_t composite_debug, uint32_t colorspace_mask, bool st2084_output, bool force_wide_gammut);
+	VkPipeline compilePipeline(uint32_t layerCount, uint32_t ycbcrMask, ShaderType type, uint32_t blur_layer_count, uint32_t composite_debug, uint32_t colorspace_mask, bool st2084_output, bool force_wide_gammut, bool itm_enable);
 	void compileAllPipelines();
 	void resetCmdBuffers(uint64_t sequence);
 
@@ -1261,9 +1264,9 @@ VkSampler CVulkanDevice::sampler( SamplerState key )
 	return ret;
 }
 
-VkPipeline CVulkanDevice::compilePipeline(uint32_t layerCount, uint32_t ycbcrMask, ShaderType type, uint32_t blur_layer_count, uint32_t composite_debug, uint32_t colorspace_mask, bool st2084_output, bool force_wide_gammut)
+VkPipeline CVulkanDevice::compilePipeline(uint32_t layerCount, uint32_t ycbcrMask, ShaderType type, uint32_t blur_layer_count, uint32_t composite_debug, uint32_t colorspace_mask, bool st2084_output, bool force_wide_gammut, bool itm_enable)
 {
-	const std::array<VkSpecializationMapEntry, 7> specializationEntries = {{
+	const std::array<VkSpecializationMapEntry, 8> specializationEntries = {{
 		{
 			.constantID = 0,
 			.offset     = sizeof(uint32_t) * 0,
@@ -1301,6 +1304,12 @@ VkPipeline CVulkanDevice::compilePipeline(uint32_t layerCount, uint32_t ycbcrMas
 			.offset     = sizeof(uint32_t) * 6,
 			.size       = sizeof(uint32_t)
 		},
+
+		{
+			.constantID = 7,
+			.offset     = sizeof(uint32_t) * 7,
+			.size       = sizeof(uint32_t)
+		},
 	}};
 
 	struct {
@@ -1311,6 +1320,7 @@ VkPipeline CVulkanDevice::compilePipeline(uint32_t layerCount, uint32_t ycbcrMas
 		uint32_t colorspace_mask;
 		uint32_t st2084_output;
 		uint32_t force_wide_gammut;
+		uint32_t itm_enable;
 	} specializationData = {
 		.layerCount   = layerCount,
 		.ycbcrMask    = ycbcrMask,
@@ -1319,6 +1329,7 @@ VkPipeline CVulkanDevice::compilePipeline(uint32_t layerCount, uint32_t ycbcrMas
 		.colorspace_mask = colorspace_mask,
 		.st2084_output = st2084_output,
 		.force_wide_gammut = force_wide_gammut,
+		.itm_enable = itm_enable,
 	};
 
 	VkSpecializationInfo specializationInfo = {
@@ -1376,7 +1387,7 @@ void CVulkanDevice::compileAllPipelines()
 					if (blur_layers > layerCount)
 						continue;
 
-					VkPipeline newPipeline = compilePipeline(layerCount, ycbcrMask, info.shaderType, blur_layers, info.compositeDebug, info.colorspaceMask, info.st2084Output, info.forceWideGammut);
+					VkPipeline newPipeline = compilePipeline(layerCount, ycbcrMask, info.shaderType, blur_layers, info.compositeDebug, info.colorspaceMask, info.st2084Output, info.forceWideGammut, info.itmEnable);
 					{
 						std::lock_guard<std::mutex> lock(m_pipelineMutex);
 						PipelineInfo_t key = {info.shaderType, layerCount, ycbcrMask, blur_layers, info.compositeDebug};
@@ -1390,14 +1401,14 @@ void CVulkanDevice::compileAllPipelines()
 	}
 }
 
-VkPipeline CVulkanDevice::pipeline(ShaderType type, uint32_t layerCount, uint32_t ycbcrMask, uint32_t blur_layers, uint32_t colorspace_mask, bool st2084_output, bool force_wide_gammut)
+VkPipeline CVulkanDevice::pipeline(ShaderType type, uint32_t layerCount, uint32_t ycbcrMask, uint32_t blur_layers, uint32_t colorspace_mask, bool st2084_output, bool force_wide_gammut, bool itm_enable)
 {
 	std::lock_guard<std::mutex> lock(m_pipelineMutex);
-	PipelineInfo_t key = {type, layerCount, ycbcrMask, blur_layers, g_uCompositeDebug, colorspace_mask, st2084_output, force_wide_gammut};
+	PipelineInfo_t key = {type, layerCount, ycbcrMask, blur_layers, g_uCompositeDebug, colorspace_mask, st2084_output, force_wide_gammut, itm_enable};
 	auto search = m_pipelineMap.find(key);
 	if (search == m_pipelineMap.end())
 	{
-		VkPipeline result = compilePipeline(layerCount, ycbcrMask, type, blur_layers, g_uCompositeDebug, colorspace_mask, st2084_output, force_wide_gammut);
+		VkPipeline result = compilePipeline(layerCount, ycbcrMask, type, blur_layers, g_uCompositeDebug, colorspace_mask, st2084_output, force_wide_gammut, itm_enable);
 		m_pipelineMap[key] = result;
 		return result;
 	}
@@ -3156,7 +3167,6 @@ std::shared_ptr<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width
 
 float g_flLinearToNits = 400.0f;
 float g_flNitsToLinear = 1.0f / 100.0f;
-bool g_bHDRItmEnable = false;
 float g_flHDRItmSdrNits = 100.f;
 float g_flHDRItmTargetNits = 1000.f;
 
@@ -3171,7 +3181,6 @@ struct BlitPushData_t
 
 	float linearToNits;
 	float nitsToLinear;
-	bool itmEnable;
 	float itmSdrNits;
 	float itmTargetNits;
 
@@ -3189,7 +3198,6 @@ struct BlitPushData_t
 
 		linearToNits = g_flLinearToNits;
 		nitsToLinear = g_flNitsToLinear;
-		itmEnable = g_bHDRItmEnable;
 		itmSdrNits = g_flHDRItmSdrNits;
 		itmTargetNits = g_flHDRItmTargetNits;
 	}
@@ -3203,7 +3211,6 @@ struct BlitPushData_t
 
 		linearToNits = g_flLinearToNits;
 		nitsToLinear = g_flNitsToLinear;
-		itmEnable = g_bHDRItmEnable;
 		itmSdrNits = g_flHDRItmSdrNits;
 		itmTargetNits = g_flHDRItmTargetNits;
 	}
@@ -3265,7 +3272,6 @@ struct RcasPushData_t
 
     float linearToNits;
     float nitsToLinear;
-    bool itmEnable;
     float itmSdrNits;
     float itmTargetNits;
 
@@ -3281,7 +3287,6 @@ struct RcasPushData_t
 		u_c1 = tmp.x;
 		linearToNits = g_flLinearToNits;
 		nitsToLinear = g_flNitsToLinear;
-		itmEnable = g_bHDRItmEnable;
 		itmSdrNits = g_flHDRItmSdrNits;
 		itmTargetNits = g_flHDRItmTargetNits;
 		for (uint32_t i = 1; i < k_nMaxLayers; i++)
@@ -3456,7 +3461,7 @@ bool vulkan_composite( const struct FrameInfo_t *frameInfo, std::shared_ptr<CVul
 	}
 	else
 	{
-		cmdBuffer->bindPipeline( g_device.pipeline(SHADER_TYPE_BLIT, frameInfo->layerCount, frameInfo->ycbcrMask(), 0u, frameInfo->colorspaceMask(), g_bOutputHDREnabled, g_bHDRForceWideGammutForSDR));
+		cmdBuffer->bindPipeline( g_device.pipeline(SHADER_TYPE_BLIT, frameInfo->layerCount, frameInfo->ycbcrMask(), 0u, frameInfo->colorspaceMask(), g_bOutputHDREnabled, g_bHDRForceWideGammutForSDR, g_bOutputHDREnabled ? g_bHDRItmEnable : false));
 		bind_all_layers(cmdBuffer.get(), frameInfo);
 		cmdBuffer->bindTarget(compositeImage);
 		cmdBuffer->pushConstants<BlitPushData_t>(frameInfo);

--- a/src/shaders/blit_push_data.h
+++ b/src/shaders/blit_push_data.h
@@ -10,7 +10,6 @@ uniform layers_t {
     // hdr
     float u_linearToNits; // sdr -> hdr
     float u_nitsToLinear; // hdr -> sdr
-    bool u_itmEnable;
     float u_itmSdrNits;
     float u_itmTargetNits;
 };

--- a/src/shaders/blit_push_data.h
+++ b/src/shaders/blit_push_data.h
@@ -10,4 +10,7 @@ uniform layers_t {
     // hdr
     float u_linearToNits; // sdr -> hdr
     float u_nitsToLinear; // hdr -> sdr
+    bool u_itmEnable;
+    float u_itmSdrNits;
+    float u_itmTargetNits;
 };

--- a/src/shaders/colorimetry.h
+++ b/src/shaders/colorimetry.h
@@ -167,4 +167,158 @@ vec3 tonemap(vec3 color) {
     return tonemap_filmic(color);
 }
 
+// Rep. ITU-R BT.2446-1 Table 2-4 (inversed)
+// BT.2446 Method A inverse tone mapping (itm)
+vec3 bt2446a_inverse_tonemapping(
+    vec3  color,
+    float sdr_nits,
+    float target_nits)
+{
+    const vec3 k_bt2020 = vec3(0.262698338956556, 0.678008765772817, 0.0592928952706273);
+    const float k_bt2020_r_helper = 1.47460332208689; // 2 - 2 * 0.262698338956556
+    const float k_bt2020_b_helper = 1.88141420945875; // 2 - 2 * 0.0592928952706273
+
+    //gamma
+    const float inverse_gamma = 2.4f;
+    const float gamma = 1.f / inverse_gamma;
+
+    //RGB->R'G'B' gamma compression
+    color = pow(color, vec3(gamma));
+
+    // Rec. ITU-R BT.2020-2 Table 4
+    //Y'tmo
+    const float y_tmo = dot(color, k_bt2020);
+    //C'b,tmo
+    const float c_b_tmo = (color.b - y_tmo) /
+                          k_bt2020_b_helper;
+    //C'r,tmo
+    const float c_r_tmo = (color.r - y_tmo) /
+                          k_bt2020_r_helper;
+
+    // fast path as per Rep. ITU-R BT.2446-1 Table 4
+    // matches the output of the inversed version for the given input
+    if ((sdr_nits > 99.f && sdr_nits < 101.f) && (target_nits > 999.f && target_nits < 1001.f))
+    //avoid float issues
+    {
+        sdr_nits = 100.f;
+        target_nits = 1000.f;
+
+        const float a1 =  1.8712e-5;
+        const float b1 = -2.7334e-3;
+        const float c1 =  1.3141;
+        const float a2 =  2.8305e-6;
+        const float b2 = -7.4622e-4;
+        const float c2 =  1.2328;
+
+        const float yy_ = 255.0f * y_tmo;
+
+        const float t = 70;
+
+        float e = yy_ <= t ?
+            a1 * pow(yy_, 2.f) + b1 * yy_ + c1 : 
+            a2 * pow(yy_, 2.f) + b2 * yy_ + c2;
+
+        const float y_hdr = pow(yy_, e);
+
+        float s_c = y_tmo > 0.f ?
+            1.075f * (y_hdr / y_tmo) : 
+            1.f;
+
+        const float c_b_hdr = c_b_tmo * s_c;
+        const float c_r_hdr = c_r_tmo * s_c;
+
+        color = vec3(clamp(y_hdr + k_bt2020_r_helper * c_r_hdr, 0.f, 1000.f),
+                     clamp(y_hdr - 0.16455312684366 * c_b_hdr - 0.57135312684366 * c_r_hdr, 0.f, 1000.f),
+                     clamp(y_hdr + k_bt2020_b_helper * c_b_hdr, 0.f, 1000.f));
+        color /= 1000.f;
+    }
+    else
+    {
+        // adjusted luma component (inverse)
+        // get Y'sdr
+        const float y_sdr = y_tmo + max(0.1f * c_r_tmo, 0.f);
+
+        // Tone mapping step 3 (inverse)
+        // get Y'c
+        const float p_sdr = 1 + 32 * pow(
+                                         sdr_nits /
+                                         10000.f
+                                    , gamma);
+        //Y'c
+        const float y_c = log((y_sdr * (p_sdr - 1)) + 1) /
+                          log(p_sdr); //log = ln
+
+        // Tone mapping step 2 (inverse)
+        // get Y'p
+        float y_p = 0.f;
+
+        const float y_p_0 = y_c / 1.0770f;
+        const float y_p_2 = (y_c - 0.5000f) /
+                            0.5000f;
+
+        const float _first = -2.7811f;
+        const float  _sqrt = sqrt(4.83307641 - 4.604 * y_c);
+        const float   _div = -2.302f;
+        const float  y_p_1 = (_first + _sqrt) /
+                             _div;
+
+        if (y_p_0 <= 0.7399f)
+            y_p = y_p_0;
+        else if (y_p_1 > 0.7399f && y_p_1 < 0.9909f)
+            y_p = y_p_1;
+        else if (y_p_2 >= 0.9909f)
+            y_p = y_p_2;
+        else //y_p_1 sometimes (about 0.12% out of the full RGB range)
+             //is less than 0.7399f or more than 0.9909f because of float inaccuracies
+        {
+            //error is small enough (less than 0.001) for this to be OK
+            //ideally you would choose between y_p_0 and y_p_1 if y_p_1 < 0.7399f depending on which is closer to 0.7399f
+            //or between y_p_1 and y_p_2 if y_p_1 > 0.9909f depending on which is closer to 0.9909f
+            y_p = y_p_1;
+
+            //this clamps it to 2 float steps above 0.7399f or 2 float steps below 0.9909f
+            //if (y_p_1 < 0.7399f)
+            //	y_p = 0.7399001f;
+            //else
+            //	y_p = 0.99089986f;
+        }
+
+        // Tone mapping step 1 (inverse)
+        // get Y'
+        const float p_hdr = 1 + 32 * pow(
+                                         target_nits /
+                                         10000.f
+                                    , gamma);
+        //Y'
+        const float y_ = (pow(p_hdr, y_p) - 1) /
+                         (p_hdr - 1);
+
+        // Colour scaling function
+        const float col_scale = y_sdr /
+                                (1.1f * y_);
+
+        // Colour difference signals (inverse) and Luma (inverse)
+        // get R'G'B'
+        color.b = ((c_b_tmo * k_bt2020_b_helper) /
+                  col_scale) + y_;
+        color.r = ((c_r_tmo * k_bt2020_r_helper) /
+                  col_scale) + y_;
+        color.g = (y_ - (k_bt2020.r * color.r + k_bt2020.b * color.b)) /
+                  k_bt2020.g;
+
+        //safety
+        color.r = clamp(color.r, 0.f, 1.f);
+        color.g = clamp(color.g, 0.f, 1.f);
+        color.b = clamp(color.b, 0.f, 1.f);
+    }
+
+    // R'G'B' gamma expansion
+    color = pow(color, vec3(inverse_gamma));
+
+    // map target luminance into 10000 nits
+    color = color * target_nits;
+
+    return color;
+}
+
 #include "heatmap.h"

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -80,11 +80,7 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
             color.rgb = bt2446a_inverse_tonemapping(color.rgb, u_itmSdrNits, u_itmTargetNits);
         }
         if (checkDebugFlag(compositedebug_Heatmap)) {
-            if(c_itmEnable) {
-                color.rgb = hdr_heatmap(color.rgb, c_itmEnable, true, c_st2084Output);
-            } else {
-                color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
-            }
+            color.rgb = hdr_heatmap(color.rgb, c_itmEnable, c_itmEnable, c_st2084Output);
         } else {
             if (!c_itmEnable && c_st2084Output) {
                 color.rgb = linearToNits(color.rgb);

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -50,7 +50,7 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
             color.rgb = hdr_heatmap(color.rgb, true, true, c_st2084Output);
         } else {
             if (!c_st2084Output) {
-                // HDR10 ST2048 is rec2020.
+                // HDR10 ST2084 is rec2020.
                 color.rgb = convert_primaries(color.rgb, rec2020_to_xyz, xyz_to_rec709);
                 color.rgb = nitsToLinear(color.rgb);
                 color.rgb = tonemap(color.rgb);
@@ -75,20 +75,36 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
     } else if (get_layer_colorspace(layerIdx) == colorspace_sRGB) {
         color.rgb = srgbToLinear(color.rgb);
 
+        if(u_itmEnable && c_st2084Output) {
+            color.rgb = convert_primaries(color.rgb, rec709_to_xyz, xyz_to_rec2020);
+            color.rgb = bt2446a_inverse_tonemapping(color.rgb, u_itmSdrNits, u_itmTargetNits);
+        }
         if (checkDebugFlag(compositedebug_Heatmap)) {
-            color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
+            if(u_itmEnable && c_st2084Output) {
+                color.rgb = hdr_heatmap(color.rgb, true, true, c_st2084Output);
+            } else {
+                color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
+            }
         } else {
-            if (c_st2084Output) {
+            if (!u_itmEnable && c_st2084Output) {
                 color.rgb = linearToNits(color.rgb);
                 if (!c_forceWideGammut)
                     color.rgb = convert_primaries(color.rgb, rec709_to_xyz, xyz_to_rec2020);
             }
         }
     } else if (get_layer_colorspace(layerIdx) == colorspace_linear) {
+        if(u_itmEnable && c_st2084Output) {
+            color.rgb = convert_primaries(color.rgb, rec709_to_xyz, xyz_to_rec2020);
+            color.rgb = bt2446a_inverse_tonemapping(color.rgb, u_itmSdrNits, u_itmTargetNits);
+        }
         if (checkDebugFlag(compositedebug_Heatmap)) {
-            color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
+            if(u_itmEnable && c_st2084Output) {
+                color.rgb = hdr_heatmap(color.rgb, true, true, c_st2084Output);
+            } else {
+                color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
+            }
         } else {
-            if (c_st2084Output) {
+            if (!u_itmEnable && c_st2084Output) {
                 color.rgb = linearToNits(color.rgb);
                 if (!c_forceWideGammut)
                     color.rgb = convert_primaries(color.rgb, rec709_to_xyz, xyz_to_rec2020);

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -81,7 +81,7 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
         }
         if (checkDebugFlag(compositedebug_Heatmap)) {
             if(c_itmEnable) {
-                color.rgb = hdr_heatmap(color.rgb, true, true, c_st2084Output);
+                color.rgb = hdr_heatmap(color.rgb, true, true, c_itmEnable);
             } else {
                 color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
             }
@@ -99,7 +99,7 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
         }
         if (checkDebugFlag(compositedebug_Heatmap)) {
             if(c_itmEnable) {
-                color.rgb = hdr_heatmap(color.rgb, true, true, c_st2084Output);
+                color.rgb = hdr_heatmap(color.rgb, true, true, c_itmEnable);
             } else {
                 color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
             }

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -81,7 +81,7 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
         }
         if (checkDebugFlag(compositedebug_Heatmap)) {
             if(c_itmEnable) {
-                color.rgb = hdr_heatmap(color.rgb, true, true, c_itmEnable);
+                color.rgb = hdr_heatmap(color.rgb, c_itmEnable, true, c_st2084Output);
             } else {
                 color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
             }
@@ -99,7 +99,7 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
         }
         if (checkDebugFlag(compositedebug_Heatmap)) {
             if(c_itmEnable) {
-                color.rgb = hdr_heatmap(color.rgb, true, true, c_itmEnable);
+                color.rgb = hdr_heatmap(color.rgb, c_itmEnable, true, c_st2084Output);
             } else {
                 color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
             }

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -75,36 +75,36 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
     } else if (get_layer_colorspace(layerIdx) == colorspace_sRGB) {
         color.rgb = srgbToLinear(color.rgb);
 
-        if(u_itmEnable && c_st2084Output) {
+        if(c_itmEnable) {
             color.rgb = convert_primaries(color.rgb, rec709_to_xyz, xyz_to_rec2020);
             color.rgb = bt2446a_inverse_tonemapping(color.rgb, u_itmSdrNits, u_itmTargetNits);
         }
         if (checkDebugFlag(compositedebug_Heatmap)) {
-            if(u_itmEnable && c_st2084Output) {
+            if(c_itmEnable) {
                 color.rgb = hdr_heatmap(color.rgb, true, true, c_st2084Output);
             } else {
                 color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
             }
         } else {
-            if (!u_itmEnable && c_st2084Output) {
+            if (!c_itmEnable && c_st2084Output) {
                 color.rgb = linearToNits(color.rgb);
                 if (!c_forceWideGammut)
                     color.rgb = convert_primaries(color.rgb, rec709_to_xyz, xyz_to_rec2020);
             }
         }
     } else if (get_layer_colorspace(layerIdx) == colorspace_linear) {
-        if(u_itmEnable && c_st2084Output) {
+        if(c_itmEnable) {
             color.rgb = convert_primaries(color.rgb, rec709_to_xyz, xyz_to_rec2020);
             color.rgb = bt2446a_inverse_tonemapping(color.rgb, u_itmSdrNits, u_itmTargetNits);
         }
         if (checkDebugFlag(compositedebug_Heatmap)) {
-            if(u_itmEnable && c_st2084Output) {
+            if(c_itmEnable) {
                 color.rgb = hdr_heatmap(color.rgb, true, true, c_st2084Output);
             } else {
                 color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
             }
         } else {
-            if (!u_itmEnable && c_st2084Output) {
+            if (!c_itmEnable && c_st2084Output) {
                 color.rgb = linearToNits(color.rgb);
                 if (!c_forceWideGammut)
                     color.rgb = convert_primaries(color.rgb, rec709_to_xyz, xyz_to_rec2020);

--- a/src/shaders/composite.h
+++ b/src/shaders/composite.h
@@ -98,11 +98,7 @@ vec4 sampleLayer(sampler2D layerSampler, uint layerIdx, vec2 uv, bool unnormaliz
             color.rgb = bt2446a_inverse_tonemapping(color.rgb, u_itmSdrNits, u_itmTargetNits);
         }
         if (checkDebugFlag(compositedebug_Heatmap)) {
-            if(c_itmEnable) {
-                color.rgb = hdr_heatmap(color.rgb, c_itmEnable, true, c_st2084Output);
-            } else {
-                color.rgb = hdr_heatmap(color.rgb, false, false, c_st2084Output);
-            }
+            color.rgb = hdr_heatmap(color.rgb, c_itmEnable, c_itmEnable, c_st2084Output);
         } else {
             if (!c_itmEnable && c_st2084Output) {
                 color.rgb = linearToNits(color.rgb);

--- a/src/shaders/cs_composite_rcas.comp
+++ b/src/shaders/cs_composite_rcas.comp
@@ -22,7 +22,6 @@ uniform layers_t {
     // hdr
     float u_linearToNits;
     float u_nitsToLinear;
-    bool u_itmEnable;
     float u_itmSdrNits;
     float u_itmTargetNits;
 };

--- a/src/shaders/cs_composite_rcas.comp
+++ b/src/shaders/cs_composite_rcas.comp
@@ -22,6 +22,9 @@ uniform layers_t {
     // hdr
     float u_linearToNits;
     float u_nitsToLinear;
+    bool u_itmEnable;
+    float u_itmSdrNits;
+    float u_itmTargetNits;
 };
 
 #include "composite.h"

--- a/src/shaders/cs_gaussian_blur_horizontal.comp
+++ b/src/shaders/cs_gaussian_blur_horizontal.comp
@@ -21,7 +21,6 @@ uniform layers_t {
     // hdr
     float u_linearToNits;
     float u_nitsToLinear;
-    bool u_itmEnable;
     float u_itmSdrNits;
     float u_itmTargetNits;
 };

--- a/src/shaders/cs_gaussian_blur_horizontal.comp
+++ b/src/shaders/cs_gaussian_blur_horizontal.comp
@@ -21,6 +21,9 @@ uniform layers_t {
     // hdr
     float u_linearToNits;
     float u_nitsToLinear;
+    bool u_itmEnable;
+    float u_itmSdrNits;
+    float u_itmTargetNits;
 };
 
 #include "composite.h"

--- a/src/shaders/cs_rgb_to_nv12.comp
+++ b/src/shaders/cs_rgb_to_nv12.comp
@@ -17,7 +17,6 @@ layout(
 const uint u_frameId = 0;
 const float u_linearToNits = 400.0f;
 const float u_nitsToLinear = 1.0f / 100.0f;
-const bool u_itmEnable = false;
 const float u_itmSdrNits = 100.f;
 const float u_itmTargetNits = 1000.f;
 

--- a/src/shaders/cs_rgb_to_nv12.comp
+++ b/src/shaders/cs_rgb_to_nv12.comp
@@ -17,6 +17,9 @@ layout(
 const uint u_frameId = 0;
 const float u_linearToNits = 400.0f;
 const float u_nitsToLinear = 1.0f / 100.0f;
+const bool u_itmEnable = false;
+const float u_itmSdrNits = 100.f;
+const float u_itmTargetNits = 1000.f;
 
 layout(push_constant)
 uniform layers_t {

--- a/src/shaders/descriptor_set.h
+++ b/src/shaders/descriptor_set.h
@@ -8,6 +8,7 @@ layout(constant_id = 3) const int  c_blur_layer_count = 0;
 layout(constant_id = 4) const uint c_colorspaceMask = 0;
 layout(constant_id = 5) const bool c_st2084Output = false;
 layout(constant_id = 6) const bool c_forceWideGammut = false;
+layout(constant_id = 7) const bool c_itmEnable = false;
 
 const int colorspace_linear = 0;
 const int colorspace_sRGB = 1;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -97,7 +97,6 @@
 #include "gpuvis_trace_utils.h"
 
 extern float g_flLinearToNits;
-extern bool g_bHDRItmEnable;
 extern float g_flHDRItmSdrNits;
 extern float g_flHDRItmTargetNits;
 
@@ -248,6 +247,7 @@ bool g_bForceHDR10OutputDebug = false;
 bool g_bForceHDRSupportDebug = false;
 bool g_bHDREnabled = false;
 bool g_bHDRForceWideGammutForSDR = false;
+bool g_bHDRItmEnable = false;
 std::pair<uint32_t, uint32_t> g_LastConnectorIdentifier = { 0u, 0u };
 
 struct motif_hints_t

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -97,6 +97,9 @@
 #include "gpuvis_trace_utils.h"
 
 extern float g_flLinearToNits;
+extern bool g_bHDRItmEnable;
+extern float g_flHDRItmSdrNits;
+extern float g_flHDRItmTargetNits;
 
 const uint32_t WS_OVERLAPPED          		= 0x00000000u;
 const uint32_t WS_POPUP               		= 0x80000000u;
@@ -4591,6 +4594,29 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 			g_flLinearToNits = 400.0f;
 		hasRepaint = true;
 	}
+	if ( ev->atom == ctx->atoms.gamescopeHDRItmEnable )
+	{
+		g_bHDRItmEnable = !!get_prop( ctx, ctx->root, ctx->atoms.gamescopeHDRItmEnable, 0 );
+		hasRepaint = true;
+	}
+	if ( ev->atom == ctx->atoms.gamescopeHDRItmSDRNits )
+	{
+		g_flHDRItmSdrNits = get_prop( ctx, ctx->root, ctx->atoms.gamescopeHDRItmSDRNits, 0 );
+		if ( g_flHDRItmSdrNits < 1.f )
+			g_flHDRItmSdrNits = 100.f;
+		else if ( g_flHDRItmSdrNits > 1000.f)
+			g_flHDRItmSdrNits = 1000.f;
+		hasRepaint = true;
+	}
+	if ( ev->atom == ctx->atoms.gamescopeHDRItmTargetNits )
+	{
+		g_flHDRItmTargetNits = get_prop( ctx, ctx->root, ctx->atoms.gamescopeHDRItmTargetNits, 0 );
+		if ( g_flHDRItmTargetNits < 1.f )
+			g_flHDRItmTargetNits = 1000.f;
+		else if ( g_flHDRItmTargetNits > 10000.f)
+			g_flHDRItmTargetNits = 10000.f;
+		hasRepaint = true;
+	}
 	if ( ev->atom == ctx->atoms.gamescopeForceWindowsFullscreen )
 	{
 		ctx->force_windows_fullscreen = !!get_prop( ctx, ctx->root, ctx->atoms.gamescopeForceWindowsFullscreen, 0 );
@@ -5625,6 +5651,9 @@ void init_xwayland_ctx(gamescope_xwayland_server_t *xwayland_server)
 	ctx->atoms.gamescopeHDROnSDRTonemapOperator = XInternAtom( ctx->dpy, "GAMESCOPE_HDR_ON_SDR_TONEMAP_OPERATOR", false );
 	ctx->atoms.gamescopeHDROutputFeedback = XInternAtom( ctx->dpy, "GAMESCOPE_HDR_OUTPUT_FEEDBACK", false );
 	ctx->atoms.gamescopeHDRSDRContentBrightness = XInternAtom( ctx->dpy, "GAMESCOPE_HDR_SDR_CONTENT_BRIGHTNESS", false );
+	ctx->atoms.gamescopeHDRItmEnable = XInternAtom( ctx->dpy, "GAMESCOPE_HDR_ITM_ENABLE", false );
+	ctx->atoms.gamescopeHDRItmSDRNits = XInternAtom( ctx->dpy, "GAMESCOPE_HDR_ITM_SDR_NITS", false );
+	ctx->atoms.gamescopeHDRItmTargetNits = XInternAtom( ctx->dpy, "GAMESCOPE_HDR_ITM_TARGET_NITS", false );
 
 	ctx->atoms.gamescopeForceWindowsFullscreen = XInternAtom( ctx->dpy, "GAMESCOPE_FORCE_WINDOWS_FULLSCREEN", false );
 
@@ -5844,6 +5873,12 @@ steamcompmgr_main(int argc, char **argv)
 					g_bForceHDR10OutputDebug = true;
 				} else if (strcmp(opt_name, "hdr-wide-gammut-for-sdr") == 0) {
 					g_bHDRForceWideGammutForSDR = true;
+				} else if (strcmp(opt_name, "hdr-itm-enable") == 0) {
+					g_bHDRItmEnable = true;
+				} else if (strcmp(opt_name, "hdr-itm-sdr-nits") == 0) {
+					g_flHDRItmSdrNits = atof(optarg);
+				} else if (strcmp(opt_name, "hdr-itm-target-nits") == 0) {
+					g_flHDRItmTargetNits = atof(optarg);
 				}
 				break;
 			case '?':

--- a/src/steamcompmgr.hpp
+++ b/src/steamcompmgr.hpp
@@ -37,6 +37,7 @@ static const uint32_t g_zposOverlay = 3;
 static const uint32_t g_zposCursor = 4;
 
 extern bool g_bHDRForceWideGammutForSDR;
+extern bool g_bHDRItmEnable;
 
 extern EStreamColorspace g_ForcedNV12ColorSpace;
 

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -180,6 +180,9 @@ struct xwayland_ctx_t
 		Atom gamescopeHDROnSDRTonemapOperator;
 		Atom gamescopeHDROutputFeedback;
 		Atom gamescopeHDRSDRContentBrightness;
+		Atom gamescopeHDRItmEnable;
+		Atom gamescopeHDRItmSDRNits;
+		Atom gamescopeHDRItmTargetNits;
 
 		Atom gamescopeForceWindowsFullscreen;
 


### PR DESCRIPTION
adds BT.2446 Method A inverse tone mapping as per §4 Table 2-4 from https://www.itu.int/dms_pub/itu-r/opb/rep/R-REP-BT.2446-1-2021-PDF-E.pdf
makes SDR apps look more like real HDR
has really good results imo
though it can be a bit intense at times