### PR TITLE
Move sol usertype registration to dedicated TU

### DIFF
--- a/src/Script/Script.h
+++ b/src/Script/Script.h
@@ -159,26 +159,6 @@ namespace gamescope
         return out;
     }
 
-    #define SCRIPTDESC_TEMPLATE( type ) template <typename type>
-    #define DECLARE_SCRIPTDESC( type ) \
-        static sol::usertype< type > s_ScriptType; \
-        class CEnsureScriptTypeInstantiation { public: CEnsureScriptTypeInstantiation() { (void) type :: s_ScriptType; } } m_EnsureTemplateInstantiation_ScriptDesc;
-
-    #define START_SCRIPTDESC( type, lua_name ) \
-        inline sol::usertype<type> type::s_ScriptType = CScriptScopedLock()->new_usertype<type>( lua_name
-    #define START_SCRIPTDESC_ANON( type ) \
-        inline sol::usertype<type> type::s_ScriptType = CScriptScopedLock()->new_usertype<type>( typeid( type ).name()
-    #define SCRIPTDESC( x, y ) , x, y
-    #define END_SCRIPTDESC() );
 }
-
-#else
-
-    #define SCRIPTDESC_TEMPLATE( type )
-    #define DECLARE_SCRIPTDESC( x )
-    #define START_SCRIPTDESC( type, lua_name )
-    #define START_SCRIPTDESC_ANON( type )
-    #define SCRIPTDESC( x, y )
-    #define END_SCRIPTDESC()
 
 #endif

--- a/src/convar.cpp
+++ b/src/convar.cpp
@@ -16,10 +16,8 @@ namespace gamescope
         assert( !GetCommands().contains( pszName ) );
         GetCommands()[ std::string( pszName ) ] = this;
 
-#if HAVE_SCRIPTING
         if ( bRegisterScript )
-            CScriptScopedLock().Manager().Gamescope().Convars.Base[pszName] = this;
-#endif
+            RegisterScript( pszName, this );
     }
 
     ConCommand::~ConCommand()
@@ -81,4 +79,10 @@ namespace gamescope
     {
         PrintVersion();
     });
+
+#if !HAVE_SCRIPTING
+    void ConCommand::RegisterScript( std::string_view, ConCommand * )
+    {
+    }
+#endif
 }

--- a/src/convar.h
+++ b/src/convar.h
@@ -12,7 +12,6 @@
 #include <functional>
 #include <cassert>
 
-#include "Script/Script.h"
 #include "Utils/Dict.h"
 
 #include "log.hpp"
@@ -84,13 +83,14 @@ namespace gamescope
         return tokens;
     }
 
+    namespace detail { struct ConVarScriptRegistrar; }
+
     class ConCommand
     {
+        friend struct detail::ConVarScriptRegistrar;
         using ConCommandFunc = std::function<void( std::span<std::string_view> )>;
 
     public:
-        DECLARE_SCRIPTDESC( ConCommand );
-
         ConCommand( std::string_view pszName, std::string_view pszDescription, ConCommandFunc func, bool bRegisterScript = true );
         ~ConCommand();
 
@@ -116,25 +116,20 @@ namespace gamescope
         std::string_view GetDescription() const { return m_pszDescription; }
 
         static Dict<ConCommand *>& GetCommands();
+        static void RegisterScript( std::string_view name, ConCommand *cmd );
     protected:
         std::string_view m_pszName;
         std::string_view m_pszDescription;
         ConCommandFunc m_Func;
     };
 
-    START_SCRIPTDESC( ConCommand, "concommand" )
-        SCRIPTDESC( "name", &ConCommand::m_pszName )
-        SCRIPTDESC( "description", &ConCommand::m_pszDescription )
-        SCRIPTDESC( "call", &ConCommand::CallWithArgString )
-    END_SCRIPTDESC()
 
     template <typename T>
     class ConVar : public ConCommand
     {
+        friend struct detail::ConVarScriptRegistrar;
         using ConVarCallbackFunc = std::function<void(ConVar<T> &)>;
     public:
-        DECLARE_SCRIPTDESC( ConVar<T> );
-
         ConVar( std::string_view pszName, T defaultValue = T{}, std::string_view pszDescription = "", ConVarCallbackFunc func = nullptr, bool bRunCallbackAtStartup = false, bool bRegisterScript = true )
             : ConCommand( pszName, pszDescription, [this]( std::span<std::string_view> pArgs ){ this->InvokeFunc( pArgs ); }, false )
             , m_Value{ defaultValue }
@@ -145,12 +140,10 @@ namespace gamescope
                 RunCallback();
             }
 
