### PR TITLE
build: bump libdisplay-info maximum version

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -28,7 +28,7 @@ wlroots_dep = dependency(
 
 displayinfo_dep = dependency(
   'display-info',
-  version: ['>= 0.0.0', '< 0.1.0'],
+  version: ['>= 0.0.0', '< 0.2.0'],
   fallback: ['libdisplay-info', 'di_dep'],
   default_options: ['default_library=static'],
 )


### PR DESCRIPTION
libdisplay-info 0.1.x still works fine for gamescope. Bump maximum version to allow it.