### PR TITLE
Install layer lib to private directory

### DIFF
--- a/layer/meson.build
+++ b/layer/meson.build
@@ -4,11 +4,12 @@ dep_x11_xcb = dependency('x11-xcb')
 glm_dep = dependency('glm')
 wayland_client = dependency('wayland-client')
 
+out_lib_dir = join_paths(prefix, lib_dir, 'gamescope')
+
 gamescope_wsi_layer = shared_library('VkLayer_FROG_gamescope_wsi', 'VkLayer_FROG_gamescope_wsi.cpp', protocols_client_src,
   dependencies     : [ vkroots_dep, dep_xcb, dep_x11, dep_x11_xcb, glm_dep, wayland_client ],
-  install          : true )
-
-out_lib_dir = join_paths(prefix, lib_dir)
+  install          : true,
+  install_dir      : out_lib_dir )
 
 configure_file(
     input         : 'VkLayer_FROG_gamescope_wsi.json.in',


### PR DESCRIPTION
Installing the Vulkan layer .so to the systems libdir throws of linting tools of classic Linux distributions. Libraries in this folder are usually reserved for actual shared libraries, which is not the case for plugins like Vulkan layers.  Installing it in a subfolder is the correct behavior here (e.g. same is also done in MangoHud [here]()https://github.com/flightlessmango/MangoHud/blob/master/src/meson.build).