### PR TITLE
OpenVRBackend: Handle new focus events from SteamVR

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,90 @@
+
+{
+    "version": "2.0.0",
+    "inputs" : [
+        {
+            "id" : "device_ip",
+            "description" : "SteamOS Device IP or hostname",
+            "type" : "promptString",
+        },
+        {
+            "id" : "device_password",
+            "description" : "'steamos' user's password",
+            "type" : "promptString",
+        },
+    ],
+    "tasks": [
+        {
+            "label": "Build + Install on a SteamOS Device (remote)",
+            "type": "shell",
+            "command": "./tools/build_and_install_on_steamos_device_remote.sh ${input:device_ip} ${input:device_password}",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": {
+                "base": "$gcc",
+                "fileLocation": [
+                    "autoDetect",
+                    "${workspaceFolder}/src/"
+                ]
+            }
+        },
+        {
+            "label": "Restart Session (remote)",
+            "type": "shell",
+            "command": "./tools/steamos_sessionctl_remote.sh restart ${input:device_ip} ${input:device_password}",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        },
+        {
+            "label": "Start Session (remote)",
+            "type": "shell",
+            "command": "./tools/steamos_sessionctl_remote.sh start ${input:device_ip} ${input:device_password}",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        },
+        {
+            "label": "Stop Session (remote)",
+            "type": "shell",
+            "command": "./tools/steamos_sessionctl_remote.sh stop ${input:device_ip} ${input:device_password}",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        },
+        {
+            "label": "Reset to system Gamescope (remote)",
+            "type": "shell",
+            "command": "./tools/reset_to_system_gamescope_remote.sh ${input:device_ip} ${input:device_password}",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        },
+    ]
+}

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -77,12 +77,50 @@ gamescope::ConVar<bool> cv_vr_nudge_to_visible_per_connector( "vr_nudge_to_visib
 // Maximum interval between polling for VR events (normally paced by frame sync)
 gamescope::ConVar<uint32_t> cv_vr_poll_rate( "vr_poll_rate", 50ul, "Max time between input polls. In milliseconds." );
 
+extern std::atomic<uint64_t> g_FocusedVROverlayMouse;
+extern std::atomic<uint64_t> g_FocusedVROverlayKeyboard;
+
 // Not in public headers yet.
 namespace vr
 {
     const EVRButtonId k_EButton_Steam = (EVRButtonId)(50);
     const EVRButtonId k_EButton_QAM = (EVRButtonId)(51);
+
+    constexpr EVREventType VREvent_OverlayInputFocusChanged = ( EVREventType )(564); // data is overlayInputFocus
+
+
+    /** Used in VREvent_OverlayInputFocus_t */
+    enum EVRInputFocusEventFlags
+    {
+        // Indicates the overlay should actively have keyboard focus.
+        k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForKeyboardInput = 1 << 0,
+        // Indicates the overlay should actively have gamepad focus.
+        k_EVRInputFocusEventFlags_OverlayShouldShowAffordanceForGamepadInput = 1 << 1,
+    };
+    /** Used for a few events about overlay input focus */
+    struct VREvent_OverlayInputFocus_t
+    {
+        // Overlay that has keyboard and/or gamepad focus. If this is your overlay and its contents is a desktop or a desktop window,
+        // this event is a great oppportunity to move that window to the foreground so it receives input.
+        uint64_t overlayHandle; // VROverlayHandle_t
+        uint32_t flags; // EVRInputFocusEventFlags
+    };
+
+    typedef union
+    {
+        VREvent_OverlayInputFocus_t overlayInputFocus;
+    } VREvent_Data_Gamescope_t;
+
+    static inline const VREvent_Data_Gamescope_t &CastToGamescopeEventData( const VREvent_Data_t &eventData )
+    {
+        return reinterpret_cast< const vr::VREvent_Data_Gamescope_t & >( eventData );
+    }
+    static inline VREvent_Data_Gamescope_t &CastToGamescopeEventData( VREvent_Data_t &eventData )
+    {
+        return reinterpret_cast< vr::VREvent_Data_Gamescope_t & >( eventData );
+    }
 }
+//
 
 extern std::atomic<uint32_t> g_unCurrentVRSceneAppId;
 
@@ -740,8 +778,12 @@ namespace gamescope
 
 		virtual IBackendConnector *GetCurrentConnector() override
 		{
-			return m_pFocusConnector;
+			return m_pKeyboardFocusConnector;
 		}
+        virtual IBackendConnector *GetCurrentMouseConnector()
+        {
+            return m_pMouseFocusConnector;
+        }
 		virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) override
 		{
 			if ( eScreenType == GAMESCOPE_SCREEN_TYPE_INTERNAL )
@@ -832,20 +874,23 @@ namespace gamescope
                 return TouchClickModes::Trackpad;
             }
 
