### PR TITLE
build: Add option for scripting support, fix compiler errors if disabled

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,5 +6,6 @@ option('avif_screenshots',           type: 'feature', description: 'Support for 
 option('input_emulation' ,           type: 'feature', description: 'Support for XTest/Input Emulation with libei')
 option('enable_gamescope',           type : 'boolean', value : true, description: 'Build Gamescope executable')
 option('enable_gamescope_wsi_layer', type : 'boolean', value : true, description: 'Build Gamescope layer')
+option('enable_gamescope_scripting', type : 'boolean', value : true, description: 'Gamescope Lua scripting support')
 option('enable_openvr_support',      type : 'boolean', value : true, description: 'OpenVR Integrations')
 option('benchmark', type: 'feature', description: 'Benchmark tools')

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2301,6 +2301,7 @@ namespace gamescope
 		m_Mutable.ValidDynamicRefreshRates.clear();
 		m_Mutable.fnDynamicModeGenerator = nullptr;
 		{
+#if HAVE_SCRIPTING
 			CScriptScopedLock script;
 
 			auto oKnownDisplay = script.Manager().Gamescope().Config.LookupDisplay( script, m_Mutable.szMakePNP, pProduct->product, m_Mutable.szModel, m_Mutable.szDataString );
@@ -2400,6 +2401,7 @@ namespace gamescope
 				}
 			}
 			else
+#endif
 			{
 				// Unknown display, see if there are any other refresh rates in the EDID we can get.
 				if ( GetScreenType() == GAMESCOPE_SCREEN_TYPE_INTERNAL || cv_drm_allow_dynamic_modes_for_external_display )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -869,10 +869,12 @@ int main(int argc, char **argv)
 		fprintf( stderr, "Tracing is enabled\n");
 	}
 
+#if HAVE_SCRIPTING
 	{
 		gamescope::CScriptScopedLock script;
 		script.Manager().RunDefaultScripts();
 	}
+#endif
 
 	XInitThreads();
 	g_mainThread = pthread_self();

--- a/src/meson.build
+++ b/src/meson.build
@@ -100,7 +100,6 @@ src = [
   'Utils/TempFiles.cpp',
   'Utils/Version.cpp',
   'Utils/Process.cpp',
-  'Script/Script.cpp',
   'BufferMemo.cpp',
   'steamcompmgr.cpp',
   'convar.cpp',
@@ -149,7 +148,11 @@ gamescope_cpp_args += '-DHAVE_SDL2=@0@'.format(sdl2_dep.found().to_int())
 gamescope_cpp_args += '-DHAVE_AVIF=@0@'.format(avif_dep.found().to_int())
 gamescope_cpp_args += '-DHAVE_LIBCAP=@0@'.format(cap_dep.found().to_int())
 gamescope_cpp_args += '-DHAVE_LIBEIS=@0@'.format(eis_dep.found().to_int())
-gamescope_cpp_args += '-DHAVE_SCRIPTING=1'
+
+if get_option('enable_gamescope_scripting')
+  gamescope_cpp_args += '-DHAVE_SCRIPTING=1'
+  src += ['Script/Script.cpp']
+endif
 
 src += spirv_shaders
 src += protocols_server_src

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8972,11 +8972,12 @@ steamcompmgr_main(int argc, char **argv)
 			hasRepaint = false;
 			hasRepaintNonBasePlane = false;
 			nIgnoredOverlayRepaints = 0;
-
+#if HAVE_SCRIPTING
 			{
 				gamescope::CScriptScopedLock script;
 				script.Manager().CallHook( "OnPostPaint" );
 			}
+#endif
 		}
 
 		if ( bIsVBlankFromTimer )


### PR DESCRIPTION
`HAVE_SCRIPTING` define exists in meson but is not configurable. This adds the option to disable it via meson.

Some scripting related code is already hidden behind the define but not all. Fixes the remaining spots that would not compile with it disabled.