### PR TITLE
This is a fix for the volume button key up event not triggering and causing the button to be stuck

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -317,10 +317,10 @@ static void wlserver_handle_key(struct wl_listener *listener, void *data)
 		struct wlr_surface *new_kb_surf = steamcompmgr_get_server_input_surface( 0 );
 		if ( new_kb_surf )
 		{
-			wlserver_keyboardfocus( new_kb_surf, false );
+			wlserver_keyboardfocus( new_kb_surf, false, true );
 			wlr_seat_set_keyboard( wlserver.wlr.seat, keyboard->wlr );
 			wlr_seat_keyboard_notify_key( wlserver.wlr.seat, event->time_msec, event->keycode, event->state );
-			wlserver_keyboardfocus( old_kb_surf, false );
+			wlserver_keyboardfocus( old_kb_surf, false, false );
 			return;
 		}
 	}
@@ -2005,7 +2005,7 @@ void wlserver_shutdown()
     }
 }
 
-void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain )
+void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain, bool shouldNotifyKeyboardEnter )
 {
 	assert( wlserver_is_lock_held() );
 
@@ -2022,11 +2022,13 @@ void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain )
 	assert( wlserver.wlr.virtual_keyboard_device != nullptr );
 	wlr_seat_set_keyboard( wlserver.wlr.seat, wlserver.wlr.virtual_keyboard_device );
 
-	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard( wlserver.wlr.seat );
-	if ( keyboard == nullptr )
-		wlr_seat_keyboard_notify_enter( wlserver.wlr.seat, surface, nullptr, 0, nullptr);
-	else
-		wlr_seat_keyboard_notify_enter( wlserver.wlr.seat, surface, keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
+	if (shouldNotifyKeyboardEnter) {
+		struct wlr_keyboard *keyboard = wlr_seat_get_keyboard( wlserver.wlr.seat );
+		if ( keyboard == nullptr )
+			wlr_seat_keyboard_notify_enter( wlserver.wlr.seat, surface, nullptr, 0, nullptr);
+		else
+			wlr_seat_keyboard_notify_enter( wlserver.wlr.seat, surface, keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
+	}
 
 	wlserver.kb_focus_surface = surface;
 

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -231,7 +231,7 @@ void wlserver_lock(void);
 void wlserver_unlock(bool flush = true);
 bool wlserver_is_lock_held(void);
 
-void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain = true );
+void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain = true, bool shouldNotifyKeyboardEnter = true );
 void wlserver_key( uint32_t key, bool press, uint32_t time );
 
 void wlserver_mousefocus( struct wlr_surface *wlrsurface, int x = 0, int y = 0 );


### PR DESCRIPTION
When you start a game session and the main window becomes an overlay, if you press the volume button, the press event is sent but the release event is never sent even upon re-repressing the button. This fix addresses that issue.