### PR TITLE
backend: Add support for deferred backends

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -1523,7 +1523,7 @@ void finish_drm(struct drm_t *drm)
 	// page-flip handler thread.
 }
 
-gamescope::OwningRc<gamescope::IBackendFb> drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_buffer *buf, struct wlr_dmabuf_attributes *dma_buf )
+gamescope::OwningRc<gamescope::IBackendFb> drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_dmabuf_attributes *dma_buf )
 {
 	gamescope::OwningRc<gamescope::IBackendFb> pBackendFb;
 	uint32_t fb_id = 0;
@@ -2525,7 +2525,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 		if ( i < frameInfo->layerCount )
 		{
 			const FrameInfo_t::Layer_t *pLayer = &frameInfo->layers[ i ];
-			gamescope::CDRMFb *pDrmFb = static_cast<gamescope::CDRMFb *>( pLayer->tex ? pLayer->tex->GetBackendFb() : nullptr );
+			gamescope::CDRMFb *pDrmFb = static_cast<gamescope::CDRMFb *>( pLayer->tex ? pLayer->tex->GetBackendFb()->Unwrap() : nullptr );
 
 			if ( pDrmFb == nullptr )
 			{
@@ -3710,9 +3710,9 @@ namespace gamescope
 			return std::make_shared<BackendBlob>( data, uBlob, true );
 		}
 
-		virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_buffer *pBuffer, wlr_dmabuf_attributes *pDmaBuf ) override
+		virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_dmabuf_attributes *pDmaBuf ) override
 		{
-			return drm_fbid_from_dmabuf( &g_DRM, pBuffer, pDmaBuf );
+			return drm_fbid_from_dmabuf( &g_DRM, pDmaBuf );
 		}
 
 		virtual bool UsesModifiers() const override

