### PR TITLE
rendervulkan: check max extents for format modifier

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -1997,7 +1997,18 @@ static VkResult getModifierProps( const VkImageCreateInfo *imageInfo, uint64_t m
 		.pNext = externalFormatProps,
 	};
 
-	return g_device.vk.GetPhysicalDeviceImageFormatProperties2(g_device.physDev(), &imageFormatInfo, &imageProps);
+	VkResult res = g_device.vk.GetPhysicalDeviceImageFormatProperties2(g_device.physDev(), &imageFormatInfo, &imageProps);
+	if ( res != VK_SUCCESS )
+		return res;
+
+	if ( imageInfo->extent.width > imageProps.imageFormatProperties.maxExtent.width ||
+		 imageInfo->extent.height > imageProps.imageFormatProperties.maxExtent.height ||
+		 imageInfo->extent.depth > imageProps.imageFormatProperties.maxExtent.depth )
+	{
+		return VK_ERROR_FORMAT_NOT_SUPPORTED;
+	}
+
+	return VK_SUCCESS;
 }
 
 static VkImageViewType VulkanImageTypeToViewType(VkImageType type)


### PR DESCRIPTION
Adds a check for the format modifier's extents. Previous behavior would fail silently and render a black screen from an unsuitable format being selected.

Immediately noticeable from trying to use a 4k output on Sway with `WLR_RENDERER=vulkan` on RDNA <= 3 (tested on 5700 XT).

Resolves https://github.com/ValveSoftware/gamescope/issues/1977, https://github.com/ValveSoftware/gamescope/issues/2013