### PR TITLE
steamcompmgr: render dropdowns with negative coordinates, provided they are partially visible

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3354,7 +3354,8 @@ static bool is_good_override_candidate( steamcompmgr_win_t *override, steamcompm
 	if ( !focus )
 		return false;
 
-	return override != focus && override->GetGeometry().nX >= 0 && override->GetGeometry().nY >= 0;
+	auto rect = override->GetGeometry();
+	return override != focus && (rect.nX + rect.nWidth) > 0 && (rect.nY + rect.nHeight) > 0;
 } 
 
 static bool


### PR DESCRIPTION
The previous condition (strictly positive coordinates) was too strict, it resulted in tall dropdowns not being rendered because they would have a slightly negative Y coordinate.

An instance of this problem could be observed with the account creation screen of Final Fantasy XIV Online (when using the webview2 launcher), where the 'month' dropdown would be displayed correctly (as all 13 entries fitted vertically), but the 'day' and 'year' dropdowns wouldn't be rendered because they were taller, and their position ended up with a slightly negative Y coordinate.