### PR TITLE
Support both stb_image_resize.h and stb_image_resize2.h

### DIFF
--- a/src/reshade_effect_manager.cpp
+++ b/src/reshade_effect_manager.cpp
@@ -17,7 +17,11 @@
 
 #include <stb_image.h>
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
+#if __has_include(<stb_image_resize2.h>)
+#include <stb_image_resize2.h>
+#else
 #include <stb_image_resize.h>
+#endif
 
 #include <mutex>
 #include <unistd.h>
@@ -1150,7 +1154,13 @@ bool ReshadeEffectPipeline::init(CVulkanDevice *device, const ReshadeEffectKey &
                 if (w != (int)texture->width() || h != (int)texture->height())
                 {
                     resized_data.resize(texture->width() * texture->height() * 4);
+#if __has_include(<stb_image_resize2.h>)
+                    // stb_image_resize2 renames stbir_resize_uint8 to stbir_resize_uint8_linear
+                    // (stbir_resize_uint8_srgb is the gamma-aware variant).
+                    stbir_resize_uint8_linear(data, w, h, 0, resized_data.data(), texture->width(), texture->height(), 0, STBIR_RGBA);
+#else
                     stbir_resize_uint8(data, w, h, 0, resized_data.data(), texture->width(), texture->height(), 0, STBI_rgb_alpha);
+#endif
 
                     w = texture->width();
                     h = texture->height();

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -116,7 +116,11 @@ static const int g_nBaseCursorScale = 36;
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image.h>
 #include <stb_image_write.h>
+#if __has_include(<stb_image_resize2.h>)
+#include <stb_image_resize2.h>
+#else
 #include <stb_image_resize.h>
+#endif
 
 #define GPUVIS_TRACE_IMPLEMENTATION
 #include "gpuvis_trace_utils.h"
@@ -1789,9 +1793,17 @@ bool MouseCursor::getTexture()
 				}
 			} 
 			std::vector<uint32_t> resizeBuffer( nDesiredWidth * nDesiredHeight );
+#if __has_include(<stb_image_resize2.h>)
+			// stb_image_resize2 replaces (num_channels=4, alpha_channel=3,
+			// STBIR_FLAG_ALPHA_PREMULTIPLIED) with a single STBIR_RGBA_PM enum.
+			stbir_resize_uint8_srgb( (unsigned char *)pixels.data(),       image->width,  image->height,  0,
+									 (unsigned char *)resizeBuffer.data(), nDesiredWidth, nDesiredHeight, 0,
+									 STBIR_RGBA_PM );
+#else
 			stbir_resize_uint8_srgb( (unsigned char *)pixels.data(),       image->width,  image->height,  0,
 									 (unsigned char *)resizeBuffer.data(), nDesiredWidth, nDesiredHeight, 0,
 									 4, 3, STBIR_FLAG_ALPHA_PREMULTIPLIED );
+#endif
 
 			cursorBuffer = std::vector<uint32_t>(surfaceWidth * surfaceHeight);
 			for (int i = 0; i < nDesiredHeight; i++)


### PR DESCRIPTION
Uses `__has_include` to detect which stb image resize header is available and conditionally use the appropriate API. This allows building against both old stb (which provides `stb_image_resize.h`) and new stb (which replaced it with `stb_image_resize2.h`).

The newer versions of the [nothings/stb](https://github.com/nothings/stb) repository moved `stb_image_resize.h` to `deprecated/` and replaced it with `stb_image_resize2.h`. This change adds compatibility so gamescope can build against either version.

This is intended to be used in combination with #1846 when needed by Linux distributions (e.g. NixOS) that use a system-level stb package rather than the vendored subproject.

API mapping:
- `stbir_resize_uint8` → `stbir_resize_uint8_linear` (the non-gamma-corrected variant; `stbir_resize_uint8_srgb` is the gamma-aware one)
- `stbir_resize_uint8_srgb` parameters `(num_channels=4, alpha_channel=3, STBIR_FLAG_ALPHA_PREMULTIPLIED)` → single `stbir_pixel_layout` enum `STBIR_RGBA_PM`