### PR TITLE
Bump wlroots to v0.19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           pacman-key --init
           pacman -Syu --noconfirm
-          pacman -S --noconfirm git meson clang glslang libcap wlroots0.18 \
+          pacman -S --noconfirm git meson clang glslang libcap wlroots0.19 \
             sdl2 vulkan-headers libx11 libxmu libxcomposite libxrender libxres \
             libxtst libxkbcommon libdrm libinput wayland-protocols benchmark \
             xorg-xwayland pipewire cmake \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "subprojects/wlroots"]
 	path = subprojects/wlroots
-	url = https://github.com/Joshua-Ashton/wlroots.git
+	url = https://gitlab.freedesktop.org/wlroots/wlroots.git
 [submodule "subprojects/libliftoff"]
 	path = subprojects/libliftoff
 	url = https://gitlab.freedesktop.org/emersion/libliftoff.git

--- a/meson.build
+++ b/meson.build
@@ -6,12 +6,12 @@ project(
   default_options: [
     'cpp_std=c++20',
     'warning_level=2',
-    'force_fallback_for=wlroots,libliftoff,vkroots',
+    'force_fallback_for=libliftoff,vkroots',
   ],
 )
 
 fallbacks = get_option('force_fallback_for')
-if not (fallbacks.contains('wlroots') and fallbacks.contains('libliftoff') and fallbacks.contains('vkroots'))
+if not (fallbacks.contains('libliftoff') and fallbacks.contains('vkroots'))
   error('!!!"force_fallback_for" is missing entries!!!\n\tPlease do not remove entries from force_fallback_for if you are packaging the project.\n\tWe pull in these projects at specific commits/forks/builds for a reason.\n\tIf you are not packaging, remove this line to continue.')
 endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,8 +25,8 @@ pixman_dep = dependency('pixman-1')
 udev_dep = dependency('libudev')
 
 wlroots_dep = dependency(
-  'wlroots-0.18',
-  version: ['>= 0.18.0', '< 0.19.0'],
+  'wlroots-0.19',
+  version: ['>= 0.19.0', '< 0.20.0'],
   fallback: 'wlroots',
   default_options: ['default_library=static', 'examples=false', 'xwayland=enabled', 'backends=libinput', 'renderers=[]', 'allocators=[]', 'session=enabled'],
 )


### PR DESCRIPTION
- [x] Properly remove event listeners (https://github.com/ValveSoftware/gamescope/pull/2066)

The fork is no longer required because https://github.com/misyltoad/wlroots/commit/0ebfe13ccb984835501e517dd961fe1f144342f8 has been merged upstream as https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/1e7baefe96606bc7beb7d60f6c69eb209ece832b.