### PR TITLE
Scripts: Add extended refresh rates and 60Hz timing for OneXPlayer F1 OLED

### DIFF
--- a/scripts/00-gamescope/displays/onexplayer.f1.oled.lua
+++ b/scripts/00-gamescope/displays/onexplayer.f1.oled.lua
@@ -8,8 +8,12 @@ local oxp_f1_oled_colorimetry = {
 gamescope.config.known_displays.oxp_f1_oled = {
 	pretty_name = "YHB02P25 OLED",
 	dynamic_refresh_rates = {
-		120,
-		144,
+		40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+		50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+		60, 61, 62, 63, 64, 65, 66, 67, 68, 69,
+		70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+		80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
+		90, 100, 110, 120, 130, 140, 144,
 	},
 	hdr = {
 		supported = true,
@@ -25,7 +29,13 @@ gamescope.config.known_displays.oxp_f1_oled = {
 		local mode = base_mode
 
 		gamescope.modegen.set_resolution(mode, 1080, 1920)
-		gamescope.modegen.set_h_timings(mode, 80, 44, 156)
+		if refresh <= 60 then
+			-- EDID DTD 3: native 60Hz uses different horizontal blanking
+			gamescope.modegen.set_h_timings(mode, 90, 18, 72)
+		else
+			-- EDID DTD 1/2: native 120/144Hz timings
+			gamescope.modegen.set_h_timings(mode, 80, 44, 156)
+		end
 		gamescope.modegen.set_v_timings(mode, 48, 2, 14)
 
 		mode.clock = gamescope.modegen.calc_max_clock(mode, refresh)


### PR DESCRIPTION
Extends the OneXPlayer F1 OLED display script with fine-grained refresh rates and native 60Hz timing.

## Changes

### Extended refresh rates (40-90Hz in 1Hz steps, plus 100-144Hz)

The current config only supports 120Hz and 144Hz. This is very limiting for handheld use where lower refresh rates (60-90Hz) are essential for battery life. The panel's `dynamic_modegen` generates correct timings for any refresh rate via `calc_max_clock`, so adding intermediate rates is safe.

The 40-90Hz 1Hz-step range follows the same approach as the Steam Deck OLED display script (`valve.steamdeck.oled.lua`), giving users fine-grained control over refresh rate in the QAM slider.

### Native 60Hz timing from EDID DTD 3

The panel EDID reports different horizontal blanking for 60Hz (DTD 3) vs 120/144Hz (DTD 1/2):

| Mode | Hfront | Hsync | Hback | Total H |
|------|--------|-------|-------|---------|
| 120/144Hz (DTD 1/2) | 80 | 44 | 156 | 1360 |
| 60Hz (DTD 3) | 90 | 18 | 72 | 1260 |

The previous approach avoided 60Hz entirely and used 120Hz with frame limiting. However, running at actual 60Hz modeset consumes less panel power than driving at 120Hz with frame limiting, which matters for handheld battery life.

## Testing

Tested on OneXPlayer F1 EVA-02 (same YHB02P25 panel) running Bazzite:
- All refresh rates from 40-144Hz generate valid modes
- QAM slider shows fine-grained refresh rate selection
- 60Hz mode works correctly with native EDID timing
- No display artifacts or black screen transitions

## EDID Reference

```
Manufacturer: YHB, Model: YHB02P25
DTD 1: 1080x1920 @ 144Hz - Hfront 80, Hsync 44, Hback 156
DTD 2: 1080x1920 @ 120Hz - Hfront 80, Hsync 44, Hback 156
DTD 3: 1080x1920 @  60Hz - Hfront 90, Hsync 18, Hback 72
HDR: BT2020RGB, Max 687 cd/m², Avg 400 cd/m², Min 0.005 cd/m²
```