### PR TITLE
rendervulkan: Only define 32-bit float DRM_FORMATs if necessary.

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -191,11 +191,19 @@ struct wsi_memory_allocate_info {
     bool implicit_sync;
 };
 
-// DRM doesn't have 32bit floating point formats, so add our own
-#define DRM_FORMAT_ABGR32323232F fourcc_code('A', 'B', '8', 'F')
+// DRM doesn't always have 32bit floating point formats, so add our own if necessary
 
+#ifndef DRM_FORMAT_ABGR32323232F
+#define DRM_FORMAT_ABGR32323232F fourcc_code('A', 'B', '8', 'F')
+#endif
+
+#ifndef DRM_FORMAT_R16F
 #define DRM_FORMAT_R16F fourcc_code('R', '1', '6', 'F')
+#endif
+
+#ifndef DRM_FORMAT_R32F
 #define DRM_FORMAT_R32F fourcc_code('R', '3', '2', 'F')
+#endif
 
 struct {
 	uint32_t DRMFormat;


### PR DESCRIPTION
Newer versions of the libdrm headers define this for us.