### PR TITLE
DRMBackend: Fix NULL dereference in drm_prepare_liftoff()

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2558,7 +2558,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 		if ( i < frameInfo->layerCount )
 		{
 			const FrameInfo_t::Layer_t *pLayer = &frameInfo->layers[ i ];
-			gamescope::CDRMFb *pDrmFb = static_cast<gamescope::CDRMFb *>( pLayer->tex ? pLayer->tex->GetBackendFb()->Unwrap() : nullptr );
+			gamescope::CDRMFb *pDrmFb = static_cast<gamescope::CDRMFb *>( (pLayer->tex && pLayer->tex->GetBackendFb()) ? pLayer->tex->GetBackendFb()->Unwrap() : nullptr );
 
 			if ( pDrmFb == nullptr )
 			{


### PR DESCRIPTION
Fix gamescope crashing with a NULL dereference in `drm_prepare_liftoff()`, caused by 8f82d5153840.

```
Thread 8 "gamescope-xwm" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffdd3ff6c0 (LWP 8536)]
0x00005555557a0813 in drm_prepare_liftoff (drm=0x555555b97c20 <g_DRM>, frameInfo=0x7fffdd3fe2c0, needs_modeset=false)
    at ../src/Backends/DRMBackend.cpp:2561
warning: 2561   ../src/Backends/DRMBackend.cpp: No such file or directory
(gdb) bt
#0  0x00005555557a0813 in drm_prepare_liftoff (drm=0x555555b97c20 <g_DRM>, frameInfo=0x7fffdd3fe2c0, needs_modeset=false)
    at ../src/Backends/DRMBackend.cpp:2561
#1  0x00005555557a2d29 in drm_prepare (drm=0x555555b97c20 <g_DRM>, async=false, frameInfo=0x7fffdd3fe2c0) at ../src/Backends/DRMBackend.cpp:3022
#2  0x00005555557aacd7 in gamescope::CDRMBackend::Present (this=0x555555c9a270, pFrameInfo=0x7fffdd3fe2c0, bAsync=false)
    at ../src/Backends/DRMBackend.cpp:3484
#3  0x00005555557a3e68 in HackyDRMPresent (pFrameInfo=0x7fffdd3fe2c0, bAsync=false) at ../src/Backends/DRMBackend.cpp:4009
#4  0x000055555579e695 in gamescope::CDRMConnector::Present (this=0x555555c96bd0, pFrameInfo=0x7fffdd3fe2c0, bAsync=false)
    at ../src/Backends/DRMBackend.cpp:2167
#5  0x0000555555649a6e in paint_all (pFocus=0x7fffd000ca30, async=false) at ../src/steamcompmgr.cpp:2801
#6  0x000055555565f13c in steamcompmgr_main (argc=5, argv=0x7fffffffea68) at ../src/steamcompmgr.cpp:8690
#7  0x00005555556b8474 in steamCompMgrThreadRun (argc=5, argv=0x7fffffffea68) at ../src/main.cpp:1061
#8  0x00005555556b93d6 in std::__invoke_impl<void, void (*)(int, char**), int, char**> (
    __f=@0x555555dca5c8: 0x5555556b843a <steamCompMgrThreadRun(int, char**)>) at /usr/include/c++/15.2.1/bits/invoke.h:63
#9  0x00005555556b933e in std::__invoke<void (*)(int, char**), int, char**> (__fn=@0x555555dca5c8: 0x5555556b843a <steamCompMgrThreadRun(int, char**)>)
    at /usr/include/c++/15.2.1/bits/invoke.h:98
#10 0x00005555556b928b in std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> >::_M_invoke<0ul, 1ul, 2ul> (this=0x555555dca5b8)
    at /usr/include/c++/15.2.1/bits/std_thread.h:303
#11 0x00005555556b9228 in std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> >::operator() (this=0x555555dca5b8)
    at /usr/include/c++/15.2.1/bits/std_thread.h:310
#12 0x00005555556b920c in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> > >::_M_run (
    this=0x555555dca5b0) at /usr/include/c++/15.2.1/bits/std_thread.h:255
#13 0x00007ffff74e55a4 in std::execute_native_thread_routine (__p=0x555555dca5b0) at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104
#14 0x00007ffff70969cb in ?? () from /usr/lib/libc.so.6
#15 0x00007ffff711aa0c in ?? () from /usr/lib/libc.so.6
```

@misyltoad 