### PR TITLE
rendervulkan: remove HAVE_DRM guard from createDevice()

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -465,7 +465,6 @@ bool CVulkanDevice::createDevice()
 		// (without an actual physical device)
 		vk_log.warnf( "physical device doesn't support VK_EXT_physical_device_drm" );
 	} else {
-#if HAVE_DRM
 		VkPhysicalDeviceDrmPropertiesEXT drmProps = {
 			.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT,
 		};
@@ -500,13 +499,10 @@ bool CVulkanDevice::createDevice()
 			return false;
 		}
 
-		if ( drmProps.hasPrimary ) {
+		if ( !GetBackend()->UsesVulkanSwapchain() && drmProps.hasPrimary ) {
 			m_bHasDrmPrimaryDevId = true;
 			m_drmPrimaryDevId = makedev( drmProps.primaryMajor, drmProps.primaryMinor );
 		}
-#else
-		vk_log.warnf( "built without DRM support" );
-#endif
 	}
 
 	if ( m_bSupportsModifiers && !supportsForeignQueue ) {


### PR DESCRIPTION
This whole block (render node part) needed for SDL backend.
So building with `drm_backend=disabled` and `sdl2_backend=enabled` will not remove required code.

And since it's currently not possible to build with `drm_backend=disabled` I expect this change should work for other backends as it is now (combined with #2073).

See also: ValveSoftware/gamescope#1347