### PR TITLE
rendervulkan: verify that all the extensions we need to enable are available

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -587,6 +587,27 @@ bool CVulkanDevice::createDevice()
 	for ( auto& extension : GetBackend()->GetDeviceExtensions( physDev() ) )
 		enabledExtensions.push_back( extension );
 
+	uint32_t devExtPropCount = 0;
+	vk.EnumerateDeviceExtensionProperties( physDev(), nullptr, &devExtPropCount, nullptr );
+	std::vector<VkExtensionProperties> devExtProp( devExtPropCount );
+	vk.EnumerateDeviceExtensionProperties( physDev(), nullptr, &devExtPropCount, devExtProp.data() );
+	bool anyMissing = false;
+	for ( auto& requiredExt : enabledExtensions ) {
+		bool extFound = false;
+		for ( auto & availableExt : devExtProp ) {
+			if ( strcmp( requiredExt, availableExt.extensionName ) == 0 ) {
+				extFound = true;
+				break;
+			}
+		}
+		if ( !extFound ) {
+			vk_log.errorf( "Missing required extension: %s", requiredExt );
+			anyMissing = true;
+		}
+	}
+	if ( anyMissing )
+		return false;
+
 #if 0
 	VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5 = {
 		.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR,


### PR DESCRIPTION
If not, print a nice message instead of:

    [gamescope] [Error] vulkan: vkCreateDevice failed (VkResult: -7)

(`-7` is `VK_ERROR_EXTENSION_NOT_PRESENT`)