### PR TITLE
edid: rotate non-HDR displays with bRotate as well

### DIFF
--- a/src/edid.cpp
+++ b/src/edid.cpp
@@ -124,7 +124,7 @@ namespace gamescope
         // an external display attached.
         // (Allows for debugging undocked fallback without undocking/redocking)
         if ( !hdrInfo.ShouldPatchEDID() )
-            return std::nullopt;
+            return bRotate ? std::optional( edid ) : std::nullopt;
 
         // TODO: Allow for override of min luminance
 #if 0


### PR DESCRIPTION
Closes: https://github.com/ValveSoftware/gamescope/issues/2019