--- a/src/Backends/DeferredBackend.h
+++ b/src/Backends/DeferredBackend.h
@@ -1,0 +1,432 @@
+#include "backend.h"
+#include "refresh_rate.h"
+#include "steamcompmgr.hpp"
+
+#include <cassert>
+#include <shared_mutex>
+
+extern int g_nPreferredOutputWidth;
+extern int g_nPreferredOutputHeight;
+
+std::span<const uint64_t> GetSupportedSampleModifiers( uint32_t uDrmFormat );
+
+namespace gamescope
+{
+    class CDeferredBackend;
+
+    class CDeferredFb final : public CBaseBackendFb
+    {
+    public:
+        CDeferredFb( CDeferredBackend *pDeferredBackend, struct wlr_dmabuf_attributes *attributes )
+            : m_pDeferredBackend{ pDeferredBackend }
+        {
+            wlr_dmabuf_attributes_copy( &m_attributes, attributes );
+        }
+
+        ~CDeferredFb()
+        {
+            wlr_dmabuf_attributes_finish( &m_attributes );
+        }
+        
+        IBackendFb *Unwrap() override;
+    private:
+        CDeferredBackend *m_pDeferredBackend = nullptr;
+        struct wlr_dmabuf_attributes m_attributes;
+        OwningRc<IBackendFb> m_pChild;
+    };
+
+	class CDeferredBackend final : public CBaseBackend
+	{
+	public:
+		CDeferredBackend( IBackend *pChild )
+            : m_pChild{ pChild }
+		{
+		}
+
+		virtual ~CDeferredBackend()
+		{
+            if ( m_pChild )
+            {
+                delete m_pChild;
+                m_pChild = nullptr;
+            }
+		}
+
+		virtual bool Init() override
+		{
+			g_nOutputWidth = g_nPreferredOutputWidth;
+			g_nOutputHeight = g_nPreferredOutputHeight;
+			g_nOutputRefresh = g_nNestedRefresh;
+
+			if ( g_nOutputHeight == 0 )
+			{
+				if ( g_nOutputWidth != 0 )
+				{
+					fprintf( stderr, "Cannot specify -W without -H\n" );
+					return false;
+				}
+				g_nOutputHeight = 720;
+			}
+			if ( g_nOutputWidth == 0 )
+				g_nOutputWidth = g_nOutputHeight * 16 / 9;
+			if ( g_nOutputRefresh == 0 )
+				g_nOutputRefresh = ConvertHztomHz( 60 );
+
+            if ( !vulkan_init( vulkan_get_instance(), VK_NULL_HANDLE ) )
+            {
+                return false;
+            }
+
+            if ( !wlsession_init() )
+            {
+                fprintf( stderr, "Failed to initialize deferred backend\n" );
+                return false;
+            }
+
+            TryInittingChild();
+
+			return true;
+		}
+
+		virtual bool PostInit() override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                m_bDonePostInit = true;
+
+                if ( m_bInittedChild )
+                    return m_pChild->PostInit();
+            }
+
+            return true;
+		}
+
+        virtual std::span<const char *const> GetInstanceExtensions() const override
+		{
+            // Basically what's needed to support SDL + OpenVR.
+            static const std::array<const char *const, 8> requiredInstanceExts
+            {
+                VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
+                VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+                VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME,
+                VK_KHR_SURFACE_EXTENSION_NAME,
+                "VK_KHR_xcb_surface",
+                "VK_KHR_xlib_surface",
+                "VK_KHR_wayland_surface",
+                VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME,
+            };
+			return std::span<const char *const>{ requiredInstanceExts };
+		}
+        virtual std::span<const char *const> GetDeviceExtensions( VkPhysicalDevice pVkPhysicalDevice ) const override
+		{
+            // Basically what's needed to support OpenVR.
+            static const std::array<const char *const, 8> requiredDeviceExts
+            {
+                VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
+                VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
+                VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+                VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,
+                VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
+                VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+                VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+                VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME,
+            };
+			return std::span<const char *const>{ requiredDeviceExts };
+		}
+        virtual VkImageLayout GetPresentLayout() const override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->GetPresentLayout();
+            }
+
+			return VK_IMAGE_LAYOUT_GENERAL;
+		}
+		virtual void GetPreferredOutputFormat( uint32_t *pPrimaryPlaneFormat, uint32_t *pOverlayPlaneFormat ) const override
+		{
+			*pPrimaryPlaneFormat = VulkanFormatToDRM( VK_FORMAT_A2B10G10R10_UNORM_PACK32 );
+			*pOverlayPlaneFormat = VulkanFormatToDRM( VK_FORMAT_B8G8R8A8_UNORM );
+		}
+		virtual bool ValidPhysicalDevice( VkPhysicalDevice pVkPhysicalDevice ) const override
+		{
+			return true;
+		}
+
+		virtual void DirtyState( bool bForce, bool bForceModeset ) override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->DirtyState( bForce, bForceModeset );
+            }
+		}
+
+		virtual bool PollState() override
+		{
+            TryInittingChild();
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->PollState() || m_bJustInittedPoll;
+            }
+			return false;
+		}
+
+		virtual std::shared_ptr<BackendBlob> CreateBackendBlob( const std::type_info &type, std::span<const uint8_t> data ) override
+		{
+            // Only dummy backend blobs supported.
+			return std::make_shared<BackendBlob>( data );
+		}
+
+		virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_dmabuf_attributes *pDmaBuf ) override
+		{
+			return new CDeferredFb( this, pDmaBuf );
+		}
+
+		virtual bool UsesModifiers() const override
+		{
+            return true;
+		}
+		virtual std::span<const uint64_t> GetSupportedModifiers( uint32_t uDrmFormat ) const override
+		{
+			return GetSupportedSampleModifiers( uDrmFormat );
+		}
+
+		virtual IBackendConnector *GetCurrentConnector() override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->GetCurrentConnector();
+            }
+
+            return nullptr;
+		}
+		virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->GetConnector( eScreenType );
+            }
+            
+			return nullptr;
+		}
+
+		virtual bool SupportsPlaneHardwareCursor() const override
+		{
+            // Doesn't need to be 'initted' for this check.
+            return m_pChild->SupportsPlaneHardwareCursor();
+		}
+
+		virtual bool SupportsTearing() const override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->SupportsTearing();
+            }
+            
+			return false;
+		}
+
+		virtual bool UsesVulkanSwapchain() const override
+		{
+            // Doesn't need to be 'initted' for this check.
+            return m_pChild->UsesVulkanSwapchain();
+		}
+
+        virtual bool IsSessionBased() const override
+		{
+            // Doesn't need to be 'initted' for this check.
+            return m_pChild->IsSessionBased();
+		}
+
+		virtual bool SupportsExplicitSync() const override
+		{
+            // Doesn't need to be 'initted' for this check.
+            return m_pChild->SupportsExplicitSync();
+		}
+
+		virtual bool IsPaused() const override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->IsPaused();
+            }
+
+            // We are always "paused" when not initted.
+            // Don't do any commits!
+			return true;
+		}
+
+		virtual bool IsVisible() const override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->IsVisible();
+            }
+
+			return true;
+		}
+
+		virtual glm::uvec2 CursorSurfaceSize( glm::uvec2 uvecSize ) const override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->CursorSurfaceSize( uvecSize );
+            }
+
+			return uvecSize;
+		}
+
+		virtual bool HackTemporarySetDynamicRefresh( int nRefresh ) override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->HackTemporarySetDynamicRefresh( nRefresh );
+            }
+
+			return false;
+		}
+
+		virtual void HackUpdatePatchedEdid() override
+		{
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->HackUpdatePatchedEdid();
+            }
+		}
+
+        virtual bool NeedsFrameSync() const override
+        {
+            // Deferred backends do not support frame sync.
+            return false;
+        }
+
+        virtual TouchClickMode GetTouchClickMode() override
+        {
+            // Doesn't need to be 'initted' for this check.
+            return m_pChild->GetTouchClickMode();
+        }
+
+        virtual void DumpDebugInfo() override
+        {
+            // Doesn't need to be 'initted' for this check.
+            return m_pChild->DumpDebugInfo();
+        }
+
+        virtual bool UsesVirtualConnectors() override
+        {
+            // Doesn't need to be 'initted' for this check.
+            return m_pChild->UsesVirtualConnectors();
+        }
+        virtual std::shared_ptr<IBackendConnector> CreateVirtualConnector( uint64_t ulVirtualConnectorKey ) override
+        {
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->CreateVirtualConnector( ulVirtualConnectorKey );
+            }
+
+            return nullptr;
+        }
+
+        virtual void NotifyPhysicalInput( InputType eInputType ) override
+        {
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->NotifyPhysicalInput( eInputType );
+            }
+        }
+
+        virtual bool SupportsVROverlayForwarding() override
+        {
+            // Doesn't need to be 'initted' for this check.
+            return m_pChild->SupportsVROverlayForwarding();
+        }
+        virtual void ForwardFramebuffer( std::shared_ptr<IBackendPlane> &pPlane, IBackendFb *pFramebuffer, const void *pData ) override
+        {
+            {
+                std::shared_lock lock{ m_mutInit };
+                if ( m_bInittedChild )
+                    return m_pChild->ForwardFramebuffer( pPlane, pFramebuffer, pData );
+            }
+        }
+
+        bool IsChildInitted()
+        {
+            return m_bInittedChild;
+        }
+
+        IBackend *GetChild()
+        {
+            return m_pChild;
+        }
+
+        bool NewlyInitted() override
+        {
+            return m_bJustInittedClient.exchange( false );
+        }
+
+	protected:
+
+		virtual void OnBackendBlobDestroyed( BackendBlob *pBlob ) override
+		{
+		}
+
+	private:
+
+        void TryInittingChild()
+        {
+            if ( !m_bInittedChild )
+            {
+                std::unique_lock lock{ m_mutInit };
+                if ( !m_bInittedChild )
+                {
+                    if ( m_pChild->Init() )
+                    {
+                        m_bInittedChild = true;
+
+                        if ( m_bDonePostInit )
+                        {
+                            bool bRet = m_pChild->PostInit();
+                            assert( bRet && "PostInit failed!" );
+                        }
+
+                        m_bJustInittedClient = true;
+                        m_bJustInittedPoll = true;
+                    }
+                }
+            }
+        }
+
+        IBackend *m_pChild = nullptr;
+        mutable std::shared_mutex m_mutInit;
+        bool m_bDonePostInit = false;
+
+        std::atomic<bool> m_bInittedChild = { false };
+        std::atomic<bool> m_bJustInittedClient = { false };
+        std::atomic<bool> m_bJustInittedPoll = { false };
+	};
+
+    IBackendFb *CDeferredFb::Unwrap()
+    {
+        assert( m_pDeferredBackend->IsChildInitted() );
+
+        if ( !m_pChild )
+        {
+            m_pChild = m_pDeferredBackend->GetChild()->ImportDmabufToBackend( &m_attributes );
+        }
+
+        return m_pChild.get();
+    }
+
+}