-            if ( pConnector->IsTouchForbidden() )
+            if ( pConnector )
             {
-                return TouchClickModes::Left;
-            }
-
-            if ( VirtualConnectorKeyIsNonSteamWindow( pConnector->GetVirtualConnectorKey() ) )
-            {
-                return TouchClickModes::Passthrough;
-            }
-
-            if ( VirtualConnectorInSteamPerAppState() )
-            {
-                if ( !VirtualConnectorKeyIsSteam( pConnector->GetVirtualConnectorKey() ) )
+                if ( pConnector->IsTouchForbidden() )
+                {
                     return TouchClickModes::Left;
+                }
+
+                if ( VirtualConnectorKeyIsNonSteamWindow( pConnector->GetVirtualConnectorKey() ) )
+                {
+                    return TouchClickModes::Passthrough;
+                }
+
+                if ( VirtualConnectorInSteamPerAppState() )
+                {
+                    if ( !VirtualConnectorKeyIsSteam( pConnector->GetVirtualConnectorKey() ) )
+                        return TouchClickModes::Left;
+                }
             }
 
             return CBaseBackend::GetTouchClickMode();
@@ -859,22 +904,23 @@ namespace gamescope
         {
             std::shared_ptr<COpenVRConnector> pConnector = std::make_shared<COpenVRConnector>( this, ulVirtualConnectorKey );
 
-            bool bSetCurrentConnector = false;
-            {
-                if ( !m_pFocusConnector )
-                {
-                    SetFocus( pConnector.get() );
-                    bSetCurrentConnector = true;
-                }
-            }
-
             if ( !pConnector->Init() )
             {
-                if ( bSetCurrentConnector )
-                {
-                    SetFocus( nullptr );
-                }
                 return nullptr;
+            }
+
+            {
+                COpenVRConnector *pExpected = nullptr;
+                m_pMouseFocusConnector.compare_exchange_strong( pExpected, pConnector.get() );
+            }
+
+            {
+                COpenVRConnector *pExpected = nullptr;
+                if ( m_pKeyboardFocusConnector.compare_exchange_strong( pExpected, pConnector.get() ) )
+                {
+                    openvr_log.debugf( "Changed keyboard focus connector to %p ", pConnector.get() );
+                    update_connector_display_info_wl( NULL );
+                }
             }
 
             std::scoped_lock lock{ m_mutActiveConnectors };
@@ -998,16 +1044,6 @@ namespace gamescope
             m_nOverlaysVisible.wait( 0 );
         }
 
-        void SetFocus( COpenVRConnector *pFocus )
-        {
-            COpenVRConnector *pPreviousFocus = m_pFocusConnector.exchange( pFocus );
-            if ( pPreviousFocus != pFocus )
-            {
-                MakeFocusDirty();
-                update_connector_display_info_wl( NULL );
-            }
-        }
-
         COpenVRPlane *GetPlaneByOverlayHandle( vr::VROverlayHandle_t hOverlay )
         {
             COpenVRPlane *pPlane = nullptr;
@@ -1018,6 +1054,75 @@ namespace gamescope
                     break;
             }
             return pPlane;
+        }
+
+        void SetMouseFocus( uint64_t ulFocusOverlay )
+        {
+            uint64_t oldOverlayHandle = g_FocusedVROverlayMouse.exchange( ulFocusOverlay );
+
+            if ( oldOverlayHandle == ulFocusOverlay )
+                return;
+
+            openvr_log.debugf( "Changing mouse focus from %lx to %lx", oldOverlayHandle, ulFocusOverlay );
+
+            COpenVRConnector *pInputConnector = nullptr;
+            if ( ulFocusOverlay != vr::k_ulOverlayHandleInvalid )
+            {
+                COpenVRPlane *pInputPlane = GetPlaneByOverlayHandle( ulFocusOverlay );
+                if ( pInputPlane )
+                {
+                    pInputConnector = pInputPlane->GetConnector();
+                }
+            }
+
+            if ( pInputConnector )
+            {
+                pInputConnector->m_bUsingVRMouse = true;
+
+                COpenVRConnector *pOldConnector = m_pMouseFocusConnector.exchange( pInputConnector );
+
+                if ( pOldConnector != pInputConnector )
+                {
+                    openvr_log.debugf( "Changing mouse focus connector to %p", pInputConnector );
+
+                    // We don't do anything with mouse focus that isn't local,
+                    // so only dirty focus if the focus connector changed.
+                    //
+                    // Unlike with Keyboard where we need to focus for forwarders too!
+
+                    MakeFocusDirty();
+                    nudge_steamcompmgr();
+                }
+            }
+        }
+
+        void SetKeyboardFocus( uint64_t ulFocusOverlay )
+        {
+            uint64_t oldOverlayHandle = g_FocusedVROverlayKeyboard.exchange( ulFocusOverlay );
+
+            if ( oldOverlayHandle == ulFocusOverlay )
+                return;
+
+            openvr_log.debugf( "Changing keyboard focus from %lx to %lx", oldOverlayHandle, ulFocusOverlay );
+
+            COpenVRConnector *pInputConnector = nullptr;
+            if ( ulFocusOverlay != vr::k_ulOverlayHandleInvalid )
+            {
+                COpenVRPlane *pInputPlane = GetPlaneByOverlayHandle( ulFocusOverlay );
+                if ( pInputPlane )
+                {
+                    pInputConnector = pInputPlane->GetConnector();
+                }
+            }
+
+            if ( pInputConnector )
+            {
+                openvr_log.debugf( "Changing keyboard focus connector to %p", pInputConnector );
+                m_pKeyboardFocusConnector.exchange( pInputConnector );
+            }
+
+            MakeFocusDirty();
+            nudge_steamcompmgr();
         }
 
         void ProcessVRInput()
