### PR TITLE
Fix openvr dependency name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ dep_x11 = dependency('x11')
 vulkan_dep = dependency('vulkan')
 
 if get_option('enable_openvr_support')
-  openvr_dep = dependency('openvr_api', required : false)
+  openvr_dep = dependency('openvr', required : false)
   if not openvr_dep.found()
     cmake = import('cmake')
     openvr_var = cmake.subproject_options()


### PR DESCRIPTION
This should allow building gamescope against a system installation of openvr.

The pkgconfig file of openvr specifies `openvr` as the name of the dependency: https://github.com/ValveSoftware/openvr/blob/1a0ea26642e517824b66871e6a12280a426cfec3/src/openvr.pc.in#L6