### PR TITLE
steamcompmgr: abort instead of pthread_exit on X11 I/O error

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6575,11 +6575,8 @@ steamcompmgr_exit(void)
 [[noreturn]] static int
 handle_io_error(Display *dpy)
 {
-	xwm_log.errorf("X11 I/O error");
-	steamcompmgr_exit();
-
-	g_SteamCompMgrXWaylandServerMutex.unlock();
-	pthread_exit(NULL);
+	xwm_log.errorf("X11 I/O error! This is fatal. Aborting...");
+	abort();
 }
 
 static bool


### PR DESCRIPTION
The previous handler called steamcompmgr_exit and then pthread_exit'd, but pthread_exit only kills the calling thread so the process stays alive with most of its state torn down as a wedged zombie after an Xwayland crash occurs.

Use abort to match the existing OnPollHangUp pattern for the same scenario so the gamescope process exits properly when an Xwayland connection goes away, like when Xwayland crashes while in-game.