### PR TITLE
WaylandBackend: fix crash when switching TTYs

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -2389,6 +2389,9 @@ namespace gamescope
     {
         bool bUseHostCursor = false;
 
+        if ( !m_pPointer )
+            return;
+
         if ( cv_wayland_mouse_warp_without_keyboard_focus )
             bUseHostCursor = m_pRelativePointer && !m_bKeyboardEntered && m_pDefaultCursorSurface;
         else


### PR DESCRIPTION
This PR fixes a crash in `UpdateCursor()` that occurs when switching TTYs due to m_pPointer (a `wl_pointer*`) being null.

This can happen when the seat loses pointer capability, such as when switching to another TTY on Sway.

The fix is just to ignore the cursor update with an early return when there is no `wl_pointer`, same as `SetRelativeMouseMode()` already does.

This PR makes it possible to use screen lockers that switch TTY or use multiple sessions on different TTYs while gamescope is active without the whole gamescope session crashing.

Fixes #1920.