### PR TITLE
steamcompmgr: null out overrideWindowMouse in the window destruction handler

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5339,6 +5339,8 @@ destroy_win(xwayland_ctx_t *ctx, Window id, bool gone, bool fade)
 		ctx->focus.notificationWindow = nullptr;
 	if (x11_win(ctx->focus.overrideWindow) == id && gone)
 		ctx->focus.overrideWindow = nullptr;
+	if (x11_win(ctx->focus.overrideWindowMouse) == id && gone)
+		ctx->focus.overrideWindowMouse = nullptr;
 	if (ctx->currentKeyboardFocusWindow == id && gone)
 		ctx->currentKeyboardFocusWindow = None;
 


### PR DESCRIPTION
This fixes a crash where xwayland_ctx_t::DetermineAndApplyFocus() would dereference a dangling pointer.
Full backtrace:

    #0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
    #1  0x00007faa1a1af813 in __pthread_kill_internal (threadid=<optimized out>, signo=6) at pthread_kill.c:89
    #2  0x00007faa1a155dc0 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
    #3  0x00007faa1a13d57a in __GI_abort () at abort.c:73
    #4  0x000055dcba9ee5da in std::__throw_bad_variant_access (__n=0) at /usr/include/c++/15.1.1/variant:1420
    #5  0x000055dcba9f805c in std::get<0ul, steamcompmgr_xwayland_win_t, steamcompmgr_xdg_win_t> (__v=...) at /usr/include/c++/15.1.1/variant:1792
    #6  0x000055dcba9f235a in std::get<steamcompmgr_xwayland_win_t, steamcompmgr_xwayland_win_t, steamcompmgr_xdg_win_t> (__v=...)
        at /usr/include/c++/15.1.1/variant:1153
    #7  0x000055dcba9eee10 in steamcompmgr_win_t::xwayland (this=0x7fa9ec06eb00) at ../src/steamcompmgr_shared.hpp:170
    #8  0x000055dcba9d5caf in xwayland_ctx_t::DetermineAndApplyFocus (this=0x7fa9ec00c190, vecPossibleFocusWindows=...) at ../src/steamcompmgr.cpp:3939
    #9  0x000055dcba9d684d in determine_and_apply_focus (pFocus=0x7fa9ec0110a0) at ../src/steamcompmgr.cpp:4117
    #10 0x000055dcba9e852b in steamcompmgr_main (argc=26, argv=0x7ffd864c5f68) at ../src/steamcompmgr.cpp:8679
    #11 0x000055dcbaa43a18 in steamCompMgrThreadRun (argc=26, argv=0x7ffd864c5f68) at ../src/main.cpp:1061
    #12 0x000055dcbaa4497a in std::__invoke_impl<void, void (*)(int, char**), int, char**> (
        __f=@0x55dcf6c69aa8: 0x55dcbaa439de <steamCompMgrThreadRun(int, char**)>) at /usr/include/c++/15.1.1/bits/invoke.h:63
    #13 0x000055dcbaa448e2 in std::__invoke<void (*)(int, char**), int, char**> (
        __fn=@0x55dcf6c69aa8: 0x55dcbaa439de <steamCompMgrThreadRun(int, char**)>) at /usr/include/c++/15.1.1/bits/invoke.h:98
    #14 0x000055dcbaa4482f in std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> >::_M_invoke<0ul, 1ul, 2ul> (this=0x55dcf6c69a98)
        at /usr/include/c++/15.1.1/bits/std_thread.h:303
    #15 0x000055dcbaa447cc in std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> >::operator() (this=0x55dcf6c69a98)
        at /usr/include/c++/15.1.1/bits/std_thread.h:310
    #16 0x000055dcbaa447b0 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(int, char**), int, char**> > >::_M_run (
        this=0x55dcf6c69a90) at /usr/include/c++/15.1.1/bits/std_thread.h:255
    #17 0x00007faa1a4e51a4 in std::execute_native_thread_routine (__p=0x55dcf6c69a90) at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104
    #18 0x00007faa1a1ad7eb in start_thread (arg=<optimized out>) at pthread_create.c:448
    #19 0x00007faa1a23120c in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78