### PR TITLE
Do proper wayland teardown cleaning up listeners and fds

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -22,6 +22,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -168,6 +169,14 @@ bool drm_set_mode( struct drm_t *drm, const drmModeModeInfo *mode );
 using namespace std::literals;
 
 struct drm_t g_DRM = {};
+
+// Flip handler thread control. Keep the thread object global so we
+// can join it during shutdown instead of detaching and risking the
+// thread still using the DRM fd while we clean up.
+static std::thread g_page_flip_handler_thread;
+static std::atomic<bool> g_page_flip_handler_thread_should_exit{false};
+
+static int g_page_flip_pipe_fds[2] = { -1, -1 };
 
 namespace gamescope
 {
@@ -785,25 +794,44 @@ void flip_handler_thread_run(void)
 {
 	pthread_setname_np( pthread_self(), "gamescope-kms" );
 
-	struct pollfd pollfd = {
-		.fd = g_DRM.fd,
-		.events = POLLIN,
-	};
+	// Prepare pollfds: one for DRM fd and one for the pipe read end to
+	// detect when the write end is closed (POLLHUP) to exit.
+	struct pollfd fds[2];
+	int nfds = 0;
 
-	while ( true )
+	fds[nfds].fd = g_DRM.fd;
+	fds[nfds].events = POLLIN;
+	nfds++;
+
+	fds[nfds].fd = g_page_flip_pipe_fds[0];
+	fds[nfds].events = POLLIN;
+	nfds++;
+
+	while ( !g_page_flip_handler_thread_should_exit.load( std::memory_order_acquire ) )
 	{
-		int ret = poll( &pollfd, 1, -1 );
+		int ret = poll( fds, nfds, -1 );
 		if ( ret < 0 ) {
+			if ( errno == EINTR )
+				continue;
 			drm_log.errorf_errno( "polling for DRM events failed" );
 			break;
 		}
 
-		drmEventContext evctx = {
-			.version = 3,
-			.page_flip_handler2 = page_flip_handler,
-		};
-		drmHandleEvent(g_DRM.fd, &evctx);
+		// Check if the pipe read end got POLLHUP (write end closed) to exit.
+		if ( fds[1].revents & (POLLIN | POLLHUP) ) {
+			break;
+		}
+
+		if ( (fds[0].revents & POLLIN) ) {
+			drmEventContext evctx = {
+				.version = 3,
+				.page_flip_handler2 = page_flip_handler,
+			};
+			drmHandleEvent( g_DRM.fd, &evctx );
+		}
 	}
+
+	drm_log.debugf("page_flip_handler_thread exiting");
 }
 
 static bool refresh_state( drm_t *drm )
@@ -1397,8 +1425,14 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh)
 		}
 	}
 
-	std::thread flip_handler_thread( flip_handler_thread_run );
-	flip_handler_thread.detach();
+	// Create a pipe to wake the flip handler poll for immediate exit.
+	// Closing the write end will cause the read end to get POLLHUP.
+	if ( pipe2( g_page_flip_pipe_fds, O_CLOEXEC ) != 0 ) {
+		drm_log.errorf_errno( "page-flip pipe creation failed" );
+		return false;
+	}
+
+	g_page_flip_handler_thread = std::thread( flip_handler_thread_run );
 
 	// Set log priority to the max, liftoff_log_scope will filter for us.
 	liftoff_log_set_priority(LIFTOFF_DEBUG);
@@ -1569,9 +1603,23 @@ void finish_drm(struct drm_t *drm)
 	drm->connectors.clear();
 
 
+	// Signal the page-flip handler thread to exit and join it so it won't be
+	// using the DRM fd while we clean it up. Closing the pipe write end
+	// causes the read end to get POLLHUP, waking the thread.
+	if ( g_page_flip_handler_thread.joinable() ) {
+		g_page_flip_handler_thread_should_exit.store( true, std::memory_order_release );
 
-	// We can't close the DRM FD here, it might still be in use by the
-	// page-flip handler thread.
+		close( g_page_flip_pipe_fds[1] );
+		g_page_flip_pipe_fds[1] = -1;
+
+		g_page_flip_handler_thread.join();
+
+		close( g_page_flip_pipe_fds[0] );
+		g_page_flip_pipe_fds[0] = -1;
+	}
+
+	wlsession_close_kms();
+	g_DRM.fd = -1;
 }
 
 gamescope::OwningRc<gamescope::IBackendFb> drm_fbid_from_dmabuf( struct drm_t *drm, struct wlr_dmabuf_attributes *dma_buf )

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1776,6 +1776,8 @@ gamescope_xwayland_server_t::~gamescope_xwayland_server_t()
 	}
 	content_overrides.clear();
 
+	wl_list_remove(&xwayland_ready_listener.link);
+
 	wlr_xwayland_server_destroy(xwayland_server);
 	xwayland_server = nullptr;
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2288,7 +2288,11 @@ void wlserver_run(void)
 
 #if HAVE_SESSION
 	if ( wlserver.wlr.session )
+	{
 		wl_list_remove( &wlserver.session_active.link );
+		wlr_session_destroy( wlserver.wlr.session );
+		wlserver.wlr.session = nullptr;
+	}
 #endif
 
 	wl_display_destroy_clients(wlserver.display);

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1748,6 +1748,7 @@ void wlsession_close_kms()
 		wlserver.wlr.device_change_listener = nullptr;
 	}
 	wlr_session_close_file( wlserver.wlr.session, wlserver.wlr.device );
+	wlserver.wlr.device = nullptr;
 }
 
 #endif

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1732,15 +1732,21 @@ int wlsession_open_kms( const char *device_name ) {
 		}
 	}
 
