### PR TITLE
add ability to restore the focus just by the update the prop

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3597,6 +3597,25 @@ found:;
 		}
 	}
 
+	if ( eStrategy == gamescope::VirtualConnectorStrategies::SingleApplication )
+	{
+		if ( focusControlWindow != None )
+		{
+			for ( steamcompmgr_win_t *focusable_window : vecPossibleFocusWindows )
+			{
+				if ( focusable_window->type != steamcompmgr_win_type_t::XWAYLAND )
+					continue;
+
+				if ( focusable_window->xwayland().id == focusControlWindow )
+				{
+					override_focus = focus = focusable_window;
+					localGameFocused = true;
+					break;
+				}
+			}
+		}
+	}
+
 	if ( focus )
 	{
 		if ( window_has_commits( focus ) ) 


### PR DESCRIPTION
Add ability to use GAMESCOPECTRL_BASELAYER_WINDOW to force SingleApplication to focus game windows.

I need this because I am using Wine to execute Steam without a desktop environment.
In some cases, Steam restarts itself. When this happens, it may completely take over the input focus, making it impossible to return focus to the intended window.

This is a conceptual solution that allows the user to manually override the focus when such situations occur.

Although there is an existing SteamControlled strategy, I prefer not to fully manage or control focus behavior myself.
I only need a lightweight mechanism that allows overriding the focus when it becomes incorrect.

You can use `xprop -f GAMESCOPECTRL_BASELAYER_WINDOW 32x1 -set GAMESCOPECTRL_BASELAYER_WINDOW "XXXX" ` to change the x11 prop value to trigger the focus change if the focus is incorrect