### PR TITLE
Revert "build: add workaround to build with CMake 4.0"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,10 +60,7 @@ if get_option('enable_openvr_support')
   if not openvr_dep.found()
     cmake = import('cmake')
     openvr_var = cmake.subproject_options()
-    openvr_var.add_cmake_defines({'USE_LIBCXX': false,
-    #HACK: remove me when openvr supports CMake 4.0
-    'CMAKE_POLICY_VERSION_MINIMUM': '3.5'})
-    #ENDHACK
+    openvr_var.add_cmake_defines({'USE_LIBCXX': false})
     openvr_var.set_override_option('warning_level', '0')
     openvr_proj = cmake.subproject('openvr', options : openvr_var)
     openvr_dep = openvr_proj.dependency('openvr_api')


### PR DESCRIPTION
This reverts commit 5ab0954026934e81fcccf6b4e10ea62dc6c86ae4.

OpenVR 2.12.1 made this hack no longer necessary.