-	struct wl_listener *listener = new wl_listener();
-	listener->notify = kms_device_handle_change;
-	wl_signal_add( &wlserver.wlr.device->events.change, listener );
+	wlserver.wlr.device_change_listener = new wl_listener();
+	wlserver.wlr.device_change_listener->notify = kms_device_handle_change;
+	wl_signal_add( &wlserver.wlr.device->events.change, wlserver.wlr.device_change_listener );
 
 	return wlserver.wlr.device->fd;
 }
 
 void wlsession_close_kms()
 {
+	if ( wlserver.wlr.device_change_listener )
+	{
+		wl_list_remove( &wlserver.wlr.device_change_listener->link );
+		delete wlserver.wlr.device_change_listener;
+		wlserver.wlr.device_change_listener = nullptr;
+	}
 	wlr_session_close_file( wlserver.wlr.session, wlserver.wlr.device );
 }
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -610,6 +610,9 @@ static void handle_wl_surface_destroy( struct wl_listener *l, void *data )
 		wl_resource_set_user_data( pSwapchain, nullptr );
 	}
 
+	wl_list_remove( &surf->commit.link );
+	wl_list_remove( &surf->destroy.link );
+
 	delete surf;
 }
 

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2245,6 +2245,19 @@ void wlserver_run(void)
 	// wlroots will restart it automatically.
 	wlserver_lock();
 	wlserver.wlr.xwayland_servers.clear();
+
+	wl_list_remove( &new_surface_listener.link );
+	wl_list_remove( &new_input_listener.link );
+	wl_list_remove( &wlserver.new_pointer_constraint.link );
+	wl_list_remove( &wlserver.new_xdg_surface.link );
+	wl_list_remove( &wlserver.new_xdg_toplevel.link );
+	wl_list_remove( &wlserver.new_layer_shell_surface.link );
+
+#if HAVE_SESSION
+	if ( wlserver.wlr.session )
+		wl_list_remove( &wlserver.session_active.link );
+#endif
+
 	wl_display_destroy_clients(wlserver.display);
 	wl_display_destroy(wlserver.display);
     wlserver.display = NULL;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2252,6 +2252,19 @@ void wlserver_run(void)
 	// wlroots will restart it automatically.
 	wlserver_lock();
 	wlserver.wlr.xwayland_servers.clear();
+
+	wl_list_remove( &new_surface_listener.link );
+	wl_list_remove( &new_input_listener.link );
+	wl_list_remove( &wlserver.new_pointer_constraint.link );
+	wl_list_remove( &wlserver.new_xdg_surface.link );
+	wl_list_remove( &wlserver.new_xdg_toplevel.link );
+	wl_list_remove( &wlserver.new_layer_shell_surface.link );
+
+#if HAVE_SESSION
+	if ( wlserver.wlr.session )
+		wl_list_remove( &wlserver.session_active.link );
+#endif
+
 	wl_display_destroy_clients(wlserver.display);
 	wl_display_destroy(wlserver.display);
     wlserver.display = NULL;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1732,9 +1732,8 @@ int wlsession_open_kms( const char *device_name ) {
 		}
 	}
 
-	struct wl_listener *listener = new wl_listener();
-	listener->notify = kms_device_handle_change;
-	wl_signal_add( &wlserver.wlr.device->events.change, listener );
+	wlserver.wlr.device_change_listener.notify = kms_device_handle_change;
+	wl_signal_add( &wlserver.wlr.device->events.change, &wlserver.wlr.device_change_listener );
 
 	return wlserver.wlr.device->fd;
 }

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1745,6 +1745,7 @@ void wlsession_close_kms()
 		wl_list_remove( &wlserver.wlr.device_change_listener.link );
 	}
 	wlr_session_close_file( wlserver.wlr.session, wlserver.wlr.device );
+	wlserver.wlr.device = nullptr;
 }
 
 #endif

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1740,6 +1740,10 @@ int wlsession_open_kms( const char *device_name ) {
 
 void wlsession_close_kms()
 {
+	if ( wlserver.wlr.device )
+	{
+		wl_list_remove( &wlserver.wlr.device_change_listener.link );
+	}
 	wlr_session_close_file( wlserver.wlr.session, wlserver.wlr.device );
 }
 

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -210,6 +210,7 @@ struct wlserver_pointer {
 	struct wl_listener button;
 	struct wl_listener axis;
 	struct wl_listener frame;
+	struct wl_listener destroy;
 };
 
 struct wlserver_touch {
@@ -218,6 +219,7 @@ struct wlserver_touch {
 	struct wl_listener down;
 	struct wl_listener up;
 	struct wl_listener motion;
+	struct wl_listener destroy;
 
     gamescope::IBackendConnector* connector;
 };

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -125,6 +125,7 @@ struct wlserver_t {
 		struct wlr_keyboard *virtual_keyboard_device;
 
 		struct wlr_device *device;
+		struct wl_listener *device_change_listener = nullptr;
 
 		std::vector<std::unique_ptr<gamescope_xwayland_server_t>> xwayland_servers;
 	} wlr;

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -125,6 +125,7 @@ struct wlserver_t {
 		struct wlr_keyboard *virtual_keyboard_device;
 
 		struct wlr_device *device;
+		struct wl_listener device_change_listener = {};
 
 		std::vector<std::unique_ptr<gamescope_xwayland_server_t>> xwayland_servers;
 	} wlr;


### PR DESCRIPTION
In debian we're already using wlroots-0.19, but with it every time a client window is closed or when gamescope itself is closed, we crash with an assertion error.

So remove event listeners (helping #1990) and close the drm FD, ensuring that the page-flip thread is completed.

See commits for details.