### PR TITLE
build: fix 32-bit build on SteamOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -105,7 +105,7 @@ if get_option('enable_gamescope')
   subdir('src')
 endif
 
-if get_option('enable_tests')
+if get_option('enable_tests') and get_option('enable_gamescope')
   subdir('tests')
 endif
 


### PR DESCRIPTION
With -Denable_gamescope=false, the lib32-gamescope build now fails with:
../tests/meson.build:5:14: ERROR: Unknown variable "gamescope_core_src".