### PR TITLE
feat(pipewire): Add PipeWire source texture selection and fixed capture dimensions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,6 +150,10 @@ const struct option *gamescope_options = (struct option[]){
 
 	// Steam Deck options
 	{ "mura-map", required_argument, nullptr, 0 },
+	// PipeWire options
+	{ "pipewire-source", required_argument, nullptr, 0 },
+	{ "pipewire-width", required_argument, nullptr, 0 },
+	{ "pipewire-height", required_argument, nullptr, 0 },
 
 	{} // keep last
 };
@@ -209,6 +213,9 @@ const char usage[] =
 	"  --framerate-limit              Set a simple framerate limit. Used as a divisor of the refresh rate, rounds down eg 60 / 59 -> 60fps, 60 / 25 -> 30fps. Default: 0, disabled.\n"
 	"  --mangoapp                     Launch with the mangoapp (mangohud) performance overlay enabled. You should use this instead of using mangohud on the game or gamescope.\n"
 	"  --adaptive-sync                Enable adaptive sync if available (variable rate refresh)\n"
+	"  --pipewire-source              Select PipeWire source: 'output' (default) or 'source' (unscaled source texture).\n"
+	"  --pipewire-width               Fixed width for PipeWire capture (overrides output width).\n"
+	"  --pipewire-height              Fixed height for PipeWire capture (overrides output height).\n"
 	"\n"
 	"Nested mode options:\n"
 	"  -o, --nested-unfocused-refresh game refresh rate when unfocused\n"
@@ -680,6 +687,9 @@ static void UpdateCompatEnvVars()
 int g_nPreferredOutputWidth = 0;
 int g_nPreferredOutputHeight = 0;
 bool g_bExposeWayland = false;
+PipeWireSourceMode g_ePipewireSourceMode = PipeWireSourceMode::Output;
+int g_nPipewireWidth = 0;
+int g_nPipewireHeight = 0;
 const char *g_sOutputName = nullptr;
 bool g_bDebugLayers = false;
 bool g_bForceDisableColorMgmt = false;
@@ -821,6 +831,19 @@ int main(int argc, char **argv)
 								
 						}
 					}
+				} else if (strcmp(opt_name, "pipewire-source") == 0) {
+					if (strcmp(optarg, "source") == 0) {
+						g_ePipewireSourceMode = PipeWireSourceMode::Source;
+					} else if (strcmp(optarg, "output") == 0) {
+						g_ePipewireSourceMode = PipeWireSourceMode::Output;
+					} else {
+						fprintf( stderr, "gamescope: invalid pipewire source mode: %s\n", optarg );
+						return 1;
+					}
+				} else if (strcmp(opt_name, "pipewire-width") == 0) {
+					g_nPipewireWidth = atoi(optarg);
+				} else if (strcmp(opt_name, "pipewire-height") == 0) {
+					g_nPipewireHeight = atoi(optarg);
 				}
 				break;
 			case '?':

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -73,3 +73,12 @@ extern int g_nXWaylandCount;
 extern uint32_t g_preferVendorID;
 extern uint32_t g_preferDeviceID;
 
+enum class PipeWireSourceMode {
+	Output,
+	Source
+};
+
+extern PipeWireSourceMode g_ePipewireSourceMode;
+extern int g_nPipewireWidth;
+extern int g_nPipewireHeight;
+

--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -52,7 +52,7 @@ static void destroy_buffer(struct pipewire_buffer *buffer) {
 		break; // nothing to do
 	default:
 		assert(false); // unreachable
-	}	
+	}
 
 	// If out_buffer == buffer, then set it to nullptr.
 	// We don't care about the result.
@@ -71,6 +71,12 @@ void pipewire_destroy_buffer(struct pipewire_buffer *buffer)
 
 static void calculate_capture_size()
 {
+	if (g_nPipewireWidth > 0 && g_nPipewireHeight > 0) {
+		s_nCaptureWidth = g_nPipewireWidth;
+		s_nCaptureHeight = g_nPipewireHeight;
+		return;
+	}
+
 	s_nCaptureWidth = s_nOutputWidth;
 	s_nCaptureHeight = s_nOutputHeight;
 
@@ -278,6 +284,10 @@ static void dispatch_nudge(struct pipewire_state *state, int fd)
 	if (g_nOutputWidth != s_nOutputWidth || g_nOutputHeight != s_nOutputHeight) {
 		s_nOutputWidth = g_nOutputWidth;
 		s_nOutputHeight = g_nOutputHeight;
+		calculate_capture_size();
+	}
+
+	if (g_nPipewireWidth > 0 && g_nPipewireHeight > 0) {
 		calculate_capture_size();
 	}
 	if (s_nCaptureWidth != state->video_info.size.width || s_nCaptureHeight != state->video_info.size.height) {


### PR DESCRIPTION
## Summary

This PR adds new options to control PipeWire capture behavior in Gamescope, allowing users to:
1. Select between source (pre-upscaled) and output (post-upscaled) textures
2. Specify fixed capture dimensions instead of using output dimensions

## New Options

- `--pipewire-source=<output|source>` - Select which texture to capture:
  - `output` (default): Capture the final composited and upscaled texture
  - `source`: Capture the original window texture before upscaling
- `--pipewire-width=<width>` - Set a fixed width for PipeWire capture (overrides output width)
- `--pipewire-height=<height>` - Set a fixed height for PipeWire capture (overrides output height)

## Use Cases

This is particularly useful for:
1. Streaming/recording applications that need the original game resolution
2. Capturing content at a specific resolution regardless of display scaling
3. Avoiding quality loss from multiple scaling operations

My primary objective is the first one, and because the image‑analysis tool requires the game’s original resolution, this modification became necessary.

## Examples

```
# Capture source texture at 1920x1080
gamescope --pipewire-source=source --pipewire-width=1920 --pipewire-height=1080 -- game

# Capture at fixed 720p while displaying at 4K
gamescope -W 3840 -H 2160 --pipewire-width=1280 --pipewire-height=720 -- game
```

## Implementation Details

- When --pipewire-source=source is used, the source texture (vulkanTex) is selected instead of the upscaled texture
- A new PaintWindowFlag::PipeWire flag identifies PipeWire paint operations
- Scaling calculations are adapted to use PipeWire dimensions when the flag is set
- The implementation maintains full backward compatibility - default behavior is unchanged