@@ -1161,7 +1266,8 @@ namespace gamescope
                 {
                     if (pConnector && pConnector->m_bUsingVRMouse)
                     {
-                        SetFocus(pConnector);
+                        SetMouseFocus( hOverlay );
+
                         float flX = vrEvent.data.mouse.x / float(g_nOutputWidth);
                         float flY = (g_nOutputHeight - vrEvent.data.mouse.y) / float(g_nOutputHeight);
 
@@ -1197,17 +1303,31 @@ namespace gamescope
                     break;
                 }
                 case vr::VREvent_FocusEnter:
-                    if (pConnector)
                     {
-                        pConnector->m_bUsingVRMouse = true;
-                        SetFocus(pConnector);
+                        if (pConnector)
+                        {
+                            pConnector->m_bUsingVRMouse = true;
+                            SetMouseFocus( hOverlay );
+                        }
+                    }
+                    break;
+
+                case vr::VREvent_OverlayFocusChanged:
+                    {
+                        SetMouseFocus( vrEvent.data.overlay.overlayHandle );
+                    }
+                    break;
+                case vr::VREvent_OverlayInputFocusChanged:
+                    {
+                        const vr::VREvent_Data_Gamescope_t &data = CastToGamescopeEventData( vrEvent.data );
+                        SetKeyboardFocus( data.overlayInputFocus.overlayHandle );
                     }
                     break;
                 case vr::VREvent_MouseButtonUp:
                 case vr::VREvent_MouseButtonDown:
                     if (pConnector)
                     {
-                        SetFocus(pConnector);
+                        SetMouseFocus( hOverlay );
 
                         if (!pConnector->m_bUsingVRMouse)
                         {
@@ -1289,31 +1409,14 @@ namespace gamescope
                 case vr::VREvent_ScrollSmooth:
                     if (pConnector)
                     {
-                        SetFocus(pConnector);
+                        SetMouseFocus( hOverlay );
+
                         float flX = -vrEvent.data.scroll.xdelta * m_flScrollSpeed;
                         float flY = -vrEvent.data.scroll.ydelta * m_flScrollSpeed;
                         wlserver_lock();
                         wlserver_mousewheel(flX, flY, ++m_uFakeTimestamp);
                         wlserver_unlock();
                         bDidScrollThisFrame = true;
-                    }
-                    break;
-
-                case vr::VREvent_ButtonPress:
-                    if (pConnector)
-                    {
-                        SetFocus(pConnector);
-                        vr::EVRButtonId button = (vr::EVRButtonId)vrEvent.data.controller.button;
-
-                        if (button != vr::k_EButton_Steam && button != vr::k_EButton_QAM)
-                            break;
-
-                        if (button == vr::k_EButton_Steam)
-                            openvr_log.infof("STEAM button pressed.");
-                        else
-                            openvr_log.infof("QAM button pressed.");
-
-                        wlserver_open_steam_menu(button == vr::k_EButton_QAM);
                     }
                     break;
 
@@ -1419,7 +1522,8 @@ namespace gamescope
         friend COpenVRConnector;
         std::vector<COpenVRConnector*> m_pActiveConnectors;
         std::mutex m_mutActiveConnectors;
-        std::atomic<COpenVRConnector *> m_pFocusConnector;
+        std::atomic<COpenVRConnector *> m_pMouseFocusConnector;
+        std::atomic<COpenVRConnector *> m_pKeyboardFocusConnector;
 
         std::atomic<bool> m_bInitted = { false };
         std::atomic<bool> m_bRunning = { false };
@@ -1462,9 +1566,10 @@ namespace gamescope
             m_pBackend->m_pActiveConnectors.erase( iter );
 
         COpenVRConnector *pThis = this;
-        m_pBackend->m_pFocusConnector.compare_exchange_strong( pThis, nullptr );
+        m_pBackend->m_pMouseFocusConnector.compare_exchange_strong( pThis, nullptr );
+        pThis = this;
+        m_pBackend->m_pKeyboardFocusConnector.compare_exchange_strong( pThis, nullptr );
     }
-
     GamescopeScreenType COpenVRConnector::GetScreenType() const
     {
         return GAMESCOPE_SCREEN_TYPE_INTERNAL;

--- a/src/backend.h
+++ b/src/backend.h
@@ -349,6 +349,10 @@ namespace gamescope
 		}
 
         virtual IBackendConnector *GetCurrentConnector() = 0;
+        virtual IBackendConnector *GetCurrentMouseConnector()
+        {
+            return this->GetCurrentConnector();
+        }
         virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) = 0;
 
         virtual bool SupportsPlaneHardwareCursor() const = 0;

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -122,6 +122,7 @@ static const int g_nBaseCursorScale = 36;
 #include "gpuvis_trace_utils.h"
 
 LogScope xwm_log("xwm");
+LogScope focus_log("focus");
 LogScope g_WaitableLog("waitable");
 
 gamescope::ConVar<bool> cv_overlay_unmultiplied_alpha{ "overlay_unmultiplied_alpha", false };
@@ -134,6 +135,8 @@ bool g_bWasPartialComposite = false;
 bool ShouldDrawCursor();
 
 std::atomic<uint32_t> g_unCurrentVRSceneAppId;
+std::atomic<uint64_t> g_FocusedVROverlayMouse;
+std::atomic<uint64_t> g_FocusedVROverlayKeyboard;
 
 ///
 // Color Mgmt
@@ -823,7 +826,7 @@ Window x11_win(steamcompmgr_win_t *w) {
 	return w->xwayland().id;
 }
 
-static uint64_t s_ulFocusSerial = 0ul;
+static std::atomic<uint64_t> s_ulFocusSerial = 0ul;
 void MakeFocusDirty()
 {
 	s_ulFocusSerial++;
@@ -866,17 +869,11 @@ struct global_focus_t : public focus_t
 std::unordered_map<gamescope::VirtualConnectorKey_t, global_focus_t> g_VirtualConnectorFocuses;
 global_focus_t *GetCurrentFocus()
 {
-	if ( GetBackend()->GetCurrentConnector() )
-	{
-		uint64_t ulKey = GetBackend()->GetCurrentConnector()->GetVirtualConnectorKey();
+	uint64_t ulKey = GetBackend()->GetCurrentConnector() ? GetBackend()->GetCurrentConnector()->GetVirtualConnectorKey() : 0;
 
-		auto iter = g_VirtualConnectorFocuses.find( ulKey );
-		if ( iter != g_VirtualConnectorFocuses.end() )
-			return &iter->second;
-	}
-
-	if ( g_VirtualConnectorFocuses.size() > 0 )
-		return &g_VirtualConnectorFocuses.begin()->second;
+	auto iter = g_VirtualConnectorFocuses.find( ulKey );
+	if ( iter != g_VirtualConnectorFocuses.end() )
+		return &iter->second;
 
 	return nullptr;
 }
@@ -3778,25 +3775,23 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 		inputFocus = ctx->focus.focusWindow;
 	}
 
-	if ( !ctx->focus.focusWindow )
+	if ( ctx->focus.focusWindow )
 	{
-		return;
-	}
-
-	if ( prevFocusWindow != ctx->focus.focusWindow )
-	{
-		/* Some games (e.g. DOOM Eternal) don't react well to being put back as
-		* iconic, so never do that. Only take them out of iconic. */
-		set_wm_state( ctx, ctx->focus.focusWindow->xwayland().id, ICCCM_NORMAL_STATE );
-
-		gpuvis_trace_printf( "determine_and_apply_focus focus %lu", ctx->focus.focusWindow->xwayland().id );
-
-		if ( debugFocus == true )
+		if ( prevFocusWindow != ctx->focus.focusWindow )
 		{
-			xwm_log.debugf( "determine_and_apply_focus focus %lu", ctx->focus.focusWindow->xwayland().id );
-			char buf[512];
-			sprintf( buf,  "xwininfo -id 0x%lx; xprop -id 0x%lx; xwininfo -root -tree", ctx->focus.focusWindow->xwayland().id, ctx->focus.focusWindow->xwayland().id );
-			system( buf );
+			/* Some games (e.g. DOOM Eternal) don't react well to being put back as
+			* iconic, so never do that. Only take them out of iconic. */
+			set_wm_state( ctx, ctx->focus.focusWindow->xwayland().id, ICCCM_NORMAL_STATE );
+
+			gpuvis_trace_printf( "determine_and_apply_focus focus %lu", ctx->focus.focusWindow->xwayland().id );
+
+			if ( debugFocus == true )
+			{
+				xwm_log.debugf( "determine_and_apply_focus focus %lu", ctx->focus.focusWindow->xwayland().id );
+				char buf[512];
+				sprintf( buf,  "xwininfo -id 0x%lx; xprop -id 0x%lx; xwininfo -root -tree", ctx->focus.focusWindow->xwayland().id, ctx->focus.focusWindow->xwayland().id );
+				system( buf );
+			}
 		}
 	}
 
@@ -3806,6 +3801,64 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 	{
 		if ( inputFocus && inputFocus->inputFocusMode == 2 )
 			keyboardFocusWin = ctx->focus.focusWindow;
+	}
+	else
+	{
+		// Handle mouse focus being totally disjoint from KB in VR.
+		if ( GetBackend() && GetBackend()->GetCurrentMouseConnector() )
+		{
+			gamescope::VirtualConnectorKey_t ulMouseKey = GetBackend()->GetCurrentMouseConnector()->GetVirtualConnectorKey();
+			
+			focus_t mouse_focus{};
+			pick_primary_focus_and_override( &mouse_focus, ctx->focusControlWindow, vecPossibleFocusWindows, false, vecFocuscontrolAppIDs, ulMouseKey, eStrategy );
+
+			if ( mouse_focus.overrideWindow || mouse_focus.focusWindow )
+			{
+				inputFocus = mouse_focus.overrideWindow ? mouse_focus.overrideWindow : mouse_focus.focusWindow;
+			}
+		}
+
+		uint64_t ulFocusedKeyboardOverlayVR = g_FocusedVROverlayKeyboard;
+		uint64_t ulFocusedMouseOverlayVR = g_FocusedVROverlayMouse;
+
+		if ( ulFocusedKeyboardOverlayVR || ulFocusedMouseOverlayVR )
+		{
+			for ( steamcompmgr_win_t *queryWindow = ctx->list; queryWindow; queryWindow = queryWindow->xwayland().next )
+			{
+				if ( queryWindow->oulTargetVROverlay && *queryWindow->oulTargetVROverlay == ulFocusedKeyboardOverlayVR )
+				{
+					focus_log.debugf( "[XWL] Overriding keyboard focus window with VR forwarder overlay! Overlay: 0x%lx XWindow: 0x%x Title: %s", ulFocusedKeyboardOverlayVR, queryWindow->id(), queryWindow->debug_name() );
+
+					keyboardFocusWin = queryWindow;
+					ctx->focus.focusWindow = queryWindow;
+
+					// No support for overrides with this VR path!
+					ctx->focus.overrideWindow = nullptr;
+				}
+
+				if ( queryWindow->oulTargetVROverlay && *queryWindow->oulTargetVROverlay == ulFocusedMouseOverlayVR )
+				{
+					// We don't want to do any mouse input for target VR overlays right now.
+					// SteamWebHelper is handling this.
+
+					if ( !inputFocus )
+						inputFocus = queryWindow;
+
+					// No support for overrides with this VR path!
+					ctx->focus.overrideWindow = nullptr;
+				}
+			}
+		}
+	}
+
+	if ( !ctx->focus.focusWindow )
+	{
+		return;
+	}
+
+	if ( !inputFocus )
+	{
+		inputFocus = ctx->focus.focusWindow;
 	}
 
 	Window keyboardFocusWindow = keyboardFocusWin ? keyboardFocusWin->xwayland().id : None;
@@ -4023,6 +4076,8 @@ determine_and_apply_focus( global_focus_t *pFocus )
 	pFocus->pVirtualConnector = previousLocalFocus.pVirtualConnector;
 	gameFocused = false;
 
+	focus_log.debugf( "Rerolling global focus..." );
+
 	std::vector< unsigned long > focusable_appids;
 	std::vector< unsigned long > focusable_windows;
 
@@ -4127,6 +4182,52 @@ determine_and_apply_focus( global_focus_t *pFocus )
 		pFocus->keyboardFocusWindow = pFocus->overrideWindow ? pFocus->overrideWindow : pFocus->focusWindow;
 	}
 