-#if HAVE_SCRIPTING
             if ( bRegisterScript )
             {
-                CScriptScopedLock().Manager().Gamescope().Convars.Base[pszName] = this;
+                RegisterScript( pszName, this );
             }
-#endif
         }
 
         const T& Get() const
@@ -237,13 +230,5 @@ namespace gamescope
         bool m_bInCallback;
     };
 
-    SCRIPTDESC_TEMPLATE( T )
-    START_SCRIPTDESC_ANON( ConVar<T> )
-        SCRIPTDESC( "name", &ConVar<T>::m_pszName )
-        SCRIPTDESC( "description", &ConVar<T>::m_pszDescription )
-        SCRIPTDESC( "call", &ConVar<T>::CallWithArgString )
-
-        SCRIPTDESC( "value", &ConVar<T>::m_Value )
-    END_SCRIPTDESC()
 
 }

--- a/src/convar_script.cpp
+++ b/src/convar_script.cpp
@@ -1,0 +1,52 @@
+#include "convar.h"
+#include "Script/Script.h"
+#include "backend.h"
+
+namespace gamescope
+{
+#if HAVE_SCRIPTING
+    namespace detail
+    {
+        struct ConVarScriptRegistrar
+        {
+            static sol::usertype<ConCommand> RegisterConCommand()
+            {
+                return CScriptScopedLock()->new_usertype<ConCommand>( "concommand",
+                    "name", &ConCommand::m_pszName,
+                    "description", &ConCommand::m_pszDescription,
+                    "call", &ConCommand::CallWithArgString );
+            }
+
+            template <typename T>
+            static sol::usertype<ConVar<T>> RegisterConVarType()
+            {
+                return CScriptScopedLock()->new_usertype<ConVar<T>>(
+                    typeid( ConVar<T> ).name(),
+                    "name", &ConVar<T>::m_pszName,
+                    "description", &ConVar<T>::m_pszDescription,
+                    "call", &ConVar<T>::CallWithArgString,
+                    "value", &ConVar<T>::m_Value );
+            }
+        };
+    }
+
+    static auto s_ConCommandType = detail::ConVarScriptRegistrar::RegisterConCommand();
+    static auto s_CVBool   = detail::ConVarScriptRegistrar::RegisterConVarType<bool>();
+    static auto s_CVInt    = detail::ConVarScriptRegistrar::RegisterConVarType<int>();
+    static auto s_CVFloat  = detail::ConVarScriptRegistrar::RegisterConVarType<float>();
+    static auto s_CVU32    = detail::ConVarScriptRegistrar::RegisterConVarType<uint32_t>();
+    static auto s_CVU64    = detail::ConVarScriptRegistrar::RegisterConVarType<uint64_t>();
+    static auto s_CVString = detail::ConVarScriptRegistrar::RegisterConVarType<std::string>();
+    static auto s_CVVCS    = detail::ConVarScriptRegistrar::RegisterConVarType<VirtualConnectorStrategy>();
+    static auto s_CVTCM    = detail::ConVarScriptRegistrar::RegisterConVarType<TouchClickMode>();
+
+    void ConCommand::RegisterScript( std::string_view name, ConCommand *cmd )
+    {
+        CScriptScopedLock().Manager().Gamescope().Convars.Base[name] = cmd;
+    }
+#else
+    void ConCommand::RegisterScript( std::string_view, ConCommand * )
+    {
+    }
+#endif
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -106,6 +106,7 @@ src = [
   'BufferMemo.cpp',
   'steamcompmgr.cpp',
   'convar.cpp',
+  'convar_script.cpp',
   'commit.cpp',
   'color_helpers.cpp',
   'main.cpp',

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -90,6 +90,7 @@
 #include "edid.h"
 #include "hdmi.h"
 #include "convar.h"
+#include "Script/Script.h"
 #include "refresh_rate.h"
 #include "commit.h"
 #include "reshade_effect_manager.hpp"


### PR DESCRIPTION
The sol2 header is massive. Instantiating a static in every file also has implications on binary size.

Move usertype registration to a dedicated translation unit, per official advice [1].

[1]: https://sol2.readthedocs.io/en/latest/compilation.html