--- a/src/Backends/HeadlessBackend.cpp
+++ b/src/Backends/HeadlessBackend.cpp
@@ -180,7 +180,7 @@ namespace gamescope
 			return std::make_shared<BackendBlob>( data );
 		}
 
-		virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_buffer *pBuffer, wlr_dmabuf_attributes *pDmaBuf ) override
+		virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_dmabuf_attributes *pDmaBuf ) override
 		{
 			return new CBaseBackendFb();
 		}

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -1,4 +1,5 @@
 #include "backend.h"
+#include "Backends/DeferredBackend.h"
 #include "vblankmanager.hpp"
 #include "convar.h"
 #include "wlserver.hpp"
@@ -9,6 +10,8 @@
 
 extern void sleep_until_nanos(uint64_t nanos);
 extern bool env_to_bool(const char *env);
+
+extern bool g_bAllowDeferredBackend;
 
 namespace gamescope
 {
@@ -38,9 +41,22 @@ namespace gamescope
             s_pBackend = pBackend;
             if ( !s_pBackend->Init() )
             {
-                delete s_pBackend;
-                s_pBackend = nullptr;
-                return false;
+                if ( g_bAllowDeferredBackend )
+                {
+                    s_pBackend = new CDeferredBackend( pBackend );
+                    if ( !s_pBackend->Init() )
+                    {
+                        delete s_pBackend;
+                        s_pBackend = nullptr;
+                        return false;
+                    }
+                }
+                else
+                {
+                    delete s_pBackend;
+                    s_pBackend = nullptr;
+                    return false;
+                }
             }
         }
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -256,6 +256,8 @@ namespace gamescope
     public:
         virtual void SetBuffer( wlr_buffer *pClientBuffer ) = 0;
         virtual void SetReleasePoint( std::shared_ptr<CReleaseTimelinePoint> pReleasePoint ) = 0;
