### PR TITLE
steamcompmgr: fix the detection of the .nv12.bin extension for screenshot requests

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2848,7 +2848,7 @@ paint_all( global_focus_t *pFocus, bool async )
 			drmCaptureFormat = DRM_FORMAT_XRGB2101010;
 		else if ( path.extension() == ".png" )
 			drmCaptureFormat = DRM_FORMAT_XRGB8888;
-		else if ( path.extension() == ".nv12.bin" )
+		else if ( path.extension() == ".bin" && path.stem().extension() == ".nv12" )
 			drmCaptureFormat = DRM_FORMAT_NV12;
 
 		gamescope::Rc<CVulkanTexture> pScreenshotTexture;


### PR DESCRIPTION
The extension() method returns only the rightmost extension, in that case ".bin", so the check would never match. As a result the format wouldn't be assigned, and the request would always fail with this misleading error message:

    "Oh no, we ran out of screenshot images. Not actually writing a screenshot."