### PR TITLE
Replace -ffast-math flag with -funsafe-math-optimizations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ add_project_arguments(cppc.get_supported_arguments([
 
 add_project_arguments(cppc.get_supported_arguments([
   '-fno-exceptions',
-  '-ffast-math',
+  '-funsafe-math-optimizations',
 ]), language: 'cpp')
 
 pipewire_dep = dependency('libpipewire-0.3', required: get_option('pipewire'))


### PR DESCRIPTION
An alternative to removing the `-ffast-math` flag - this PR replaces it with a more conservative one, which does not enable NaN or infinity assumptions that cause rounding errors - most notably blurriness when compiling with Clang.
`-funsafe-math-optimizations` enables most of the optimizations that `-ffast-math` does, so there shouldn't be a noticeable performance difference.

Fixes #1493 

Sources:
- https://llvm.org/devmtg/2024-10/slides/techtalk/Kaylor-Towards-Useful-Fast-Math.pdf
- https://clang.llvm.org/docs/UsersManual.html
- https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html