### PR TITLE
rendervulkan: bump pScreenshotImages to 6 again (partially reverts 24bdce9)

### DIFF
--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -537,7 +537,7 @@ struct VulkanOutput_t
 	uint32_t uOutputFormat = DRM_FORMAT_INVALID;
 	uint32_t uOutputFormatOverlay = DRM_FORMAT_INVALID;
 
-	std::array<gamescope::OwningRc<CVulkanTexture>, 2> pScreenshotImages;
+	std::array<gamescope::OwningRc<CVulkanTexture>, 6> pScreenshotImages;
 
 	// NIS and FSR
 	gamescope::OwningRc<CVulkanTexture> tmpOutput;


### PR DESCRIPTION
This is to account for Steam settings that allow restricting the maximum game recording video height to 480px, 720px, 800px, 1080px, 1200px or 1440px.

On a LCD Steam Deck with a vertical screen resolution of 800px, we need at least 3 textures (to capture at 480px, 720px or 800px). The previous default of 2 textures would trigger a crash when recording a video after cycling through all three possible maximum heights in the settings.