### PR TITLE
steamcompmgr: Do not try to match a dropdown window's PID with the focused window's PID

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3449,10 +3449,6 @@ static bool is_good_override_candidate( steamcompmgr_win_t *override, steamcompm
 	if ( !focus )
 		return false;
 
-	// The pids should probably match for a dropdown to be a good candidate for this window.
-	if (override->pid != focus->pid)
-		return false;
-
 	auto rect = override->GetGeometry();
 	return override != focus && (rect.nX + rect.nWidth) > 0 && (rect.nY + rect.nHeight) > 0;
 } 


### PR DESCRIPTION
Some apps, like WebView2 (used in some game launchers) spawn child processes to render dropdowns, so the PIDs would not match, and the dropdown would not be shown. This was the case for e.g. Final Fantasy XIV online.