### PR TITLE
wlserver: Implement keyboard input filtering

### DIFF
--- a/src/main.hpp
+++ b/src/main.hpp
@@ -3,11 +3,19 @@
 #include <getopt.h>
 
 #include <atomic>
+#include <vector>
 
 extern const char *gamescope_optstring;
 extern const struct option *gamescope_options;
 
 extern std::atomic< bool > g_bRun;
+
+typedef struct {
+    uint32_t start;
+    uint32_t end;
+} filter_range;
+
+extern std::vector< filter_range > g_keyboardFilterRange;
 
 extern int g_nNestedWidth;
 extern int g_nNestedHeight;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2247,6 +2247,16 @@ bool wlserver_process_hotkeys( wlr_keyboard *keyboard, uint32_t key, bool press 
 
 void wlserver_key( uint32_t key, bool press, uint32_t time )
 {
+	if (g_keyboardFilterRange.size() != 0) {
+		bool should_continue = false;
+		for (auto filter: g_keyboardFilterRange) {
+			if (key >= filter.start && key <= filter.end) {
+				should_continue = true;
+			}
+		}
+		if (!should_continue) return;
+	}
+
 	assert( wlserver_is_lock_held() );
 
 	wlr_keyboard *keyboard = wlserver.wlr.virtual_keyboard_device;


### PR DESCRIPTION
Allow for subset of keyboard keys to be processed by gamescope, and thus client applications. This commit adds a `--keyboard-filter` option that allows users to specify a subset of keyboard keys to be passed to client applications. This is primarily useful when combined with #1897 allowing for a helper program to pass partial keyboard implementations to each window, but can also be useful in normal operation to avoid mixing keybinds with clients and the main compositor. This option takes a list of values or ranges, including the example of ```--keyboard-filter 17,30-32,57``` to pass only the keys wasd and space, although this may not be a usual use case.