### PR TITLE
rendervulkan: Fix UB caused by undersized struct definition

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -189,6 +189,7 @@ struct wsi_memory_allocate_info {
     VkStructureType sType;
     const void *pNext;
     bool implicit_sync;
+    bool dma_buf_sync_file;
 };
 
 // DRM doesn't have 32bit floating point formats, so add our own


### PR DESCRIPTION
Taken from the upstream mesa definition [here](https://gitlab.freedesktop.org/mesa/mesa/-/blob/837dfb8d62cb95ca04ee3e26e953ee7068ea06db/src/vulkan/util/vk_internal_exts.h#L44-64). Below is a "backtrace", or my best effort in trying to explain where it went wrong.

- gamescope crashes with
```
[gamescope] [Error] vulkan: vkGetMemoryFdKHR failed (VkResult: -2)
[gamescope] [Error] vulkan: failed to allocate buffer for KMS
vulkan_make_output failed
```
- mesa/RADV returns -2 (`VK_ERROR_OUT_OF_DEVICE_MEMORY`) because of [these lines](https://gitlab.freedesktop.org/mesa/mesa/-/blob/837dfb8d62cb95ca04ee3e26e953ee7068ea06db/src/amd/vulkan/radv_device.c#L1706-1708)
- libdrm calls `DRM_IOCTL_PRIME_HANDLE_TO_FD` which results in -1 (`EPERM (Operation not permitted)`)
- the kernel seems to return that error because of [this](https://github.com/torvalds/linux/blob/7d0a66e4bb9081d75c82ec4957c50034cb0ea449/drivers/gpu/drm/amd/amdgpu/amdgpu_dma_buf.c#L368-L369) (the `bo->flags & AMDGPU_GEM_CREATE_VM_ALWAYS_VALID` in particular)
- mesa sets that flag [here](https://gitlab.freedesktop.org/mesa/mesa/-/blob/837dfb8d62cb95ca04ee3e26e953ee7068ea06db/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_bo.c#L619-624)
- This is where I get a little confused (and where the UB happens)... I set a breakpoint on [this line](https://gitlab.freedesktop.org/mesa/mesa/-/blob/837dfb8d62cb95ca04ee3e26e953ee7068ea06db/src/amd/vulkan/radv_device_memory.c#L131), and `flags` gets set to `0x660` which is at least `RADEON_FLAG_NO_INTERPROCESS_SHARING | RADEON_FLAG_PREFER_LOCAL_BO`. (I have yet to look at the disassembly for a reasonable explanation)
- [`wsi_info`](https://gitlab.freedesktop.org/mesa/mesa/-/blob/837dfb8d62cb95ca04ee3e26e953ee7068ea06db/src/amd/vulkan/radv_device_memory.c#L98-99) in mesa comes from the `VK_STRUCTURE_TYPE_WSI_MEMORY_ALLOCATE_INFO_MESA` gamescope sets in [these lines](https://github.com/ValveSoftware/gamescope/blob/48c60587b6dcd574e32dbfe38d914a78684f38d8/src/rendervulkan.cpp#L2271-L2274)
- `wsi_info->dma_buf_sync_file` is undefined because the gamescope struct does not have that field