### PR TITLE
wlserver: keep cursor position in sync when constraint rejects motion

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2681,6 +2681,17 @@ void wlserver_mousemotion( double dx, double dy, uint32_t time )
 
 	if ( !wlserver_apply_constraint( &dx, &dy ) )
 	{
+		// Even when the constraint rejects motion, keep the cursor position
+		// in sync so subsequent button events have correct coordinates and
+		// the camera doesn't snap when the constraint is released.
+		if ( g_bForceRelativeMouse )
+		{
+			wlserver.mouse_surface_cursorx += dx;
+			wlserver.mouse_surface_cursory += dy;
+			wlserver_clampcursor();
+			wlserver_oncursorevent();
+			wlr_seat_pointer_notify_motion( wlserver.wlr.seat, time, wlserver.mouse_surface_cursorx, wlserver.mouse_surface_cursory );
+		}
 		wlr_seat_pointer_notify_frame( wlserver.wlr.seat );
 		return;
 	}


### PR DESCRIPTION
When `--force-grab-cursor` is active and the inner XWayland client sets a locked pointer constraint, `wlserver_apply_constraint()` rejects the motion and returns early. The problem is that the early return skips updating `mouse_surface_cursorx`/`cursory`, even though relative motion was already forwarded by `wlserver_perform_rel_pointer_motion()` just above.

This means the absolute cursor position gets stuck at wherever it was when the constraint kicked in. Games that use both relative motion (camera/mouselook) and absolute position (UI clicks) via XWayland see the camera snap to a fixed angle because the stale absolute coords get used on the next accepted motion or button event.

I hit this running EverQuest under Wine in multiple concurrent gamescope instances (6 clients, each in its own gamescope with `--force-grab-cursor`). A single instance worked fine — the issue only appeared with multiple instances. EQ uses DirectInput for mouselook (relative) and XWayland absolute positioning for UI interaction, so the stale coordinates caused the camera to fight the player on every mouselook release.

The fix keeps the cursor position tracking in sync even when the constraint blocks. Only runs under `g_bForceRelativeMouse` so normal constraint behavior is untouched.

Related issues: #1748 #1428 #1470