+	if ( !gamescope::VirtualConnectorIsSingleOutput() )
+	{
+		// Handle mouse focus being totally disjoint from KB in VR.
+		if ( GetBackend() && GetBackend()->GetCurrentMouseConnector() )
+		{
+			gamescope::VirtualConnectorKey_t ulMouseKey = GetBackend()->GetCurrentMouseConnector()->GetVirtualConnectorKey();
+			
+			focus_t mouse_focus{};
+			pick_primary_focus_and_override( &mouse_focus, root_ctx->focusControlWindow, vecPossibleFocusWindows, true, vecFocuscontrolAppIDs, ulMouseKey, gamescope::cv_backend_virtual_connector_strategy );
+
+			if ( mouse_focus.overrideWindow || mouse_focus.focusWindow )
+			{
+				pFocus->inputFocusWindow = mouse_focus.overrideWindow ? mouse_focus.overrideWindow : mouse_focus.focusWindow;
+			}
+		}
+
+		uint64_t ulFocusedKeyboardOverlayVR = g_FocusedVROverlayKeyboard;
+		uint64_t ulFocusedMouseOverlayVR = g_FocusedVROverlayMouse;
+
+		focus_log.debugf( "Current focus VR overlays: keyboard 0x%lx | mouse 0x%lx", ulFocusedKeyboardOverlayVR, ulFocusedMouseOverlayVR );
+
+		if ( ulFocusedKeyboardOverlayVR || ulFocusedMouseOverlayVR )
+		{
+			for ( steamcompmgr_win_t *queryWindow = root_ctx->list; queryWindow; queryWindow = queryWindow->xwayland().next )
+			{
+				if ( queryWindow->oulTargetVROverlay && *queryWindow->oulTargetVROverlay == ulFocusedKeyboardOverlayVR )
+				{
+					focus_log.debugf( "[WL GLOBAL] Overriding keyboard focus window with VR forwarder overlay! Overlay: 0x%lx XWindow: 0x%x Title: %s", ulFocusedKeyboardOverlayVR, queryWindow->id(), queryWindow->debug_name() );
+					pFocus->keyboardFocusWindow = queryWindow;
+
+					pFocus->overrideWindow = nullptr;
+				}
+
+				if ( queryWindow->oulTargetVROverlay && *queryWindow->oulTargetVROverlay == ulFocusedMouseOverlayVR )
+				{
+					// We don't want to do any mouse input for target VR overlays right now.
+					// SteamWebHelper is handling this.
+
+					//pFocus->inputFocusWindow = queryWindow;
+
+					pFocus->overrideWindow = nullptr;
+				}
+			}
+		}
+	}
+
 	// Pick cursor from our input focus window
 
 	// Initially pick cursor from the ctx of our input focus.
