### PR TITLE
rendervulkan: add VK_IMAGE_USAGE_SAMPLED_BIT to screenshot texture

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3605,6 +3605,7 @@ gamescope::Rc<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, 
 			screenshotImageFlags.bMappable = true;
 			screenshotImageFlags.bTransferDst = true;
 			screenshotImageFlags.bStorage = true;
+			screenshotImageFlags.bSampled = true;
 			if (exportable || drmFormat == DRM_FORMAT_NV12) {
 				screenshotImageFlags.bExportable = true;
 				screenshotImageFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire


### PR DESCRIPTION
cs_rgb_to_nv12 samples from the screenshot texture, but it was being created without VK_IMAGE_USAGE_SAMPLED_BIT. This is undefined behavior under the Vulkan spec. RADV tolerates it, but ANV returns zero from the sample reads, producing all-black video when using Steam Game Recording in gamescope.

Spotted with VVL:

Validation Error: [ VUID-VkWriteDescriptorSet-descriptorType-00337 ]
vkUpdateDescriptorSets(): pDescriptorWrites[3].pImageInfo[0].imageView was created with VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT, but descriptorType is VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER.
The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE or VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, the imageView member of each element of pImageInfo must have been created with VK_IMAGE_USAGE_SAMPLED_BIT set (https://docs.vulkan.org/spec/latest/chapters/descriptorsets.html#VUID-VkWriteDescriptorSet-descriptorType-00337)
Objects: 2
    [0] VkImageView 0x1a800000001a8
    [1] VkImage 0x1a600000001a6

Closes: https://github.com/ValveSoftware/gamescope/issues/1875