+
+        virtual IBackendFb *Unwrap() = 0;
     };
 
     class IBackendPlane
@@ -275,6 +277,8 @@ namespace gamescope
 
         void SetBuffer( wlr_buffer *pClientBuffer ) override;
         void SetReleasePoint( std::shared_ptr<CReleaseTimelinePoint> pReleasePoint ) override;
+
+        virtual IBackendFb *Unwrap() override { return this; };
 
     private:
         wlr_buffer *m_pClientBuffer = nullptr;
@@ -311,7 +315,7 @@ namespace gamescope
         //
         // shared_ptr owns the structure.
         // Rc manages acquire/release of buffer to/from client while imported.
-        virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_buffer *pBuffer, wlr_dmabuf_attributes *pDmaBuf ) = 0;
+        virtual OwningRc<IBackendFb> ImportDmabufToBackend( wlr_dmabuf_attributes *pDmaBuf ) = 0;
 
         virtual bool UsesModifiers() const = 0;
         virtual std::span<const uint64_t> GetSupportedModifiers( uint32_t uDrmFormat ) const = 0;
@@ -366,6 +370,8 @@ namespace gamescope
         virtual bool SupportsVROverlayForwarding() = 0;
         virtual void ForwardFramebuffer( std::shared_ptr<IBackendPlane> &pPlane, IBackendFb *pFramebuffer, const void *pData ) = 0;
 
+        virtual bool NewlyInitted() = 0;
+
         static IBackend *Get();
         template <typename T>
         static bool Set();