@@ -4183,7 +4284,7 @@ determine_and_apply_focus( global_focus_t *pFocus )
 
 				if ( gamescope::VirtualConnectorInSteamPerAppState() && pFocus->inputFocusWindow )
 				{
-					if ( pFocus->focusWindow->type == steamcompmgr_win_type_t::XWAYLAND )
+					if ( pFocus->inputFocusWindow->type == steamcompmgr_win_type_t::XWAYLAND )
 					{
 						xwayland_ctx_t *ctx = pFocus->inputFocusWindow->xwayland().ctx;
 						bool bTouchPointerEmulation = gamescope::VirtualConnectorKeyIsNonSteamWindow( pFocus->ulVirtualFocusKey );
@@ -4201,10 +4302,16 @@ determine_and_apply_focus( global_focus_t *pFocus )
 				}
 
 				if ( win_surface(pFocus->inputFocusWindow) != nullptr && pFocus->cursor )
+				{
 					wlserver_mousefocus( pFocus->inputFocusWindow->main_surface(), pFocus->cursor->x(), pFocus->cursor->y() );
+					focus_log.debugf( "Setting mouse focus to: %s (%x)", pFocus->inputFocusWindow->debug_name(), pFocus->inputFocusWindow->id() );
+				}
 
 				if ( win_surface(pFocus->keyboardFocusWindow) != nullptr )
+				{
 					wlserver_keyboardfocus( pFocus->keyboardFocusWindow->main_surface() );
+					focus_log.debugf( "Setting keyboard focus to: %s (%x)", pFocus->keyboardFocusWindow->debug_name(), pFocus->keyboardFocusWindow->id() );
+				}
 				wlserver_unlock();
 			}
 
