### PR TITLE
steamcompmgr: Downgrade duplicate buffer commit log from warn to debug

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -7115,7 +7115,7 @@ void update_wayland_res(CommitDoneList_t *doneCommits, steamcompmgr_win_t *w, Re
 		wlserver_lock();
 		wlr_buffer_unlock( buf );
 		wlserver_unlock();
-		xwm_log.warnf( "got the same buffer committed twice, ignoring." );
+		xwm_log.debugf( "got the same buffer committed twice, ignoring." );
 
 		// If we have a duplicated commit + frame callback, ensure that is signalled.
 		// This matches Mutter and Weston behavior, so it's plausible that some application relies on forward progress.


### PR DESCRIPTION
When a game commits a surface without attaching a new buffer (reusing the same buffer), gamescope logs a warning on every occurrence. This is normal behavior for games that need to signal state changes like cursor hint updates without rendering a new frame. During mouselook for example, this can fire every frame, producing a wall of warnings that adds noise to the log and wastes cycles and I/O.

Since the code already handles this case gracefully, a warning seems too aggressive for what is a valid and expected code path. This change downgrades it to debug level.

If there's a reason this should stay as a warning, I'm happy to implement rate limiting instead, something like logging the first occurrence and then summarizing every N seconds. Let me know which approach you'd prefer.