### PR TITLE
DRMBackend: fix crash when GetBackendFb() returns nullptr

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -2561,7 +2561,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 		if ( i < frameInfo->layerCount )
 		{
 			const FrameInfo_t::Layer_t *pLayer = &frameInfo->layers[ i ];
-			gamescope::CDRMFb *pDrmFb = static_cast<gamescope::CDRMFb *>( pLayer->tex ? pLayer->tex->GetBackendFb()->Unwrap() : nullptr );
+			gamescope::CDRMFb *pDrmFb = static_cast<gamescope::CDRMFb *>( pLayer->tex && pLayer->tex->GetBackendFb() ? pLayer->tex->GetBackendFb()->Unwrap() : nullptr );
 
 			if ( pDrmFb == nullptr )
 			{


### PR DESCRIPTION
GetBackendFb() can potentially return nullptr, which now will crash here after the deferred backend was added.

```
0x000056303499e23d in drm_prepare_liftoff (drm=0x563034d99c20 <g_DRM>, frameInfo=0x7ff0ae8d9210, needs_modeset=false) at ../src/Backends/DRMBackend.cpp:2564
0x00005630349a077d in drm_prepare (drm=0x563034d99c20 <g_DRM>, async=false, frameInfo=0x7ff0ae8d9210) at ../src/Backends/DRMBackend.cpp:3026
0x00005630349a872b in gamescope::CDRMBackend::Present (this=0x56305b944480, pFrameInfo=0x7ff0ae8d9210, bAsync=false) at ../src/Backends/DRMBackend.cpp:3488
0x00005630349a18bc in HackyDRMPresent (pFrameInfo=0x7ff0ae8d9210, bAsync=false) at ../src/Backends/DRMBackend.cpp:4013
0x000056303499c0a3 in gamescope::CDRMConnector::Present (this=0x56305b9894d0, pFrameInfo=0x7ff0ae8d9210, bAsync=false) at ../src/Backends/DRMBackend.cpp:2167
0x00005630348459bd in paint_all (pFocus=0x7ff0a85806a0, async=false) at ../src/steamcompmgr.cpp:2816
0x000056303485bd14 in steamcompmgr_main (argc=16, argv=0x7fff56880e98) at ../src/steamcompmgr.cpp:8922
0x00005630348b5b72 in steamCompMgrThreadRun (argc=16, argv=0x7fff56880e98) at ../src/main.cpp:1061
0x00005630348b6ad4 in std::__invoke_impl<void, void (*)(int, char**), int, char**> (__f=@0x56305bb22898: 0x5630348b5b38 <steamCompMgrThreadRun(int, char**)>) at /usr/include/c++/15.2.1/bits/invoke.h:63
0x00005630348b6a3c in std::__invoke<void (*)(int, char**), int, char**> (__fn=@0x56305bb22898: 0x5630348b5b38 <steamCompMgrThreadRun(int, char**)>) at /usr/include/c++/15.2.1/bits/invoke.h:98
0x00005630348b6989 in std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> >::_M_invoke<0ul, 1ul, 2ul> (this=0x56305bb22888) at /usr/include/c++/15.2.1/bits/std_thread.h:303
0x00005630348b6926 in std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> >::operator() (this=0x56305bb22888) at /usr/include/c++/15.2.1/bits/std_thread.h:310
0x00005630348b690a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> > >::_M_run (this=0x56305bb22880) at /usr/include/c++/15.2.1/bits/std_thread.h:255
0x00007ff0bd3002f4 in std::execute_native_thread_routine (__p=0x56305bb22880) at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104
```