@@ -398,6 +404,8 @@ namespace gamescope
 
         virtual bool SupportsVROverlayForwarding() override { return false; }
         virtual void ForwardFramebuffer( std::shared_ptr<IBackendPlane> &pPlane, IBackendFb *pFramebuffer, const void *pData ) override {}
+
+        virtual bool NewlyInitted() override { return false; }
     };
 
     // This is a blob of data that may be associated with

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,10 +45,13 @@ using namespace std::literals;
 
 EStreamColorspace g_ForcedNV12ColorSpace = k_EStreamColorspace_Unknown;
 extern gamescope::ConVar<bool> cv_adaptive_sync;
+extern gamescope::ConVar<bool> cv_shutdown_on_primary_child_death;
 
 const char *gamescope_optstring = nullptr;
 const char *g_pOriginalDisplay = nullptr;
 const char *g_pOriginalWaylandDisplay = nullptr;
+
+bool g_bAllowDeferredBackend = false;
 
 int g_nCursorScaleHeight = -1;
 
@@ -150,6 +153,9 @@ const struct option *gamescope_options = (struct option[]){
 
 	// Steam Deck options
 	{ "mura-map", required_argument, nullptr, 0 },
+
+	{ "allow-deferred-backend", no_argument, nullptr, 0 },
+	{ "keep-alive", no_argument, nullptr, 0 },
 
 	{} // keep last
 };
@@ -264,6 +270,10 @@ const char usage[] =
 	"\n"
 	"Steam Deck options:\n"
 	"  --mura-map                     Set the mura compensation map to use for the display. Takes in a path to the mura map.\n"
+	"\n"
+	"Platform options:\n"
+	"  --allow-deferred-backend       Allows initting the backend in a deferred way, if it doesn't work immediately. (Note: This has some very minor correctness compromises that you should consider wrt. your platform with modifiers, etc).\n"
+	"  --keep-alive                   Keep Gamescope alive even when the primary process has died.\n"
 	"\n"
 	"Keyboard shortcuts:\n"
 	"  Super + F                      toggle fullscreen\n"
@@ -810,6 +820,10 @@ int main(int argc, char **argv)
 					g_nCursorScaleHeight = parse_integer(optarg, opt_name);
 				} else if (strcmp(opt_name, "mangoapp") == 0) {
 					g_bLaunchMangoapp = true;
+				} else if (strcmp(opt_name, "allow-deferred-backend") == 0) {
+					g_bAllowDeferredBackend = true;
+				} else if (strcmp(opt_name, "keep-alive") == 0) {
+					cv_shutdown_on_primary_child_death = false;
 				} else if (strcmp(opt_name, "virtual-connector-strategy") == 0) {
 					for ( uint32_t i = 0; i < gamescope::VirtualConnectorStrategies::Count; i++ )
 					{

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1624,6 +1624,10 @@ static bool filter_global(const struct wl_client *client, const struct wl_global
 }
 
 bool wlsession_init( void ) {
+	static bool s_bInitted = false;
+	if ( s_bInitted )
+		return true;
+
 	wlr_log_init(WLR_DEBUG, handle_wlr_log);
 
 	wlserver.display = wl_display_create();
@@ -1639,7 +1643,10 @@ bool wlsession_init( void ) {
 
 #if HAVE_SESSION
 	if ( !GetBackend()->IsSessionBased() )
+	{
+		s_bInitted = true;
 		return true;
+	}
 
 	wlserver.wlr.session = wlr_session_create( wlserver.event_loop );
 	if ( wlserver.wlr.session == nullptr )
@@ -1651,6 +1658,8 @@ bool wlsession_init( void ) {
 	wlserver.session_active.notify = handle_session_active;
 	wl_signal_add( &wlserver.wlr.session->events.active, &wlserver.session_active );
 #endif
+
+	s_bInitted = true;
 
 	return true;
 }


### PR DESCRIPTION
So we can eg. init Gamescope headlessly then transition into a backend that only uses SAMPLED modifiers like SteamVR.

This way we can init VRWebHelper in a Gamescope before SteamVR fully comes up.