### PR TITLE
CVulkanCmdBuffer::dispatch(): VU fix + layout tweak

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1437,8 +1437,10 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
 	insertBarrier();
 
 	VkDescriptorSet descriptorSet = m_device->descriptorSet();
-
-	std::array<VkWriteDescriptorSet, 7> writeDescriptorSets;
+	
+	bool bYcbcr = m_target->isYcbcr();
+	size_t wDescLen = 6 + (bYcbcr ? 1 : 0);
+	VkWriteDescriptorSet writeDescriptorSets[wDescLen];
 	std::array<VkDescriptorImageInfo, VKR_SAMPLER_SLOTS> imageDescriptors = {};
 	std::array<VkDescriptorImageInfo, VKR_SAMPLER_SLOTS> ycbcrImageDescriptors = {};
 	std::array<VkDescriptorImageInfo, VKR_TARGET_SLOTS> targetDescriptors = {};
@@ -1485,18 +1487,21 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
 		.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
 		.pImageInfo = imageDescriptors.data(),
 	};
+	
+	size_t offset = 3;
+	if (bYcbcr) {
+		writeDescriptorSets[++offset] = {
+			.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+			.dstSet = descriptorSet,
+			.dstBinding = 4,
+			.dstArrayElement = 0,
+			.descriptorCount = ycbcrImageDescriptors.size(),
+			.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+			.pImageInfo = ycbcrImageDescriptors.data(),
+		};
+	}
 
-	writeDescriptorSets[4] = {
-		.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-		.dstSet = descriptorSet,
-		.dstBinding = 4,
-		.dstArrayElement = 0,
-		.descriptorCount = ycbcrImageDescriptors.size(),
-		.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-		.pImageInfo = ycbcrImageDescriptors.data(),
-	};
-
-	writeDescriptorSets[5] = {
+	writeDescriptorSets[++offset] = {
 		.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
 		.dstSet = descriptorSet,
 		.dstBinding = 5,
@@ -1506,7 +1511,7 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
 		.pImageInfo = shaperLutDescriptor.data(),
 	};
 
-	writeDescriptorSets[6] = {
+	writeDescriptorSets[++offset] = {
 		.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
 		.dstSet = descriptorSet,
 		.dstBinding = 6,
@@ -1523,8 +1528,8 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
 	for (uint32_t i = 0; i < VKR_SAMPLER_SLOTS; i++)
 	{
 		imageDescriptors[i].sampler = m_device->sampler(m_samplerState[i]);
-		imageDescriptors[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-		ycbcrImageDescriptors[i].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+		imageDescriptors[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+		ycbcrImageDescriptors[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		if (m_boundTextures[i] == nullptr)
 			continue;
 
@@ -1556,7 +1561,7 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
 		lut3DDescriptor[i].imageView = m_lut3D[i] ? m_lut3D[i]->srgbView() : VK_NULL_HANDLE;
 	}
 
-	if (!m_target->isYcbcr())
+	if (!bYcbcr)
 	{
 		targetDescriptors[0].imageView = m_target->srgbView();
 		targetDescriptors[0].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1570,7 +1575,7 @@ void CVulkanCmdBuffer::dispatch(uint32_t x, uint32_t y, uint32_t z)
 		targetDescriptors[1].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 	}
 
-	m_device->vk.UpdateDescriptorSets(m_device->device(), writeDescriptorSets.size(), writeDescriptorSets.data(), 0, nullptr);
+	m_device->vk.UpdateDescriptorSets(m_device->device(), wDescLen, writeDescriptorSets, 0, nullptr);
 
 	m_device->vk.CmdBindDescriptorSets(m_cmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, m_device->pipelineLayout(), 0, 1, &descriptorSet, 0, nullptr);
 


### PR DESCRIPTION
Fix [VUID-VkWriteDescriptorSet-descriptorType-09506](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkWriteDescriptorSet-descriptorType-09506) found by VVL (`vkUpdateDescriptorSets(): pDescriptorWrites[4].pImageInfo[<num>].imageView is VK_NULL_HANDLE. The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, dstSet was allocated with a layout that included immutable samplers for dstBinding, and those samplers enable sampler Y'CBCR conversion, then imageView must not be VK_NULL_HANDLE`)

Switch `{imageDescriptors[i],ycbcrImageDescriptors[i]}.imageLayout` to `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`, since the shaders only read from those two descriptors.
Not sure if the layout change makes much of a difference normally.
However, when compiling gamescope w/ the color management shader code commented out, it seemed like the switch to the read only layout slightly increased the peak gpu utilization reported by `intel_gpu_top` (probably due to higher cache hits). 