### PR TITLE
fix: drain timer fds to avoid epoll_wait returning constantly

### DIFF
--- a/src/waitable.h
+++ b/src/waitable.h
@@ -182,6 +182,11 @@ namespace gamescope
             ArmTimer( 0ul, false );
         }
 
+        void OnPollIn()
+        {
+            IWaitable::Drain(m_nFD);
+        }
+
         int GetFD()
         {
             return m_nFD;
@@ -200,6 +205,7 @@ namespace gamescope
 
         void OnPollIn() final
         {
+            ITimerWaitable::OnPollIn();
             m_fnPollFunc();
         }
     private:


### PR DESCRIPTION
Currently, if the VBlank or VRR timers expire without being rescheduled, their FDs remain readable, causing epoll_wait to return instantly. In cases where e.g., SteamUI stops compositing in the library view, this can cause a busy loop and pin a CPU core at 100%. Drain the FDs in the OnPollIn handler of the timers to prevent this.