### PR TITLE
steamcompmgr: Fix regression in --force-windows-fullscreeen caused by 81d6554.

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3872,7 +3872,7 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 
 	if ( win_has_game_id( w ) )
 	{
-		if ( window_is_fullscreen( ctx->focus.focusWindow ) )
+		if ( window_is_fullscreen( ctx->focus.focusWindow ) || ctx->force_windows_fullscreen )
 		{
 			bool bIsSteam = window_is_steam( ctx->focus.focusWindow );
 			int fs_width  = ctx->root_width;
@@ -4562,7 +4562,7 @@ handle_desktop_window(steamcompmgr_win_t *w)
 
 	xwayland_ctx_t *ctx = w->xwayland().ctx;
 
-	if ( w->sizeHintsSpecified && !window_is_fullscreen( w ) )
+	if ( w->sizeHintsSpecified && !(window_is_fullscreen( w ) || ctx->force_windows_fullscreen) )
 	{
 		if ((unsigned)w->GetGeometry().nWidth != w->requestedWidth || (unsigned)w->GetGeometry().nHeight != w->requestedHeight)
 		{


### PR DESCRIPTION
Fix the issue of the `--force-windows-fullscreen` option no longer being respected in gamescope after some changes done on [81d6554](https://github.com/ValveSoftware/gamescope/commit/81d6554a2b55a4e8cd7ad9c6636a1cfc3ab5a278#diff-452db373032f99b8c4bd2ed8b40bbd2bab7bed63bf8c51714acc025ea9b6200fL3868) that incorrectly forgot to apply the proper window resize rules, instead only operating on windows that self-declare as fullscreen, neglecting the forceful setting.

First reported on issue #2053. 