@@ -8251,18 +8358,12 @@ steamcompmgr_main(int argc, char **argv)
 
 	globalScaleRatio = overscanScaleRatio * zoomScaleRatio;
 
-	if ( gamescope::VirtualConnectorIsSingleOutput() )
+	static constexpr uint64_t k_unSingleOutputVirtualConnectorKey = 0;
+	g_VirtualConnectorFocuses[ k_unSingleOutputVirtualConnectorKey ] = global_focus_t
 	{
-		// misyl: Make the virtual connector up-front if we are in a single-output mode.
-		// So we don't delay in getting display/output info to the game
-		static constexpr uint64_t k_unSingleOutputVirtualConnectorKey = 0;
-
-		g_VirtualConnectorFocuses[ k_unSingleOutputVirtualConnectorKey ] = global_focus_t
-		{
-			.ulVirtualFocusKey = k_unSingleOutputVirtualConnectorKey,
-			.pVirtualConnector = GetBackend()->UsesVirtualConnectors() ? GetBackend()->CreateVirtualConnector( k_unSingleOutputVirtualConnectorKey ) : nullptr,
-		};
-	}
+		.ulVirtualFocusKey = k_unSingleOutputVirtualConnectorKey,
+		.pVirtualConnector = GetBackend()->UsesVirtualConnectors() ? GetBackend()->CreateVirtualConnector( k_unSingleOutputVirtualConnectorKey ) : nullptr,
+	};
 
 	for ( auto &iter : g_VirtualConnectorFocuses )
 	{
@@ -8403,18 +8504,15 @@ steamcompmgr_main(int argc, char **argv)
 
 			xwm_log.infof( "Late init of virtual connector stuff." );
 
-			if ( gamescope::VirtualConnectorIsSingleOutput() )
-			{
-				// misyl: Make the virtual connector up-front if we are in a single-output mode.
-				// So we don't delay in getting display/output info to the game
-				static constexpr uint64_t k_unSingleOutputVirtualConnectorKey = 0;
+			// misyl: Make the virtual connector up-front if we are in a single-output mode.
+			// So we don't delay in getting display/output info to the game
+			static constexpr uint64_t k_unSingleOutputVirtualConnectorKey = 0;
 
-				g_VirtualConnectorFocuses[ k_unSingleOutputVirtualConnectorKey ] = global_focus_t
-				{
-					.ulVirtualFocusKey = k_unSingleOutputVirtualConnectorKey,
-					.pVirtualConnector = GetBackend()->UsesVirtualConnectors() ? GetBackend()->CreateVirtualConnector( k_unSingleOutputVirtualConnectorKey ) : nullptr,
-				};
-			}
+			g_VirtualConnectorFocuses[ k_unSingleOutputVirtualConnectorKey ] = global_focus_t
+			{
+				.ulVirtualFocusKey = k_unSingleOutputVirtualConnectorKey,
+				.pVirtualConnector = GetBackend()->UsesVirtualConnectors() ? GetBackend()->CreateVirtualConnector( k_unSingleOutputVirtualConnectorKey ) : nullptr,
+			};
 
 			hasRepaint = true;
 		}
