### PR TITLE
wayland: avoid stale wl_buffer destroy after unmatched release

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -494,6 +494,7 @@ namespace gamescope
         wl_buffer *m_pHostBuffer = nullptr;
         wlr_buffer *m_pClientBuffer = nullptr;
         bool m_bCompositorAcquired = false;
+        bool m_bSawReleaseWithoutAcquire = false;
     };
     const wl_buffer_listener CWaylandFb::s_BufferListener =
     {
@@ -929,7 +930,10 @@ namespace gamescope
     CWaylandFb::~CWaylandFb()
     {
         // I own the pHostBuffer.
-        wl_buffer_destroy( m_pHostBuffer );
+        if ( m_bSawReleaseWithoutAcquire )
+            wl_proxy_destroy( (wl_proxy *)m_pHostBuffer );
+        else
+            wl_buffer_destroy( m_pHostBuffer );
         m_pHostBuffer = nullptr;
     }
 
@@ -956,6 +960,7 @@ namespace gamescope
         }
         else
         {
+            m_bSawReleaseWithoutAcquire = true;
             xdg_log.errorf( "Compositor released us but we were not acquired. Oh no." );
         }
     }


### PR DESCRIPTION
Some compositors (observed on Hyprland) can send `wl_buffer.release` for a buffer that gamescope never marked as compositor-acquired, which puts the buffer into a release-without-acquire state. In that state, sending `wl_buffer.destroy` later can target a stale server-side object id and trigger a protocol error (e.g. "invalid object 49"), aborting nested `--backend wayland` sessions.

Track this release-without-acquire condition in CWaylandFb and, in that case, destroy only the local proxy with `wl_proxy_destroy` instead of emitting `wl_buffer.destroy`.
Normal buffers keep the existing `wl_buffer_destroy` path.

edit: can't find the issue number anymore, but this fixes `--backend wayland` being completely unusable on some setups, and forcing the use of `--backend sdl`.