### PR TITLE
Close fd on mmap failure in CreateShmBuffer

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -179,7 +179,10 @@ namespace gamescope
         {
             void *pMappedData = mmap( nullptr, uSize, PROT_READ | PROT_WRITE, MAP_SHARED, nFd, 0 );
             if ( pMappedData == MAP_FAILED )
+            {
+                close( nFd );
                 return -1;
+            }
             defer( munmap( pMappedData, uSize ) );
 
             memcpy( pMappedData, pData, uSize );


### PR DESCRIPTION
The ftruncate error path closes the fd, but the mmap error path doesn't. This leaks the fd (and the backing tmpfs pages, since the file is already unlinked).