### PR TITLE
Fix Steam Remote Play black screen (Intel/NVIDIA) and inverted R/B colours (NVIDIA)

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3605,6 +3605,7 @@ gamescope::Rc<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, 
 			screenshotImageFlags.bMappable = true;
 			screenshotImageFlags.bTransferDst = true;
 			screenshotImageFlags.bStorage = true;
+			screenshotImageFlags.bSampled = true; // required for RGB-to-NV12 shader to sample this texture
 			if (exportable || drmFormat == DRM_FORMAT_NV12) {
 				screenshotImageFlags.bExportable = true;
 				screenshotImageFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3639,6 +3639,7 @@ static gamescope::Rc<CVulkanTexture> acquire_pooled_texture( auto& pool, uint32_
 			textureFlags.bMappable = true;
 			textureFlags.bTransferDst = true;
 			textureFlags.bStorage = true;
+			textureFlags.bSampled = true; // required for RGB-to-NV12 shader to sample this texture
 			if (exportable || drmFormat == DRM_FORMAT_NV12) {
 				textureFlags.bExportable = true;
 				textureFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -466,14 +466,20 @@ bool CVulkanDevice::createDevice()
 		vk_log.warnf( "physical device doesn't support VK_EXT_physical_device_drm" );
 	} else {
 #if HAVE_DRM
+		VkPhysicalDeviceDriverProperties driverProps = {
+			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES,
+		};
 		VkPhysicalDeviceDrmPropertiesEXT drmProps = {
 			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT,
+			.pNext = &driverProps,
 		};
 		VkPhysicalDeviceProperties2 props2 = {
 			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
 			.pNext = &drmProps,
 		};
 		vk.GetPhysicalDeviceProperties2( physDev(), &props2 );
+
+		m_bIsNvidiaProprietaryDriver = driverProps.driverID == VK_DRIVER_ID_NVIDIA_PROPRIETARY;
 
 		if ( !GetBackend()->UsesVulkanSwapchain() && !drmProps.hasPrimary ) {
 			vk_log.errorf( "physical device has no primary node" );

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -806,6 +806,7 @@ public:
 	inline bool hasDrmPrimaryDevId() {return m_bHasDrmPrimaryDevId;}
 	inline dev_t primaryDevId() {return m_drmPrimaryDevId;}
 	inline bool supportsFp16() {return m_bSupportsFp16;}
+	inline bool isNvidiaProprietaryDriver() {return m_bIsNvidiaProprietaryDriver;}
 	inline std::vector<VkExtensionProperties>& supportedExtensions() {return m_supportedExts;}
 
 	inline std::pair<void *, uint32_t> uploadBufferData(uint32_t size)
@@ -870,6 +871,7 @@ protected:
 	bool m_bSupportsFp16 = false;
 	bool m_bHasDrmPrimaryDevId = false;
 	bool m_bSupportsModifiers = false;
+	bool m_bIsNvidiaProprietaryDriver = false;
 	bool m_bInitialized = false;
 
 

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -804,6 +804,7 @@ public:
 	inline bool hasDrmPrimaryDevId() {return m_bHasDrmPrimaryDevId;}
 	inline dev_t primaryDevId() {return m_drmPrimaryDevId;}
 	inline bool supportsFp16() {return m_bSupportsFp16;}
+	inline bool isNvidiaProprietaryDriver() {return m_bIsNvidiaProprietaryDriver;}
 	inline std::vector<VkExtensionProperties>& supportedExtensions() {return m_supportedExts;}
 
 	inline std::pair<void *, uint32_t> uploadBufferData(uint32_t size)
@@ -868,6 +869,7 @@ protected:
 	bool m_bSupportsFp16 = false;
 	bool m_bHasDrmPrimaryDevId = false;
 	bool m_bSupportsModifiers = false;
+	bool m_bIsNvidiaProprietaryDriver = false;
 	bool m_bInitialized = false;
 
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2404,8 +2404,15 @@ static void paint_pipewire()
 				( cv_overlay_unmultiplied_alpha ? PaintWindowFlag::CoverageMode : 0 )  );
 	}
 
+	// On the NVIDIA proprietary driver, sampling VK_FORMAT_A2R10G10B10_UNORM_PACK32
+	// (DRM_FORMAT_XRGB2101010) storage images returns R and B swapped, causing colour
+	// inversion in the RGB-to-NV12 conversion shader. Use DRM_FORMAT_XBGR2101010
+	// (VK_FORMAT_A2B10G10R10_UNORM_PACK32) instead so components arrive in the correct
+	// order. This does not affect non-proprietary NVIDIA drivers or other vendors.
+	const uint32_t uRGBCaptureFormat = g_device.isNvidiaProprietaryDriver()
+		? DRM_FORMAT_XBGR2101010 : DRM_FORMAT_XRGB2101010;
 	gamescope::Rc<CVulkanTexture> pRGBTexture = s_pPipewireBuffer->texture->isYcbcr()
-		? vulkan_acquire_screenshot_texture( uWidth, uHeight, false, DRM_FORMAT_XRGB2101010 )
+		? vulkan_acquire_screenshot_texture( uWidth, uHeight, false, uRGBCaptureFormat )
 		: gamescope::Rc<CVulkanTexture>{ s_pPipewireBuffer->texture };
 
 	gamescope::Rc<CVulkanTexture> pYUVTexture = s_pPipewireBuffer->texture->isYcbcr() ? s_pPipewireBuffer->texture : nullptr;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2404,8 +2404,15 @@ static void paint_pipewire()
 				( cv_overlay_unmultiplied_alpha ? PaintWindowFlag::CoverageMode : 0 )  );
 	}
 
