### PR TITLE
edid: Include missing <climits>

### DIFF
--- a/src/edid.cpp
+++ b/src/edid.cpp
@@ -5,6 +5,7 @@
 #include "hdmi.h"
 
 #include <cassert>
+#include <climits>
 #include <cstring>
 #include <cstdlib>
 


### PR DESCRIPTION
This fixes a build failure when building with GCC 16 (ArchLinux recently updated from GCC 15.2.1 to 16.1.1), where the compiler would complain about PATH_MAX not being declared.