@@ -8503,6 +8601,7 @@ steamcompmgr_main(int argc, char **argv)
 				for ( gamescope::VirtualConnectorKey_t ulKey : diffKeys )	
 				{
 					bool bIsSteam = gamescope::VirtualConnectorKeyIsSteam( ulKey );
+					bool bIsBaseKey = ulKey == 0;
 
 					if ( gamescope::Algorithm::Contains( newKeys, ulKey ) )
 					{
@@ -8512,7 +8611,7 @@ steamcompmgr_main(int argc, char **argv)
 							.pVirtualConnector = GetBackend()->UsesVirtualConnectors() ? GetBackend()->CreateVirtualConnector( ulKey ) : nullptr,
 						};
 					}
-					else if ( !bIsSteam ) // Never remove Steam's virtual conn	ector.
+					else if ( !bIsSteam && !bIsBaseKey ) // Never remove Steam's virtual connector or the 0th connector.
 					{
 						g_VirtualConnectorFocuses.erase( ulKey );
 					}

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -232,6 +232,14 @@ struct steamcompmgr_win_t {
 			return nullptr;
 	}
 
+	const char *debug_name() const
+	{
+		if ( title )
+			return title->c_str();
+
+		return pid_name.c_str();
+	}
+
 	gamescope::VirtualConnectorKey_t GetVirtualConnectorKey( gamescope::VirtualConnectorStrategy eStrategy )
 	{
 		switch ( eStrategy )

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2844,7 +2844,10 @@ void wlserver_touchmotion( double x, double y, int touch_id, uint32_t time, bool
 		double tx = x;
 		double ty = y;
 
-		apply_touchscreen_orientation((connector ? connector : GetBackend()->GetCurrentConnector())->GetCurrentOrientation(), &tx, &ty);
+		if ( connector )
+		{
+			apply_touchscreen_orientation(connector->GetCurrentOrientation(), &tx, &ty);
+		}
 
 		tx *= g_nOutputWidth;
 		ty *= g_nOutputHeight;
@@ -2899,7 +2902,10 @@ void wlserver_touchdown( double x, double y, int touch_id, uint32_t time, gamesc
 		double tx = x;
 		double ty = y;
 
-		apply_touchscreen_orientation((connector ? connector : GetBackend()->GetCurrentConnector())->GetCurrentOrientation(), &tx, &ty);
+		if ( connector )
+		{
+			apply_touchscreen_orientation(connector->GetCurrentOrientation(), &tx, &ty);
+		}
 
 		tx *= g_nOutputWidth;
 		ty *= g_nOutputHeight;

--- a/tools/build_and_install_on_steamos_device_local.sh
+++ b/tools/build_and_install_on_steamos_device_local.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/steamos_common_local.sh" "$@"
+
+./build_on_steamos_device_local.sh
+
+# Get to code root.
+pushd ..
+
+echo "Installing built gamescope..."
+envsudo steamos-readonly disable
+
+steamvr stop
+
+# One option is to do this, but this also installs a bunch of headers and rubbish
+# that we don't want.
+#envsudo meson install --skip-subprojects -C build.local
+
+# So just install the main gamescope executable for now...
+envsudo cp -ra build.local/src/gamescope /usr/bin/gamescope
+
+steamvr start

--- a/tools/build_and_install_on_steamos_device_remote.sh
+++ b/tools/build_and_install_on_steamos_device_remote.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/steamos_common_remote.sh" "$@"
+
+./copy_to_steamos_device_rsync.sh "$STEAMOS_DEVICE_IP"
+envsshpass ssh -t "steamos@$STEAMOS_DEVICE_IP" "/home/steamos/gamescope_local/tools/build_and_install_on_steamos_device_local.sh $STEAMOS_USER_PASSWORD"

--- a/tools/build_on_steamos_device_local.sh
+++ b/tools/build_on_steamos_device_local.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/steamos_common_local.sh" "$@"
+
+pushd ..
+
+echo "Setting up build..."
+meson setup build.local --prefix=/usr
+
+echo "Building gamescope..."
+meson compile -C build.local

--- a/tools/copy_to_steamos_device_rsync.sh
+++ b/tools/copy_to_steamos_device_rsync.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/steamos_common_remote.sh" "$@"
+
+pushd ..
+echo "Copying $(pwd) to $STEAMOS_DEVICE_IP..."
+envsshpass rsync -rzah --info=progress2  --exclude '/build*' --exclude '.git' . "steamos@$STEAMOS_DEVICE_IP:/home/steamos/gamescope_local"

--- a/tools/reset_to_system_gamescope_local.sh
+++ b/tools/reset_to_system_gamescope_local.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/steamos_common_local.sh" "$@"
+
+steamvr stop
+
+envsudo steamos-readonly disable
+envsudo pacman -Sy --noconfirm gamescope
+
+steamvr start

--- a/tools/reset_to_system_gamescope_remote.sh
+++ b/tools/reset_to_system_gamescope_remote.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/steamos_common_remote.sh" "$@"
+
+./copy_to_steamos_device_rsync.sh "$STEAMOS_DEVICE_IP"
+envsshpass ssh -t "steamos@$STEAMOS_DEVICE_IP" "/home/steamos/gamescope_local/tools/reset_to_system_gamescope_local.sh $STEAMOS_USER_PASSWORD"

--- a/tools/steamos_common_local.sh
+++ b/tools/steamos_common_local.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $(basename "$0") [device_password]"
+    exit 1
+fi
+
+if [[ -f "/usr/bin/steamvr" ]]; then
+    export STEAMOS_VR_SESSION=1
+else
+    export STEAMOS_VR_SESSION=0
+fi
+
+export STEAMOS_USER_PASSWORD="${1:-${STEAMOS_USER_PASSWORD:-}}"
+
+# Put us in the tools folder...
+export script=$(readlink -f -- "$0")
+
+# Get to the script
+pushd "$(dirname -- "$script")" > /dev/null
+
+# Setup envsudo.
+source ./steamos_password_helpers.sh

--- a/tools/steamos_common_remote.sh
+++ b/tools/steamos_common_remote.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <target_device> [device_password]"
+    exit 1
+fi
+
+export STEAMOS_DEVICE_IP="$1"
+export STEAMOS_USER_PASSWORD="${2:-${STEAMOS_USER_PASSWORD:-}}"
+
+# Put us in the tools folder...
+export script=$(readlink -f -- "$0")
+
+# Get to the script
+pushd "$(dirname -- "$script")" > /dev/null
+
+source ./steamos_password_helpers.sh

--- a/tools/steamos_password_helpers.sh
+++ b/tools/steamos_password_helpers.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+envsudo() {
+    if [[ -n "${STEAMOS_USER_PASSWORD:-}" ]]; then
+        echo "$STEAMOS_USER_PASSWORD" | sudo -S "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+envsshpass() {
+    if [[ -n "${STEAMOS_USER_PASSWORD:-}" ]]; then
+        sshpass -p "$STEAMOS_USER_PASSWORD" "$@"
+    else
+        sudo "$@"
+    fi
+}

--- a/tools/steamos_sessionctl_local.sh
+++ b/tools/steamos_sessionctl_local.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $(basename "$0") <verb> [device_password]"
+    exit 1
+fi
+
+source "$(dirname "$0")/steamos_common_local.sh" "$2"
+
+export SESSION_VERB=$1
+
+if [[ "$STEAMOS_VR_SESSION" == "1" ]]; then
+    steamvr "$SESSION_VERB"
+else
+    envsudo systemctl "$SESSION_VERB" sddm
+fi

--- a/tools/steamos_sessionctl_remote.sh
+++ b/tools/steamos_sessionctl_remote.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+    echo "Usage: $(basename "$0") <verb> <device_ip> [device_password]"
+    exit 1
+fi
+
+export SESSION_VERB=$1
+
+source "$(dirname "$0")/steamos_common_remote.sh" "$2" "$3"
+
+./copy_to_steamos_device_rsync.sh "$STEAMOS_DEVICE_IP"
+envsshpass ssh -t "steamos@$STEAMOS_DEVICE_IP" "/home/steamos/gamescope_local/tools/steamos_sessionctl_local.sh $SESSION_VERB $STEAMOS_USER_PASSWORD"


### PR DESCRIPTION
Overhaul all this so we can have working keyboard/mouse focus logic across the entire SteamVR stack.

This also allows us to forward keyboard stuff to arbitrary SteamVR fake overlay windows.

In virtual connector modes (eg. VR) we also always have a dummy 0th global focus, for when we are only forwarding to handle those.

Some stuff isn't in OpenVR headers yet, so define those.

Also, add some deployment tools for Gamescope and a vscode tasks.