### PR TITLE
script: Fix documentation for local scripts path

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,7 +15,7 @@ Scripts ending in `.lua` are executed recursively in alphabetical order from the
  - `/etc/gamescope`
  - `$XDG_CONFIG_DIR/gamescope`
 
-You can develop easily without overriding your installation by setting `script_use_local_scripts` which will eliminate `/usr/share/gamescope` and `/etc/gamescope` from being read, and instead read from `../config` of where Gamescope is run instead of those.
+You can develop easily without overriding your installation by setting `script_use_local_scripts` which will eliminate `/usr/share/gamescope` and `/etc/gamescope` from being read, and instead read from `../scripts` of where Gamescope is run instead of those.
 
 When errors are encountered, it will simply output that to the terminal. There is no visual indicator of this currently.
 

--- a/src/Script/Script.cpp
+++ b/src/Script/Script.cpp
@@ -15,7 +15,7 @@ namespace gamescope
     static LogScope s_ScriptLog{ "script" }; 
     static LogScope s_ScriptMgrLog{ "scriptmgr" };
 
-    static ConVar<bool> cv_script_use_local_scripts{ "script_use_local_scripts", false, "Whether or not to use the local scripts (../config) as opposed to the ones in /etc/gamescope.d" };
+    static ConVar<bool> cv_script_use_local_scripts{ "script_use_local_scripts", false, "Whether or not to use the local scripts (../scripts) as opposed to the ones in /etc/gamescope.d" };
     static ConVar<bool> cv_script_use_user_scripts{ "script_use_user_scripts", true, "Whether or not to use user config scripts ($XDG_CONFIG_DIR/gamescope) at all." };
 
     static std::string_view GetConfigDir()


### PR DESCRIPTION
Corrects the path for local scripts in documentation strings.

See `cv_script_use_local_scripts` usage in `CScriptManager::RunDefaultScripts`.