### PR TITLE
steamcompmgr: remove an unneeded test in paint_window_commit()

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2176,16 +2176,8 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 	layer->scale.x = 1.0 / currentScaleRatio_x;
 	layer->scale.y = 1.0 / currentScaleRatio_y;
 
-	if ( w != scaleW )
-	{
-		layer->offset.x = -drawXOffset;
-		layer->offset.y = -drawYOffset;
-	}
-	else
-	{
-		layer->offset.x = -drawXOffset;
-		layer->offset.y = -drawYOffset;
-	}
+	layer->offset.x = -drawXOffset;
+	layer->offset.y = -drawYOffset;
 
 	layer->blackBorder = flags & PaintWindowFlag::DrawBorders;
 


### PR DESCRIPTION
In d75b122cb0dc36ded36c1d96de0b1327a4fb487a an else block was removed, making the test redundant because its two branches apply the same offset.