+	// On the NVIDIA proprietary driver, sampling VK_FORMAT_A2R10G10B10_UNORM_PACK32
+	// (DRM_FORMAT_XRGB2101010) storage images returns R and B swapped, causing colour
+	// inversion in the RGB-to-NV12 conversion shader. Use DRM_FORMAT_XBGR2101010
+	// (VK_FORMAT_A2B10G10R10_UNORM_PACK32) instead so components arrive in the correct
+	// order. This does not affect non-proprietary NVIDIA drivers or other vendors.
+	const uint32_t uRGBCaptureFormat = g_device.isNvidiaProprietaryDriver()
+		? DRM_FORMAT_XBGR2101010 : DRM_FORMAT_XRGB2101010;
 	gamescope::Rc<CVulkanTexture> pRGBTexture = s_pPipewireBuffer->texture->isYcbcr()
-		? vulkan_acquire_capture_texture( uWidth, uHeight, false, DRM_FORMAT_XRGB2101010 )
+		? vulkan_acquire_capture_texture( uWidth, uHeight, false, uRGBCaptureFormat )
 		: gamescope::Rc<CVulkanTexture>{ s_pPipewireBuffer->texture };
 
 	gamescope::Rc<CVulkanTexture> pYUVTexture = s_pPipewireBuffer->texture->isYcbcr() ? s_pPipewireBuffer->texture : nullptr;


### PR DESCRIPTION
## Fix black screen (Intel/NVIDIA) and inverted colours (NVIDIA) when streaming via Steam Remote Play

Two issues affect PipeWire streaming (e.g. Steam Remote Play).

**Black screen:** Screenshot textures were created without `bSampled = true`, so no sampled image view was created for the RGB-to-NV12 conversion shader, resulting in a black frame. Fixed by adding `bSampled = true` in `vulkan_acquire_screenshot_texture()`. This is safe on all hardware and also fixes the same black screen on Intel (confirmed by @matte-schwartz in the PR comments).

**Inverted R/B channels:** Sampling a `VK_FORMAT_A2R10G10B10_UNORM_PACK32` storage image on the NVIDIA proprietary driver returns R and B swapped. The RGB-to-NV12 colour matrix then operates on the wrong channels, causing the remote client to display inverted red and blue. Fixed by using `DRM_FORMAT_XBGR2101010` as the intermediate capture format on NVIDIA, compensating for the driver's component ordering.

The colour fix is gated on `VK_DRIVER_ID_NVIDIA_PROPRIETARY` and has no effect on Nouveau, NVK, Intel, or any other vendor. A new `isNvidiaProprietaryDriver()` accessor is added to `CVulkanDevice`, populated via `VkPhysicalDeviceDriverProperties` chained into the existing `GetPhysicalDeviceProperties2` call in `createDevice()`.

Per review feedback, split into two commits: the sampling fix (Intel + NVIDIA) and the NVIDIA-specific colour swap.

Tested with NVIDIA RTX 4080, with Steam Remote Play in Game Mode (using Jovian) to Steam Link on an iPhone (PipeWire NV12 + NVENC AV1).