### PR TITLE
steamcompmgr: Add an option to disable automatic relative mouse

### DIFF
--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -1713,7 +1713,7 @@ namespace gamescope
         UpdateEdid();
         m_pBackend->HackUpdatePatchedEdid();
 
-        if ( g_bForceRelativeMouse )
+        if ( g_forceRelativeMouse == ForceRelativeMouseMode::FORCE_ON )
             this->SetRelativeMouseMode( true );
         
         if ( m_pBackend->m_oulCurrentSceneVirtualConnectorKey &&

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1013,7 +1013,7 @@ namespace gamescope
         UpdateEdid();
         m_pBackend->HackUpdatePatchedEdid();
 
-        if ( g_bForceRelativeMouse )
+        if ( g_forceRelativeMouse == ForceRelativeMouseMode::FORCE_ON )
             this->SetRelativeMouseMode( true );
 
         return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,7 @@ const struct option *gamescope_options = (struct option[]){
 	{ "grab", no_argument, nullptr, 'g' },
 	{ "force-grab-cursor", no_argument, nullptr, 0 },
 	{ "display-index", required_argument, nullptr, 0 },
+	{ "never-grab-cursor", no_argument, nullptr, 0 },
 
 	// embedded mode options
 	{ "disable-layers", no_argument, nullptr, 0 },
@@ -224,6 +225,7 @@ const char usage[] =
 	"  --force-grab-cursor            always use relative mouse mode instead of flipping dependent on cursor visibility.\n"
 	"  --display-index                forces gamescope to use a specific display in nested mode."
 	"\n"
+	"  --never-grab-cursor            never use relative mouse mode instead of flipping dependent on cursor visibility.\n"
 	"Embedded mode options:\n"
 	"  -O, --prefer-output            list of connectors in order of preference (ex: DP-1,DP-2,DP-3,HDMI-A-1)\n"
 	"  --default-touch-mode           0: hover, 1: left, 2: right, 3: middle, 4: passthrough\n"
@@ -284,6 +286,7 @@ const char usage[] =
 	"  Super + O                      decrease FSR sharpness by 1\n"
 	"  Super + S                      take a screenshot\n"
 	"  Super + G                      toggle keyboard grab\n"
+	"  Super + M                      toggle never grab mouse\n"
 	"";
 
 std::atomic< bool > g_bRun{true};
@@ -300,7 +303,7 @@ int g_nOutputRefresh = 0;
 bool g_bOutputHDREnabled = false;
 
 bool g_bFullscreen = false;
-bool g_bForceRelativeMouse = false;
+ForceRelativeMouseMode g_forceRelativeMouse = ForceRelativeMouseMode::OFF;
 
 bool g_bGrabbed = false;
 
@@ -807,7 +810,9 @@ int main(int argc, char **argv)
 				} else if (strcmp(opt_name, "immediate-flips") == 0) {
 					cv_tearing_enabled = true;
 				} else if (strcmp(opt_name, "force-grab-cursor") == 0) {
-					g_bForceRelativeMouse = true;
+					g_forceRelativeMouse = ForceRelativeMouseMode::FORCE_ON;
+				} else if (strcmp(opt_name, "never-grab-cursor") == 0) {
+					g_forceRelativeMouse = ForceRelativeMouseMode::FORCE_OFF;
 				} else if (strcmp(opt_name, "display-index") == 0) {
 					g_nNestedDisplayIndex = parse_integer( optarg, opt_name );
 				} else if (strcmp(opt_name, "adaptive-sync") == 0) {

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -4,6 +4,13 @@
 
 #include <atomic>
 
+enum class ForceRelativeMouseMode : uint32_t
+{
+    OFF,
+    FORCE_OFF,
+    FORCE_ON,
+};
+
 extern const char *gamescope_optstring;
 extern const struct option *gamescope_options;
 
@@ -17,7 +24,7 @@ extern int g_nNestedDisplayIndex;
 
 extern uint32_t g_nOutputWidth;
 extern uint32_t g_nOutputHeight;
-extern bool g_bForceRelativeMouse;
+extern ForceRelativeMouseMode g_forceRelativeMouse;
 extern int g_nOutputRefresh; // mHz
 extern bool g_bOutputHDREnabled;
 extern bool g_bForceInternal;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -800,7 +800,7 @@ constexpr const T& clamp( const T& x, const T& min, const T& max )
     return x < min ? min : max < x ? max : x;
 }
 
-extern bool g_bForceRelativeMouse;
+extern ForceRelativeMouseMode g_forceRelativeMouse;
 
 CommitDoneList_t g_steamcompmgr_xdg_done_commits;
 
@@ -2427,7 +2427,10 @@ bool ShouldDrawCursor()
 	if ( cv_cursor_composite == 0 )
 		return false;
 
-	if ( g_bForceRelativeMouse )
+	/**
+	 * Should composite cursor when RelativeMouse is not default value ForceRelativeMouseMode::OFF
+	 */
+	if ( g_forceRelativeMouse != ForceRelativeMouseMode::OFF )
 		return true;
 
 	global_focus_t *pFocus = GetCurrentFocus();
@@ -8790,7 +8793,10 @@ steamcompmgr_main(int argc, char **argv)
 					pPaintFocus->cursor->UpdatePosition();
 			}
 
-			if ( pPaintFocus->GetNestedHints() && !g_bForceRelativeMouse )
+			/**
+			 * Update after key input. This should be g_forceRelativeMouse != ForceRelativeMouseMode::FORCE_ON
+			 */
+			if ( pPaintFocus->GetNestedHints() && g_forceRelativeMouse != ForceRelativeMouseMode::FORCE_ON )
 			{
 				const bool bImageEmpty =
 					( pPaintFocus->cursor && pPaintFocus->cursor->imageEmpty() ) &&


### PR DESCRIPTION
This just mine continious from original mr https://github.com/ValveSoftware/gamescope/pull/1098.
original MR is no longer updated it seems.

I am using this on waydroid due to its cursor is too small and move to laggy. also some game sometimes missing cursor on wine.
I add a title "(mouse-off)" to shown the mouse is not grabbed.
The rest of change is almost same as original MR
Hotkey is still same as Super+M