### PR TITLE
Add cursor_sensitivity option and support for update via gamescopectl

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,8 +296,8 @@ bool g_bForceRelativeMouse = false;
 
 bool g_bGrabbed = false;
 
-float g_mouseSensitivity = 1.0;
-float g_cursorSensitivity = 1.0;
+gamescope::ConVar<float> cv_mouse_sensitivity("mouse_sensitivity", 1.0f, "Mouse movement multiplier");
+gamescope::ConVar<float> cv_cursor_sensitivity("cursor_sensitivity", 1.0f, "Cursor movement multiplier");
 
 GamescopeUpscaleFilter g_upscaleFilter = GamescopeUpscaleFilter::LINEAR;
 GamescopeUpscaleScaler g_upscaleScaler = GamescopeUpscaleScaler::AUTO;
@@ -754,7 +754,7 @@ int main(int argc, char **argv)
 				g_bGrabbed = true;
 				break;
 			case 's':
-				g_mouseSensitivity = parse_float( optarg, "mouse-sensitivity" );
+				cv_mouse_sensitivity = parse_float( optarg, "mouse-sensitivity" );
 				break;
 			case 'e':
 				steamMode = true;
@@ -812,7 +812,7 @@ int main(int argc, char **argv)
 				} else if (strcmp(opt_name, "cursor-scale-height") == 0) {
 					g_nCursorScaleHeight = parse_integer(optarg, opt_name);
 				} else if (strcmp(opt_name, "cursor-sensitivity") == 0) {
-					g_cursorSensitivity = parse_float(optarg, opt_name);
+					cv_cursor_sensitivity = parse_float(optarg, opt_name);
 				} else if (strcmp(opt_name, "mangoapp") == 0) {
 					g_bLaunchMangoapp = true;
 				} else if (strcmp(opt_name, "virtual-connector-strategy") == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,6 +118,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "cursor", required_argument, nullptr, 0 },
 	{ "cursor-hotspot", required_argument, nullptr, 0 },
 	{ "cursor-scale-height", required_argument, nullptr, 0 },
+	{ "cursor-sensitivity", required_argument, nullptr, 0 },
 	{ "virtual-connector-strategy", required_argument, nullptr, 0 },
 	{ "ready-fd", required_argument, nullptr, 'R' },
 	{ "stats-path", required_argument, nullptr, 'T' },
@@ -186,6 +187,7 @@ const char usage[] =
 	"                                     headless => use headless backend (no window, no DRM output)\n"
 	"                                     wayland => use Wayland backend\n"
 	"  --cursor                       path to default cursor image\n"
+	"  --cursor-sensitivity           multiply mouse cursor movement by given decimal number\n"
 	"  -R, --ready-fd                 notify FD when ready\n"
 	"  --rt                           Use realtime scheduling\n"
 	"  -T, --stats-path               write statistics to path\n"
@@ -295,6 +297,7 @@ bool g_bForceRelativeMouse = false;
 bool g_bGrabbed = false;
 
 float g_mouseSensitivity = 1.0;
+float g_cursorSensitivity = 1.0;
 
 GamescopeUpscaleFilter g_upscaleFilter = GamescopeUpscaleFilter::LINEAR;
 GamescopeUpscaleScaler g_upscaleScaler = GamescopeUpscaleScaler::AUTO;
@@ -808,6 +811,8 @@ int main(int argc, char **argv)
 					eCurrentBackend = parse_backend_name( optarg );
 				} else if (strcmp(opt_name, "cursor-scale-height") == 0) {
 					g_nCursorScaleHeight = parse_integer(optarg, opt_name);
+				} else if (strcmp(opt_name, "cursor-sensitivity") == 0) {
+					g_cursorSensitivity = parse_float(optarg, opt_name);
 				} else if (strcmp(opt_name, "mangoapp") == 0) {
 					g_bLaunchMangoapp = true;
 				} else if (strcmp(opt_name, "virtual-connector-strategy") == 0) {

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -27,6 +27,7 @@ extern bool g_bFullscreen;
 extern bool g_bGrabbed;
 
 extern float g_mouseSensitivity;
+extern float g_cursorSensitivity;
 extern const char *g_sOutputName;
 
 enum class GamescopeUpscaleFilter : uint32_t

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -4,6 +4,8 @@
 
 #include <atomic>
 
+#include <convar.h>
+
 extern const char *gamescope_optstring;
 extern const struct option *gamescope_options;
 
@@ -26,8 +28,8 @@ extern bool g_bFullscreen;
 
 extern bool g_bGrabbed;
 
-extern float g_mouseSensitivity;
-extern float g_cursorSensitivity;
+extern gamescope::ConVar<float> cv_mouse_sensitivity;
+extern gamescope::ConVar<float> cv_cursor_sensitivity;
 extern const char *g_sOutputName;
 
 enum class GamescopeUpscaleFilter : uint32_t

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2458,8 +2458,8 @@ void wlserver_mousemotion( double dx, double dy, uint32_t time )
 {
 	assert( wlserver_is_lock_held() );
 
-	dx *= g_mouseSensitivity;
-	dy *= g_mouseSensitivity;
+	dx *= float(cv_mouse_sensitivity);
+	dy *= float(cv_mouse_sensitivity);
 
 	wlserver_perform_rel_pointer_motion( dx, dy );
 
@@ -2472,8 +2472,8 @@ void wlserver_mousemotion( double dx, double dy, uint32_t time )
 	wlserver.ulLastMovedCursorTime = get_time_in_nanos();
 	wlserver.bCursorHidden = !wlserver.bCursorHasImage;
 
-	wlserver.mouse_surface_cursorx += dx * g_cursorSensitivity;
-	wlserver.mouse_surface_cursory += dy * g_cursorSensitivity;
+	wlserver.mouse_surface_cursorx += dx * float(cv_cursor_sensitivity);
+	wlserver.mouse_surface_cursory += dy * float(cv_cursor_sensitivity);
 
 	wlserver_clampcursor();
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2472,8 +2472,8 @@ void wlserver_mousemotion( double dx, double dy, uint32_t time )
 	wlserver.ulLastMovedCursorTime = get_time_in_nanos();
 	wlserver.bCursorHidden = !wlserver.bCursorHasImage;
 
-	wlserver.mouse_surface_cursorx += dx;
-	wlserver.mouse_surface_cursory += dy;
+	wlserver.mouse_surface_cursorx += dx * g_cursorSensitivity;
+	wlserver.mouse_surface_cursory += dy * g_cursorSensitivity;
 
 	wlserver_clampcursor();
 


### PR DESCRIPTION
Added a separate `--cursor_sensitivity` option to change cursor speed without effecting raw mouse sensitivity
This mainly to help match the cursor sensitivity of `gamescope` with the primary DE.

Converted both mouse and cursor sensitivity into `gamescope::ConVar` to allow adjustments via `gamescopectl`.