### PR TITLE
Runtime display selection in DRM backend

### DIFF
--- a/protocol/gamescope-control.xml
+++ b/protocol/gamescope-control.xml
@@ -29,7 +29,7 @@
     it.
   </description>
 
-  <interface name="gamescope_control" version="6">
+  <interface name="gamescope_control" version="7">
     <request name="destroy" type="destructor"></request>
 
     <enum name="feature">
@@ -44,6 +44,7 @@
       <entry name="mura_correction" value="5"/>
       <entry name="look" value="6"/>
       <entry name="perf_query" value="7"/>
+      <entry name="display_selection" value="8"/>
     </enum>
 
     <event name="feature_support">
@@ -59,6 +60,7 @@
       <entry name="internal_display" value="0x1"/>
       <entry name="supports_hdr" value="0x2"/>
       <entry name="supports_vrr" value="0x4"/>
+      <entry name="current" value="0x8"/>
     </enum>
 
     <event name="active_display_info" since="2">
@@ -142,6 +144,28 @@
       <arg name="frametime_ns_lo" type="uint" summary="Time delta between the two most recent frames"></arg>
       <arg name="frametime_ns_hi" type="uint" summary="frametime_ns high bits"></arg>
     </event>
+
+    <event name="available_display_info" since="7">
+      <description summary="report one display the compositor can switch to"></description>
+      <arg name="connector_name" type="string" summary="connector name (e.g. 'DP-1') to pass back via set_display"/>
+      <arg name="display_make" type="string"/>
+      <arg name="display_model" type="string"/>
+      <arg name="display_flags" type="uint" enum="display_flag" summary="combination of 'display_flag' values"/>
+      <arg name="display_identifier" type="string" summary="opaque EDID-derived key for persisting a display preference, saved and compared verbatim. Identical monitors get a trailing ' [...]' suffix to tell them apart"/>
+    </event>
+
+    <event name="available_display_info_done" since="7">
+      <description summary="terminator for an available_display_info batch, which fully replaces any previously reported list"></description>
+    </event>
+
+    <request name="set_display" since="7">
+      <description summary="select the display to drive; ignored if connector_name is not a currently-connected output"></description>
+      <arg name="connector_name" type="string" summary="connector to drive, as reported by available_display_info"/>
+    </request>
+
+    <request name="unset_display" since="7">
+      <description summary="clear any runtime display selection"></description>
+    </request>
 
   </interface>
 </protocol>

--- a/src/Apps/gamescopectl.cpp
+++ b/src/Apps/gamescopectl.cpp
@@ -33,6 +33,15 @@ namespace gamescope
         std::vector<uint32_t> ValidRefreshRates;
     };
 
+    struct GamescopeAvailableDisplayInfo
+    {
+        std::string szConnectorName;
+        std::string szDisplayMake;
+        std::string szDisplayModel;
+        uint32_t uDisplayFlags;
+        std::string szDisplayIdentifier;
+    };
+
     class GamescopeCtl
     {
     public:
@@ -44,6 +53,7 @@ namespace gamescope
 
         std::span<GamescopeFeature> GetFeatures() { return std::span<GamescopeFeature>{ m_Features }; }
         const std::optional<GamescopeActiveDisplayInfo> &GetActiveDisplayInfo() { return m_ActiveDisplayInfo; }
+        std::span<const GamescopeAvailableDisplayInfo> GetAvailableDisplays() { return m_AvailableDisplays; }
     private:
         bool m_bInitControl = false;
         bool m_bInitPrivate = false;
@@ -56,6 +66,7 @@ namespace gamescope
 
         std::vector<GamescopeFeature> m_Features;
         std::optional<GamescopeActiveDisplayInfo> m_ActiveDisplayInfo;
+        std::vector<GamescopeAvailableDisplayInfo> m_AvailableDisplays;
 
         void Wayland_Registry_Global( wl_registry *pRegistry, uint32_t uName, const char *pInterface, uint32_t uVersion );
         static const wl_registry_listener s_RegistryListener;
@@ -63,6 +74,7 @@ namespace gamescope
         void Wayland_GamescopeControl_FeatureSupport( gamescope_control *pGamescopeControl, uint32_t uFeature, uint32_t uVersion, uint32_t uFlags );
         void Wayland_GamescopeControl_ActiveDisplayInfo( gamescope_control *pGamescopeControl, const char *pConnectorName, const char *pDisplayMake, const char *pDisplayModel, uint32_t uDisplayFlags, wl_array *pValidRefreshRatesArray );
         void Wayland_GamescopeControl_ScreenshotTaken( gamescope_control *pGamescopeControl, const char *pPath );
+        void Wayland_GamescopeControl_AvailableDisplayInfo( gamescope_control *pGamescopeControl, const char *pConnectorName, const char *pDisplayMake, const char *pDisplayModel, uint32_t uDisplayFlags, const char *pDisplayIdentifier );
         static const gamescope_control_listener s_GamescopeControlListener;
 
         void Wayland_GamescopePrivate_Log( gamescope_private *pGamescopePrivate, const char *pText );
@@ -122,6 +134,12 @@ namespace gamescope
         if ( args.size() < 1 )
         {
             fprintf( stderr, "No command to execute\n" );
+            return false;
+        }
+
+        if ( args.size() > 2 )
+        {
+            fprintf( stderr, "Too many arguments - quote multi-word values, eg. set_display \"LG ULTRAGEAR ABC123\"\n" );
             return false;
         }
 
@@ -187,12 +205,26 @@ namespace gamescope
         fprintf( stderr, "Screenshot taken to: %s\n", pPath );
     }
 
+    void GamescopeCtl::Wayland_GamescopeControl_AvailableDisplayInfo( gamescope_control *pGamescopeControl, const char *pConnectorName, const char *pDisplayMake, const char *pDisplayModel, uint32_t uDisplayFlags, const char *pDisplayIdentifier )
+    {
+        m_AvailableDisplays.emplace_back( GamescopeAvailableDisplayInfo
+        {
+            .szConnectorName     = pConnectorName,
+            .szDisplayMake       = pDisplayMake,
+            .szDisplayModel      = pDisplayModel,
+            .uDisplayFlags       = uDisplayFlags,
+            .szDisplayIdentifier = pDisplayIdentifier,
+        } );
+    }
+
     const gamescope_control_listener GamescopeCtl::s_GamescopeControlListener =
     {
-        .feature_support       = WAYLAND_USERDATA_TO_THIS( GamescopeCtl, Wayland_GamescopeControl_FeatureSupport ),
-        .active_display_info   = WAYLAND_USERDATA_TO_THIS( GamescopeCtl, Wayland_GamescopeControl_ActiveDisplayInfo ),
-        .screenshot_taken      = WAYLAND_USERDATA_TO_THIS( GamescopeCtl, Wayland_GamescopeControl_ScreenshotTaken ),
-        .app_performance_stats = WAYLAND_NULL(),
+        .feature_support             = WAYLAND_USERDATA_TO_THIS( GamescopeCtl, Wayland_GamescopeControl_FeatureSupport ),
+        .active_display_info         = WAYLAND_USERDATA_TO_THIS( GamescopeCtl, Wayland_GamescopeControl_ActiveDisplayInfo ),
+        .screenshot_taken            = WAYLAND_USERDATA_TO_THIS( GamescopeCtl, Wayland_GamescopeControl_ScreenshotTaken ),
+        .app_performance_stats       = WAYLAND_NULL(),
+        .available_display_info      = WAYLAND_USERDATA_TO_THIS( GamescopeCtl, Wayland_GamescopeControl_AvailableDisplayInfo ),
+        .available_display_info_done = WAYLAND_NULL(),
     };
 
     void GamescopeCtl::Wayland_GamescopePrivate_Log( gamescope_private *pGamescopePrivate, const char *pText )
@@ -231,6 +263,8 @@ namespace gamescope
                 return "Look";
             case GAMESCOPE_CONTROL_FEATURE_PERF_QUERY:
                 return "Performance Query";
+            case GAMESCOPE_CONTROL_FEATURE_DISPLAY_SELECTION:
+                return "Display Selection";
             default:
                 return "Unknown";
         }
@@ -265,6 +299,27 @@ namespace gamescope
                     fprintf( stdout, bLast ? "%u" : "%u, ", uRate );
                 }
                 fprintf( stdout, "\n" );
+            }
+            auto availableDisplays = gamescopeCtl.GetAvailableDisplays();
+            if ( !availableDisplays.empty() )
+            {
+                fprintf( stdout, "  Available Displays:\n" );
+                for ( const GamescopeAvailableDisplayInfo &avail : availableDisplays )
+                {
+                    fprintf( stdout, "  - %s", avail.szConnectorName.c_str() );
+                    std::string szMakeModel = avail.szDisplayMake;
+                    if ( !szMakeModel.empty() && !avail.szDisplayModel.empty() )
+                        szMakeModel += " ";
+                    szMakeModel += avail.szDisplayModel;
+                    if ( !szMakeModel.empty() )
+                        fprintf( stdout, " (%s)", szMakeModel.c_str() );
+                    fprintf( stdout, " - Flags: 0x%x", avail.uDisplayFlags );
+                    if ( !avail.szDisplayIdentifier.empty() )
+                        fprintf( stdout, " - Identifier: \"%s\"", avail.szDisplayIdentifier.c_str() );
+                    if ( avail.uDisplayFlags & GAMESCOPE_CONTROL_DISPLAY_FLAG_CURRENT )
+                        fprintf( stdout, " [current]" );
+                    fprintf( stdout, "\n" );
+                }
             }
             fprintf( stdout, "  Features:\n" );
             for ( const GamescopeFeature &feature : gamescopeCtl.GetFeatures() )

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <poll.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <cinttypes>
@@ -54,6 +55,8 @@
 #include "wlr_end.hpp"
 
 #include "gamescope-control-protocol.h"
+
+#include "display_selection.h"
 
 static constexpr bool k_bUseCursorPlane = false;
 
@@ -156,8 +159,14 @@ struct drm_t {
 	std::atomic < bool > paused = { false };
 	std::atomic < int > out_of_date = { false };
 	std::atomic < bool > needs_modeset = { false };
+	std::atomic < bool > pending_display_announce = { false };
 
 	std::unordered_map< std::string, int > connector_priorities;
+	// Rebuilt on the steamcompmgr thread; the only connector state other threads read.
+	std::mutex connected_outputs_mutex;
+	std::vector< gamescope::GamescopeKnownDisplay > connected_outputs;
+	std::mutex preferred_display_mutex;
+	std::string preferred_display;
 
 	char *device_name = nullptr;
 };
@@ -397,6 +406,8 @@ namespace gamescope
 		const char *GetMake() const override { return m_Mutable.pszMake; }
 		const char *GetModel() const override { return m_Mutable.szModel; }
 		const char *GetDataString() const { return m_Mutable.szDataString; }
+		uint32_t GetEDIDSerial() const { return m_Mutable.uEDIDSerial; }
+		const char *GetEDIDSerialString() const { return m_Mutable.szEDIDSerial; }
 		uint32_t GetPossibleCRTCMask() const { return m_Mutable.uPossibleCRTCMask; }
 		std::span<const uint32_t> GetValidDynamicRefreshRates() const override { return m_Mutable.ValidDynamicRefreshRates; }
 		const displaycolorimetry_t& GetDisplayColorimetry() const { return m_Mutable.DisplayColorimetry; }
@@ -520,6 +531,8 @@ namespace gamescope
 			char szMakePNP[4]{};
 			char szModel[16]{};
 			char szDataString[16]{};
+			uint32_t uEDIDSerial = 0;
+			char szEDIDSerial[16]{};
 			const char *pszMake = ""; // Not owned, no free. This is a pointer to pnp db or szMakePNP.
 			DRMModeGenerator fnDynamicModeGenerator;
 			std::vector<uint32_t> ValidDynamicRefreshRates{};
@@ -1013,6 +1026,79 @@ static std::unordered_map<std::string, int> parse_connector_priorities(const cha
 	return priorities;
 }
 
+static std::string get_display_identifier(const gamescope::CDRMConnector *pConnector)
+{
+	const char *pszMake = pConnector->GetMake();
+	const char *pszModel = pConnector->GetModel();
+	const char *pszName = pConnector->GetName();
+	const char *pszSerialStr = pConnector->GetEDIDSerialString();
+	return gamescope::BuildDisplayIdentifier(
+		pConnector->GetScreenType() == gamescope::GAMESCOPE_SCREEN_TYPE_INTERNAL,
+		pszMake ? pszMake : "",
+		pszModel ? pszModel : "",
+		pszName ? pszName : "",
+		pConnector->GetEDIDSerial(),
+		pszSerialStr ? pszSerialStr : "" );
+}
+
+static std::string get_display_key(struct drm_t *drm, const gamescope::CDRMConnector *pConnector)
+{
+	std::string base = get_display_identifier(pConnector);
+	bool bShared = false;
+	for (auto &iter : drm->connectors)
+	{
+		gamescope::CDRMConnector *pOther = &iter.second;
+		if (pOther != pConnector
+			&& pOther->GetModeConnector()->connection == DRM_MODE_CONNECTED
+			&& get_display_identifier(pOther) == base)
+		{
+			bShared = true;
+			break;
+		}
+	}
+	const char *pszName = pConnector->GetName();
+	return gamescope::BuildDisplaySelectionKey( base, pszName ? pszName : "", bShared );
+}
+
+// steamcompmgr thread only. Returns true if the snapshot changed.
+static bool update_connected_outputs_snapshot( struct drm_t *drm )
+{
+	std::vector< gamescope::GamescopeKnownDisplay > outputs;
+	for ( auto &iter : drm->connectors )
+	{
+		gamescope::CDRMConnector *pConn = &iter.second;
+		if ( pConn->GetModeConnector()->connection != DRM_MODE_CONNECTED )
+			continue;
+
+		uint32_t flags = 0;
+		if ( pConn->GetScreenType() == gamescope::GAMESCOPE_SCREEN_TYPE_INTERNAL )
+			flags |= GAMESCOPE_CONTROL_DISPLAY_FLAG_INTERNAL_DISPLAY;
+		if ( pConn->GetHDRInfo().bExposeHDRSupport )
+			flags |= GAMESCOPE_CONTROL_DISPLAY_FLAG_SUPPORTS_HDR;
+		if ( pConn->SupportsVRR() )
+			flags |= GAMESCOPE_CONTROL_DISPLAY_FLAG_SUPPORTS_VRR;
+		if ( pConn == drm->pConnector )
+			flags |= GAMESCOPE_CONTROL_DISPLAY_FLAG_CURRENT;
+
+		outputs.emplace_back( gamescope::GamescopeKnownDisplay{
+			.szConnectorName = pConn->GetName()  ? pConn->GetName()  : "",
+			.szMake          = pConn->GetMake()  ? pConn->GetMake()  : "",
+			.szModel         = pConn->GetModel() ? pConn->GetModel() : "",
+			.szIdentifier    = get_display_key( drm, pConn ),
+			.uFlags          = flags,
+		} );
+	}
+	std::sort( outputs.begin(), outputs.end(),
+		[]( const gamescope::GamescopeKnownDisplay &a, const gamescope::GamescopeKnownDisplay &b )
+		{ return a.szConnectorName < b.szConnectorName; } );
+
+	std::lock_guard lock( drm->connected_outputs_mutex );
+	if ( outputs == drm->connected_outputs )
+		return false;
+	drm->connected_outputs = std::move( outputs );
+	return true;
+}
+
 static int get_connector_priority(struct drm_t *drm, const char *name)
 {
 	if (drm->connector_priorities.count(name) > 0) {
@@ -1022,6 +1108,29 @@ static int get_connector_priority(struct drm_t *drm, const char *name)
 		return drm->connector_priorities["*"];
 	}
 	return drm->connector_priorities.size();
+}
+
+static std::string get_saved_preferred_display()
+{
+	const char *path = getenv("GAMESCOPE_DISPLAY_SELECTION_FILE");
+	if (!path || !*path)
+		return {};
+
+	FILE *file = fopen(path, "r");
+	if (!file)
+		return {};
+
+	char line[256] = {};
+	std::string result;
+	if (fgets(line, sizeof(line), file))
+	{
+		size_t len = strlen(line);
+		while (len > 0 && (line[len-1] == '\n' || line[len-1] == '\r' || line[len-1] == ' ' || line[len-1] == '\t'))
+			line[--len] = '\0';
+		result = line;
+	}
+	fclose(file);
+	return result;
 }
 
 static bool get_saved_mode(const char *description, saved_mode &mode_info)
@@ -1057,12 +1166,55 @@ static bool get_saved_mode(const char *description, saved_mode &mode_info)
 
 static GamescopeBroadcastRGBMode_t s_ExternalBroadcastRGBMode = GAMESCOPE_BROADCAST_RGB_MODE_AUTOMATIC;
 
-static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
+static gamescope::CDRMConnector *resolve_preferred_connector(struct drm_t *drm)
+{
+	std::string pref;
+	{
+		std::lock_guard lock( drm->preferred_display_mutex );
+		pref = drm->preferred_display;
+	}
+	if (pref.empty())
+		return nullptr;
+
+	std::vector<gamescope::CDRMConnector *> pConnectors;
+	for (auto &iter : drm->connectors)
+	{
+		gamescope::CDRMConnector *pConnector = &iter.second;
+		if (pConnector->GetModeConnector()->connection != DRM_MODE_CONNECTED)
+			continue;
+		pConnectors.push_back( pConnector );
+	}
+	// Deterministic order, so the ambiguous-key fallback doesn't follow map order.
+	std::sort( pConnectors.begin(), pConnectors.end(),
+		[]( gamescope::CDRMConnector *a, gamescope::CDRMConnector *b )
+		{ return strcmp( a->GetName(), b->GetName() ) < 0; } );
+
+	std::vector<gamescope::DisplaySelectionCandidate> candidates;
+	for (gamescope::CDRMConnector *pConnector : pConnectors)
+	{
+		const char *pszName = pConnector->GetName();
+		candidates.push_back( { pszName ? pszName : "", get_display_identifier(pConnector) } );
+	}
+
+	std::optional<size_t> oIndex = gamescope::ResolveDisplaySelection( pref, candidates );
+	if (!oIndex) {
+		drm_log.infof("preferred display '%s' not connected, using output priority", pref.c_str());
+		return nullptr;
+	}
+
+	gamescope::CDRMConnector *pConnector = pConnectors[*oIndex];
+	drm_log.infof("preferred display '%s' -> connector %s", pref.c_str(), pConnector->GetName());
+	return pConnector;
+}
+
+static bool setup_best_connector(struct drm_t *drm, bool force, bool initial, bool *pbDidReconfigure = nullptr)
 {
 	if (drm->pConnector && drm->pConnector->GetModeConnector()->connection != DRM_MODE_CONNECTED) {
 		drm_log.infof("current connector '%s' disconnected", drm->pConnector->GetName());
 		drm->pConnector = nullptr;
 	}
+
+	gamescope::CDRMConnector *pPreferred = resolve_preferred_connector( drm );
 
 	gamescope::CDRMConnector *best = nullptr;
 	int nBestPriority = INT_MAX;
@@ -1076,7 +1228,7 @@ static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
 		if ( g_bForceInternal && pConnector->GetScreenType() == gamescope::GAMESCOPE_SCREEN_TYPE_EXTERNAL )
 			continue;
 
-		int nPriority = get_connector_priority( drm, pConnector->GetName() );
+		int nPriority = ( pConnector == pPreferred ) ? INT_MIN : get_connector_priority( drm, pConnector->GetName() );
 		if ( nPriority < nBestPriority )
 		{
 			best = pConnector;
@@ -1162,6 +1314,9 @@ static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
 	// Don't allow rollback of mode_id after connector change
 	drm->current.mode_id = drm->pending.mode_id;
 
+	if (pbDidReconfigure)
+		*pbDidReconfigure = true;
+
 	const struct wlserver_output_info wlserver_output_info = {
 		.description = description,
 		.phys_width = (int) best->GetModeConnector()->mmWidth,
@@ -1173,8 +1328,6 @@ static bool setup_best_connector(struct drm_t *drm, bool force, bool initial)
 
 	if (!initial)
 		WritePatchedEdid( best->GetRawEDID(), best->GetHDRInfo(), g_bRotated );
-
-	update_connector_display_info_wl( drm );
 
 	return true;
 }
@@ -1349,9 +1502,24 @@ bool init_drm(struct drm_t *drm, int width, int height, int refresh)
 
 	drm->connector_priorities = parse_connector_priorities( g_sOutputName );
 
+	{
+		std::string saved = get_saved_preferred_display();
+		if (!saved.empty()) {
+			drm_log.infof("using saved preferred display: %s", saved.c_str());
+			std::lock_guard lock( drm->preferred_display_mutex );
+			drm->preferred_display = std::move(saved);
+		}
+	}
+
 	if (!setup_best_connector(drm, true, true)) {
 		return false;
 	}
+
+	// Deferred init may replay a queued selection before the first poll, so build
+	// the snapshot now. Announcing here would deadlock under the deferred init lock.
+	update_connected_outputs_snapshot( drm );
+	drm->pending_display_announce = true;
+	drm->out_of_date = std::max<int>( drm->out_of_date, 1 );
 
 	// Fetch formats which can be scanned out
 	for ( std::unique_ptr< gamescope::CDRMPlane > &pPlane : drm->planes )
@@ -1466,6 +1634,42 @@ void drm_sleep_screen( gamescope::GamescopeScreenType eType, bool bSleep )
 	cv_drm_sleep_screens[ eType ] = bSleep;
 }
 
+// Returns true if the preference changed.
+static bool set_preferred_display( std::string identifier )
+{
+	std::lock_guard lock( g_DRM.preferred_display_mutex );
+	if ( g_DRM.preferred_display == identifier )
+		return false;
+	g_DRM.preferred_display = std::move(identifier);
+	return true;
+}
+
+static bool drm_set_preferred_connector( const char *pszName )
+{
+	std::string identifier;
+	if ( pszName && *pszName )
+	{
+		std::lock_guard lock( g_DRM.connected_outputs_mutex );
+		for ( const auto &display : g_DRM.connected_outputs )
+		{
+			if ( display.szConnectorName == pszName )
+			{
+				identifier = display.szIdentifier;
+				break;
+			}
+		}
+		if ( identifier.empty() )
+			return false; // Not a connected output - per protocol, ignore.
+	}
+
+	return set_preferred_display( std::move(identifier) );
+}
+
+static std::vector< gamescope::GamescopeKnownDisplay > drm_get_connected_outputs()
+{
+	std::lock_guard lock( g_DRM.connected_outputs_mutex );
+	return g_DRM.connected_outputs;
+}
 
 
 void finish_drm(struct drm_t *drm)
@@ -2316,6 +2520,7 @@ namespace gamescope
 		m_Mutable.szMakePNP[1] = pProduct->manufacturer[1];
 		m_Mutable.szMakePNP[2] = pProduct->manufacturer[2];
 		m_Mutable.szMakePNP[3] = '\0';
+		m_Mutable.uEDIDSerial = pProduct->serial;
 
 		m_Mutable.pszMake = m_Mutable.szMakePNP;
 		auto pnpIter = pnps.find( m_Mutable.szMakePNP );
@@ -2338,6 +2543,12 @@ namespace gamescope
 			{
 				const char *pszDataString = di_edid_display_descriptor_get_string( pDesc );
 				strncpy( m_Mutable.szDataString, pszDataString, sizeof( m_Mutable.szDataString ) );
+			}
+			else if ( eTag == DI_EDID_DISPLAY_DESCRIPTOR_PRODUCT_SERIAL )
+			{
+				// Descriptor strings are <= 14 chars, so szEDIDSerial[16] is never truncated.
+				const char *pszSerial = di_edid_display_descriptor_get_string( pDesc );
+				strncpy( m_Mutable.szEDIDSerial, pszSerial, sizeof( m_Mutable.szEDIDSerial ) );
 			}
 		}
 
@@ -3136,7 +3347,14 @@ bool drm_poll_state( struct drm_t *drm )
 
 	refresh_state( drm );
 
-	setup_best_connector(drm, out_of_date >= 2, false);
+	bool reconfigured = false;
+	setup_best_connector(drm, out_of_date >= 2, false, &reconfigured);
+
+	// Reconfigures change active_display_info (refresh rates) without changing the list.
+	bool outputs_changed = update_connected_outputs_snapshot( drm );
+	bool announce = drm->pending_display_announce.exchange( false );
+	if ( reconfigured || outputs_changed || announce )
+		update_connector_display_info_wl( drm );
 
 	return true;
 }
@@ -3858,6 +4076,18 @@ namespace gamescope
 		virtual IBackendConnector *GetCurrentConnector() override
 		{
 			return g_DRM.pConnector;
+		}
+
+		virtual std::vector< gamescope::GamescopeKnownDisplay > GetConnectedOutputs() override
+		{
+			return drm_get_connected_outputs();
+		}
+
+		virtual void SetPreferredConnector( const char *pszConnectorName ) override
+		{
+			// Our own DirtyState - GetBackend() may be a deferred wrapper holding its init lock.
+			if ( drm_set_preferred_connector( pszConnectorName ) )
+				DirtyState( false, false );
 		}
 
 		virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) override

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -396,6 +396,7 @@ namespace gamescope
 			std::optional<CDRMAtomicProperty> vrr_capable;
 			std::optional<CDRMAtomicProperty> EDID;
 			std::optional<CDRMAtomicProperty> Broadcast_RGB;
+			std::optional<CDRMAtomicProperty> PATH;
 			std::optional<CDRMAtomicProperty> DUMMY_END;
 		};
 		      ConnectorProperties &GetProperties()       { return m_Props; }
@@ -408,6 +409,7 @@ namespace gamescope
 		const char *GetDataString() const { return m_Mutable.szDataString; }
 		uint32_t GetEDIDSerial() const { return m_Mutable.uEDIDSerial; }
 		const char *GetEDIDSerialString() const { return m_Mutable.szEDIDSerial; }
+		const char *GetMstPath() const { return m_Mutable.szMstPath.c_str(); }
 		uint32_t GetPossibleCRTCMask() const { return m_Mutable.uPossibleCRTCMask; }
 		std::span<const uint32_t> GetValidDynamicRefreshRates() const override { return m_Mutable.ValidDynamicRefreshRates; }
 		const displaycolorimetry_t& GetDisplayColorimetry() const { return m_Mutable.DisplayColorimetry; }
@@ -533,6 +535,7 @@ namespace gamescope
 			char szDataString[16]{};
 			uint32_t uEDIDSerial = 0;
 			char szEDIDSerial[16]{};
+			std::string szMstPath;
 			const char *pszMake = ""; // Not owned, no free. This is a pointer to pnp db or szMakePNP.
 			DRMModeGenerator fnDynamicModeGenerator;
 			std::vector<uint32_t> ValidDynamicRefreshRates{};
@@ -1056,8 +1059,10 @@ static std::string get_display_key(struct drm_t *drm, const gamescope::CDRMConne
 			break;
 		}
 	}
+	const char *pszMstPath = pConnector->GetMstPath();
 	const char *pszName = pConnector->GetName();
-	return gamescope::BuildDisplaySelectionKey( base, pszName ? pszName : "", bShared );
+	const char *pszHint = ( pszMstPath && *pszMstPath ) ? pszMstPath : pszName;
+	return gamescope::BuildDisplaySelectionKey( base, pszHint ? pszHint : "", bShared );
 }
 
 // steamcompmgr thread only. Returns true if the snapshot changed.
@@ -1193,7 +1198,8 @@ static gamescope::CDRMConnector *resolve_preferred_connector(struct drm_t *drm)
 	for (gamescope::CDRMConnector *pConnector : pConnectors)
 	{
 		const char *pszName = pConnector->GetName();
-		candidates.push_back( { pszName ? pszName : "", get_display_identifier(pConnector) } );
+		const char *pszMstPath = pConnector->GetMstPath();
+		candidates.push_back( { pszName ? pszName : "", get_display_identifier(pConnector), pszMstPath ? pszMstPath : "" } );
 	}
 
 	std::optional<size_t> oIndex = gamescope::ResolveDisplaySelection( pref, candidates );
@@ -2430,6 +2436,20 @@ namespace gamescope
 			m_Props.vrr_capable              = CDRMAtomicProperty::Instantiate( "vrr_capable",            this, *rawProperties );
 			m_Props.EDID                     = CDRMAtomicProperty::Instantiate( "EDID",                   this, *rawProperties );
 			m_Props.Broadcast_RGB            = CDRMAtomicProperty::Instantiate( "Broadcast RGB",          this, *rawProperties );
+			m_Props.PATH                     = CDRMAtomicProperty::Instantiate( "PATH",                   this, *rawProperties );
+		}
+
+		if ( m_Props.PATH )
+		{
+			if ( uint64_t ulBlobId = m_Props.PATH->GetCurrentValue() )
+			{
+				if ( drmModePropertyBlobRes *pBlob = drmModeGetPropertyBlob( g_DRM.fd, ulBlobId ) )
+				{
+					const char *pszMstPath = reinterpret_cast<const char *>( pBlob->data );
+					m_Mutable.szMstPath.assign( pszMstPath, strnlen( pszMstPath, pBlob->length ) );
+					drmModeFreePropertyBlob( pBlob );
+				}
+			}
 		}
 
 		ParseEDID();

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -1671,6 +1671,11 @@ static bool drm_set_preferred_connector( const char *pszName )
 	return set_preferred_display( std::move(identifier) );
 }
 
+static bool drm_set_preferred_display_identifier( const char *pszIdentifier )
+{
+	return set_preferred_display( ( pszIdentifier && *pszIdentifier ) ? pszIdentifier : "" );
+}
+
 static std::vector< gamescope::GamescopeKnownDisplay > drm_get_connected_outputs()
 {
 	std::lock_guard lock( g_DRM.connected_outputs_mutex );
@@ -4107,6 +4112,12 @@ namespace gamescope
 		{
 			// Our own DirtyState - GetBackend() may be a deferred wrapper holding its init lock.
 			if ( drm_set_preferred_connector( pszConnectorName ) )
+				DirtyState( false, false );
+		}
+
+		virtual void SetPreferredDisplayIdentifier( const char *pszIdentifier ) override
+		{
+			if ( drm_set_preferred_display_identifier( pszIdentifier ) )
 				DirtyState( false, false );
 		}
 

--- a/src/Backends/DeferredBackend.h
+++ b/src/Backends/DeferredBackend.h
@@ -208,7 +208,23 @@ namespace gamescope
             if ( m_bInittedChild )
                 return m_pChild->SetPreferredConnector( pszConnectorName );
 
-            QueueDisplayPreference( pszConnectorName ? pszConnectorName : "" );
+            QueueDisplayPreference( PendingDisplayPreference
+            {
+                .bByIdentifier = false,
+                .szValue = pszConnectorName ? pszConnectorName : "",
+            } );
+		}
+
+		virtual void SetPreferredDisplayIdentifier( const char *pszIdentifier ) override
+		{
+            if ( m_bInittedChild )
+                return m_pChild->SetPreferredDisplayIdentifier( pszIdentifier );
+
+            QueueDisplayPreference( PendingDisplayPreference
+            {
+                .bByIdentifier = true,
+                .szValue = pszIdentifier ? pszIdentifier : "",
+            } );
 		}
 
 		virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) override
@@ -439,26 +455,35 @@ namespace gamescope
             }
         }
 
-        void ApplyDisplayPreference( const std::string &szConnectorName )
+        struct PendingDisplayPreference
         {
-            m_pChild->SetPreferredConnector( szConnectorName.c_str() );
+            bool bByIdentifier = false;
+            std::string szValue;
+        };
+
+        void ApplyDisplayPreference( const PendingDisplayPreference &pref )
+        {
+            if ( pref.bByIdentifier )
+                m_pChild->SetPreferredDisplayIdentifier( pref.szValue.c_str() );
+            else
+                m_pChild->SetPreferredConnector( pref.szValue.c_str() );
         }
 
-        void QueueDisplayPreference( std::string szConnectorName )
+        void QueueDisplayPreference( PendingDisplayPreference pref )
         {
             // No m_mutInit here - init's EDID parse can run Lua that lands here.
             std::lock_guard lock{ m_PendingPreferenceMutex };
             if ( m_bInittedChild )
-                return ApplyDisplayPreference( szConnectorName );
+                return ApplyDisplayPreference( pref );
 
-            m_oPendingDisplayPreference = std::move( szConnectorName );
+            m_oPendingDisplayPreference = std::move( pref );
         }
 
         IBackend *m_pChild = nullptr;
         mutable std::shared_mutex m_mutInit;
         bool m_bDonePostInit = false;
         std::mutex m_PendingPreferenceMutex;
-        std::optional<std::string> m_oPendingDisplayPreference;
+        std::optional<PendingDisplayPreference> m_oPendingDisplayPreference;
 
         std::atomic<bool> m_bInittedChild = { false };
         std::atomic<bool> m_bJustInittedClient = { false };

--- a/src/Backends/DeferredBackend.h
+++ b/src/Backends/DeferredBackend.h
@@ -3,6 +3,7 @@
 #include "steamcompmgr.hpp"
 
 #include <cassert>
+#include <mutex>
 #include <shared_mutex>
 
 extern int g_nPreferredOutputWidth;
@@ -191,6 +192,23 @@ namespace gamescope
             }
 
             return nullptr;
+		}
+
+		virtual std::vector<gamescope::GamescopeKnownDisplay> GetConnectedOutputs() override
+		{
+            if ( m_bInittedChild )
+                return m_pChild->GetConnectedOutputs();
+
+            return {};
+		}
+
+		virtual void SetPreferredConnector( const char *pszConnectorName ) override
+		{
+            // Lockless once initted: Lua can re-enter under a lock the poll path holds.
+            if ( m_bInittedChild )
+                return m_pChild->SetPreferredConnector( pszConnectorName );
+
+            QueueDisplayPreference( pszConnectorName ? pszConnectorName : "" );
 		}
 
 		virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) override
@@ -397,7 +415,16 @@ namespace gamescope
                 {
                     if ( m_pChild->Init() )
                     {
-                        m_bInittedChild = true;
+                        {
+                            // Replay before publishing so a racing setter can't be overwritten.
+                            std::lock_guard lock2{ m_PendingPreferenceMutex };
+                            if ( m_oPendingDisplayPreference )
+                            {
+                                ApplyDisplayPreference( *m_oPendingDisplayPreference );
+                                m_oPendingDisplayPreference = std::nullopt;
+                            }
+                            m_bInittedChild = true;
+                        }
 
                         if ( m_bDonePostInit )
                         {
@@ -412,9 +439,26 @@ namespace gamescope
             }
         }
 
+        void ApplyDisplayPreference( const std::string &szConnectorName )
+        {
+            m_pChild->SetPreferredConnector( szConnectorName.c_str() );
+        }
+
+        void QueueDisplayPreference( std::string szConnectorName )
+        {
+            // No m_mutInit here - init's EDID parse can run Lua that lands here.
+            std::lock_guard lock{ m_PendingPreferenceMutex };
+            if ( m_bInittedChild )
+                return ApplyDisplayPreference( szConnectorName );
+
+            m_oPendingDisplayPreference = std::move( szConnectorName );
+        }
+
         IBackend *m_pChild = nullptr;
         mutable std::shared_mutex m_mutInit;
         bool m_bDonePostInit = false;
+        std::mutex m_PendingPreferenceMutex;
+        std::optional<std::string> m_oPendingDisplayPreference;
 
         std::atomic<bool> m_bInittedChild = { false };
         std::atomic<bool> m_bJustInittedClient = { false };

--- a/src/backend.h
+++ b/src/backend.h
@@ -33,6 +33,17 @@ namespace gamescope
 
     extern ConVar<std::string> cv_backend;
 
+    struct GamescopeKnownDisplay
+    {
+        std::string szConnectorName;
+        std::string szMake;
+        std::string szModel;
+        std::string szIdentifier;
+        uint32_t uFlags = 0;
+
+        bool operator==( const GamescopeKnownDisplay &other ) const = default;
+    };
+
     namespace VirtualConnectorStrategies
     {
         enum VirtualConnectorStrategy : uint32_t
@@ -358,6 +369,9 @@ namespace gamescope
             return this->GetCurrentConnector();
         }
         virtual IBackendConnector *GetConnector( GamescopeScreenType eScreenType ) = 0;
+
+        virtual std::vector<GamescopeKnownDisplay> GetConnectedOutputs() { return {}; }
+        virtual void SetPreferredConnector( const char *pszConnectorName ) { }
 
         virtual bool SupportsPlaneHardwareCursor() const = 0;
         virtual bool SupportsTearing() const = 0;

--- a/src/backend.h
+++ b/src/backend.h
@@ -372,6 +372,7 @@ namespace gamescope
 
         virtual std::vector<GamescopeKnownDisplay> GetConnectedOutputs() { return {}; }
         virtual void SetPreferredConnector( const char *pszConnectorName ) { }
+        virtual void SetPreferredDisplayIdentifier( const char *pszIdentifier ) { }
 
         virtual bool SupportsPlaneHardwareCursor() const = 0;
         virtual bool SupportsTearing() const = 0;

--- a/src/display_selection.h
+++ b/src/display_selection.h
@@ -34,9 +34,10 @@ namespace gamescope
     {
         std::string szConnectorName;
         std::string szIdentifier;
+        std::string szMstPath;
     };
 
-    // Appends the connector only when the identifier collides, to disambiguate identical monitors.
+    // Appends a tiebreak only when the identifier collides, to disambiguate identical monitors.
     inline std::string BuildDisplaySelectionKey( const std::string &szIdentifier, const std::string &szConnectorName, bool bSharedWithOtherOutput )
     {
         if ( bSharedWithOtherOutput )
@@ -78,7 +79,7 @@ namespace gamescope
         {
             if ( candidates[i].szIdentifier != szBase )
                 continue;
-            if ( !szConnectorHint.empty() && candidates[i].szConnectorName == szConnectorHint )
+            if ( !szConnectorHint.empty() && ( candidates[i].szConnectorName == szConnectorHint || candidates[i].szMstPath == szConnectorHint ) )
                 return i;
             if ( !oBaseMatch )
                 oBaseMatch = i;

--- a/src/display_selection.h
+++ b/src/display_selection.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <cstddef>
+#include <cstdint>
+
+namespace gamescope
+{
+    // Base EDID key: "{make} {model} {serial}", else model-only, else "[{connector}]".
+    // The serial string is per-unit; the numeric serial is often a per-model constant.
+    inline std::string BuildDisplayIdentifier( bool bInternal, const std::string &szMake, const std::string &szModel, const std::string &szConnectorName, uint32_t uEDIDSerial, const std::string &szEDIDSerial )
+    {
+        if ( bInternal )
+            return "Internal screen";
+
+        std::string szBase;
+        if ( !szMake.empty() && !szModel.empty() )
+            szBase = szMake + " " + szModel;
+        else if ( !szModel.empty() )
+            szBase = szModel;
+        else
+            return "[" + szConnectorName + "]";
+
+        if ( !szEDIDSerial.empty() )
+            szBase += " " + szEDIDSerial;
+        else if ( uEDIDSerial != 0 )
+            szBase += " " + std::to_string( uEDIDSerial );
+        return szBase;
+    }
+
+    struct DisplaySelectionCandidate
+    {
+        std::string szConnectorName;
+        std::string szIdentifier;
+    };
+
+    // Appends the connector only when the identifier collides, to disambiguate identical monitors.
+    inline std::string BuildDisplaySelectionKey( const std::string &szIdentifier, const std::string &szConnectorName, bool bSharedWithOtherOutput )
+    {
+        if ( bSharedWithOtherOutput )
+            return szIdentifier + " [" + szConnectorName + "]";
+        return szIdentifier;
+    }
+
+    inline void SplitDisplaySelectionKey( const std::string &szKey, std::string &szBaseOut, std::string &szConnectorHintOut )
+    {
+        szBaseOut = szKey;
+        szConnectorHintOut.clear();
+        if ( !szKey.empty() && szKey.back() == ']' )
+        {
+            size_t uOpen = szKey.rfind( " [" );
+            if ( uOpen != std::string::npos )
+            {
+                szBaseOut = szKey.substr( 0, uOpen );
+                szConnectorHintOut = szKey.substr( uOpen + 2, szKey.size() - uOpen - 3 );
+            }
+        }
+    }
+
+    // Identifier match is primary, the connector hint only breaks ties. nullopt = no match (fall back to --prefer-output).
+    inline std::optional<size_t> ResolveDisplaySelection( const std::string &szKey, const std::vector<DisplaySelectionCandidate> &candidates )
+    {
+        if ( szKey.empty() )
+            return std::nullopt;
+
+        // Exact identifier match wins first, so a model ending in "[...]" isn't split.
+        for ( size_t i = 0; i < candidates.size(); i++ )
+            if ( candidates[i].szIdentifier == szKey )
+                return i;
+
+        std::string szBase, szConnectorHint;
+        SplitDisplaySelectionKey( szKey, szBase, szConnectorHint );
+
+        std::optional<size_t> oBaseMatch;
+        for ( size_t i = 0; i < candidates.size(); i++ )
+        {
+            if ( candidates[i].szIdentifier != szBase )
+                continue;
+            if ( !szConnectorHint.empty() && candidates[i].szConnectorName == szConnectorHint )
+                return i;
+            if ( !oBaseMatch )
+                oBaseMatch = i;
+        }
+        return oBaseMatch;
+    }
+}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -6308,6 +6308,12 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 		GetBackend()->DirtyState( true );
 		XDeleteProperty( ctx->dpy, ctx->root, ctx->atoms.gamescopeDisplayModeNudge );
 	}
+	if ( ev->atom == ctx->atoms.gamescopeDisplayPreferredIdentifier && ev->window == ctx->root )
+	{
+		// The backend dedups re-asserts, so no guard needed here.
+		std::string identifier = get_string_prop( ctx, ctx->root, ctx->atoms.gamescopeDisplayPreferredIdentifier );
+		GetBackend()->SetPreferredDisplayIdentifier( identifier.c_str() );
+	}
 	if ( ev->atom == ctx->atoms.gamescopeNewScalingFilter )
 	{
 		GamescopeUpscaleFilter nScalingFilter = ( GamescopeUpscaleFilter ) get_prop( ctx, ctx->root, ctx->atoms.gamescopeNewScalingFilter, 0 );
@@ -7843,9 +7849,11 @@ void init_xwayland_ctx(uint32_t serverId, gamescope_xwayland_server_t *xwayland_
 
 	ctx->atoms.gamescopeDisplayForceInternal = XInternAtom( ctx->dpy, "GAMESCOPE_DISPLAY_FORCE_INTERNAL", false );
 	ctx->atoms.gamescopeDisplayModeNudge = XInternAtom( ctx->dpy, "GAMESCOPE_DISPLAY_MODE_NUDGE", false );
+	ctx->atoms.gamescopeDisplayPreferredIdentifier = XInternAtom( ctx->dpy, "GAMESCOPE_DISPLAY_PREFERRED_IDENTIFIER", false );
 
 	ctx->atoms.gamescopeDisplayIsExternal = XInternAtom( ctx->dpy, "GAMESCOPE_DISPLAY_IS_EXTERNAL", false );
 	ctx->atoms.gamescopeDisplayModeListExternal = XInternAtom( ctx->dpy, "GAMESCOPE_DISPLAY_MODE_LIST_EXTERNAL", false );
+	ctx->atoms.gamescopeDisplayAvailableList = XInternAtom( ctx->dpy, "GAMESCOPE_DISPLAY_AVAILABLE_LIST", false );
 
 	ctx->atoms.gamescopeCursorVisibleFeedback = XInternAtom( ctx->dpy, "GAMESCOPE_CURSOR_VISIBLE_FEEDBACK", false );
 
@@ -8051,6 +8059,36 @@ void update_vrr_atoms(xwayland_ctx_t *root_ctx, bool force, bool* needs_flush = 
 		if (needs_flush)
 			*needs_flush = true;
 	}
+}
+
+void update_available_displays_atom(xwayland_ctx_t *root_ctx, bool* needs_flush = nullptr)
+{
+	// One display per line: identifier|connector_name|flags_hex|make|model
+	auto sanitize = []( std::string s ) {
+		for ( char &c : s ) if ( c == '|' || c == '\n' || c == '\r' ) c = ' ';
+		return s;
+	};
+	std::string out;
+	for ( const auto &display : GetBackend()->GetConnectedOutputs() )
+	{
+		char line[512];
+		snprintf( line, sizeof( line ), "%s|%s|0x%x|%s|%s\n",
+			sanitize( display.szIdentifier ).c_str(), sanitize( display.szConnectorName ).c_str(),
+			display.uFlags, sanitize( display.szMake ).c_str(), sanitize( display.szModel ).c_str() );
+		out += line;
+	}
+
+	// Don't churn the property (each write PropertyNotifies every watcher).
+	static std::optional<std::string> s_oLastList;
+	if ( s_oLastList == out )
+		return;
+	s_oLastList = out;
+
+	if (needs_flush)
+		*needs_flush = true;
+
+	XChangeProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeDisplayAvailableList, XA_STRING, 8, PropModeReplace,
+		(unsigned char *)out.c_str(), out.size() + 1 );
 }
 
 void update_mode_atoms(xwayland_ctx_t *root_ctx, bool* needs_flush = nullptr)
@@ -8439,6 +8477,7 @@ steamcompmgr_main(int argc, char **argv)
 
 	update_vrr_atoms(root_ctx, true);
 	update_mode_atoms(root_ctx);
+	update_available_displays_atom(root_ctx);
 	XFlush(root_ctx->dpy);
 
 	if ( !GetBackend()->PostInit() )
@@ -8679,6 +8718,7 @@ steamcompmgr_main(int argc, char **argv)
 			hasRepaint = true;
 
 			update_mode_atoms(root_ctx, &flush_root);
+			update_available_displays_atom(root_ctx, &flush_root);
 		}
 
 		g_uCompositeDebug = cv_composite_debug;

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1277,6 +1277,57 @@ static void gamescope_control_request_app_performance_stats( struct wl_client *c
 	wlserver.app_perf_requests[ app_id ].push_back( resource );
 }
 
+static gamescope::ConCommand cc_set_display("set_display", "Switch to a connected output by connector name (DP-1) or a substring of its make/model/serial (e.g. ULTRAGEAR). No argument clears the override and falls back to --prefer-output.",
+[]( std::span<std::string_view> args )
+{
+	if ( args.size() < 2 || args[1].empty() )
+	{
+		GetBackend()->SetPreferredConnector( nullptr );
+		return;
+	}
+
+	std::string query{ args[1] };
+
+	std::string exact;
+	std::vector<gamescope::GamescopeKnownDisplay> matches;
+	for ( const auto &display : GetBackend()->GetConnectedOutputs() )
+	{
+		if ( query == display.szConnectorName )
+		{
+			exact = display.szConnectorName;
+			break;
+		}
+		if ( strcasestr( display.szIdentifier.c_str(), query.c_str() ) )
+			matches.push_back( display );
+	}
+
+	if ( !exact.empty() )
+		GetBackend()->SetPreferredConnector( exact.c_str() );
+	else if ( matches.size() == 1 )
+		GetBackend()->SetPreferredConnector( matches[0].szConnectorName.c_str() );
+	else if ( matches.empty() )
+		console_log.errorf( "set_display: no connected display matches '%s'", query.c_str() );
+	else
+	{
+		console_log.errorf( "set_display: '%s' is ambiguous:", query.c_str() );
+		for ( const auto &match : matches )
+			console_log.errorf( "  %s (%s)", match.szConnectorName.c_str(), match.szIdentifier.c_str() );
+	}
+});
+
+static void gamescope_control_set_display( struct wl_client *client, struct wl_resource *resource, const char *connector_name )
+{
+	// "" is not a connected output, so it is ignored too. Clearing is unset_display's job.
+	if ( !connector_name || !*connector_name )
+		return;
+	GetBackend()->SetPreferredConnector( connector_name );
+}
+
+static void gamescope_control_unset_display( struct wl_client *client, struct wl_resource *resource )
+{
+	GetBackend()->SetPreferredConnector( nullptr );
+}
+
 void wlserver_app_presented( uint32_t app_id, uint64_t frametime_ns )
 {
 	assert( wlserver_is_lock_held() );
@@ -1306,6 +1357,8 @@ static const struct gamescope_control_interface gamescope_control_impl = {
 	.set_look = gamescope_control_set_look,
 	.unset_look = gamescope_control_unset_look,
 	.request_app_performance_stats = gamescope_control_request_app_performance_stats,
+	.set_display = gamescope_control_set_display,
+	.unset_display = gamescope_control_unset_display,
 };
 
 static uint32_t get_conn_display_info_flags()
@@ -1329,6 +1382,22 @@ static uint32_t get_conn_display_info_flags()
 void wlserver_send_gamescope_control( wl_resource *control )
 {
 	assert( wlserver_is_lock_held() );
+
+	// Sent before the early-return so the done event fires when no connector is active.
+	if ( wl_resource_get_version( control ) >= GAMESCOPE_CONTROL_AVAILABLE_DISPLAY_INFO_SINCE_VERSION )
+	{
+		for ( const auto &display : GetBackend()->GetConnectedOutputs() )
+		{
+			gamescope_control_send_available_display_info(
+				control,
+				display.szConnectorName.c_str(),
+				display.szMake.c_str(),
+				display.szModel.c_str(),
+				display.uFlags,
+				display.szIdentifier.c_str() );
+		}
+		gamescope_control_send_available_display_info_done( control );
+	}
 
 	gamescope::IBackendConnector *pConn = GetBackend()->GetCurrentConnector();
 	if ( !pConn )
@@ -1376,6 +1445,7 @@ static void gamescope_control_bind( struct wl_client *client, void *data, uint32
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_MURA_CORRECTION, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_LOOK, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_PERF_QUERY, 1, 0 );
+	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_DISPLAY_SELECTION, 1, 0 );
 	gamescope_control_send_feature_support( resource, GAMESCOPE_CONTROL_FEATURE_DONE, 0, 0 );
 
 	wlserver_send_gamescope_control( resource );
@@ -1385,7 +1455,7 @@ static void gamescope_control_bind( struct wl_client *client, void *data, uint32
 
 static void create_gamescope_control( void )
 {
-	uint32_t version = 6;
+	uint32_t version = 7;
 	wl_global_create( wlserver.display, &gamescope_control_interface, version, NULL, gamescope_control_bind );
 }
 

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -181,9 +181,11 @@ struct xwayland_ctx_t final : public gamescope::IWaitable
 		Atom gamescopeAllowTearing;
 		Atom gamescopeDisplayForceInternal;
 		Atom gamescopeDisplayModeNudge;
+		Atom gamescopeDisplayPreferredIdentifier;
 
 		Atom gamescopeDisplayIsExternal;
 		Atom gamescopeDisplayModeListExternal;
+		Atom gamescopeDisplayAvailableList;
 
 		Atom gamescopeCursorVisibleFeedback;
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,3 +14,11 @@ test_convar = executable(
 	cpp_args: gamescope_cpp_args,
 )
 test('convar', test_convar)
+
+test_display_selection = executable(
+	'test_display_selection',
+	['test_display_selection.cpp'],
+	include_directories: [srcdir],
+	dependencies: [catch2_dep],
+)
+test('display_selection', test_display_selection)

--- a/tests/test_display_selection.cpp
+++ b/tests/test_display_selection.cpp
@@ -99,3 +99,28 @@ TEST_CASE("ResolveDisplaySelection handles a model that itself ends in brackets"
 	REQUIRE( ResolveDisplaySelection("Aperture Science Monitor [Pro]", bracketed) == 0u );
 	REQUIRE( ResolveDisplaySelection("Aperture Science Monitor [Pro] [DP-2]", bracketed) == 1u );
 }
+
+TEST_CASE("ResolveDisplaySelection follows the MST path across a dock replug-renumber", "[display_selection]") {
+	std::string key = BuildDisplaySelectionKey("Sceptre Z27", "mst:1-5", /*bShared=*/true);
+	REQUIRE( key == "Sceptre Z27 [mst:1-5]" );
+
+	std::vector<DisplaySelectionCandidate> before = {
+		{ "DP-9", "Sceptre Z27", "mst:1-5" },
+		{ "DP-10", "Sceptre Z27", "mst:1-6" },
+	};
+	REQUIRE( ResolveDisplaySelection(key, before) == 0u );
+
+	std::vector<DisplaySelectionCandidate> after = {
+		{ "DP-7", "Sceptre Z27", "mst:1-5" },
+		{ "DP-12", "Sceptre Z27", "mst:1-6" },
+	};
+	REQUIRE( ResolveDisplaySelection(key, after) == 0u );
+
+	REQUIRE( ResolveDisplaySelection("Sceptre Z27 [DP-10]", before) == 1u );
+
+	std::vector<DisplaySelectionCandidate> moved = {
+		{ "DP-7", "Sceptre Z27", "mst:1-9" },
+		{ "DP-12", "Sceptre Z27", "mst:1-6" },
+	};
+	REQUIRE( ResolveDisplaySelection(key, moved) == 0u );
+}

--- a/tests/test_display_selection.cpp
+++ b/tests/test_display_selection.cpp
@@ -1,0 +1,101 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "display_selection.h"
+
+using namespace gamescope;
+
+TEST_CASE("BuildDisplayIdentifier", "[display_selection]") {
+	REQUIRE( BuildDisplayIdentifier(true, "Some", "Panel", "eDP-1", 42, "x") == "Internal screen" );
+
+	REQUIRE( BuildDisplayIdentifier(false, "Dell Inc.", "Dell AW3423DW", "DP-3", 16843009, "ABC123") == "Dell Inc. Dell AW3423DW ABC123" );
+	REQUIRE( BuildDisplayIdentifier(false, "Dell Inc.", "Dell AW3423DW", "DP-3", 810309971, "") == "Dell Inc. Dell AW3423DW 810309971" );
+	REQUIRE( BuildDisplayIdentifier(false, "LG Electronics", "LG ULTRAGEAR+", "DP-1", 0, "ABC123") == "LG Electronics LG ULTRAGEAR+ ABC123" );
+	REQUIRE( BuildDisplayIdentifier(false, "Dell Inc.", "Dell AW3423DW", "DP-3", 0, "") == "Dell Inc. Dell AW3423DW" );
+
+	REQUIRE( BuildDisplayIdentifier(false, "", "MysteryModel", "DP-2", 0, "") == "MysteryModel" );
+	REQUIRE( BuildDisplayIdentifier(false, "", "", "DP-2", 0, "") == "[DP-2]" );
+	REQUIRE( BuildDisplayIdentifier(false, "Dell Inc.", "", "DP-2", 0, "") == "[DP-2]" );
+}
+
+TEST_CASE("BuildDisplayIdentifier round-trips through SplitDisplaySelectionKey", "[display_selection]") {
+	std::string id = BuildDisplayIdentifier(false, "", "", "DP-2", 0, "");
+	std::string base, hint;
+	SplitDisplaySelectionKey(id, base, hint);
+	REQUIRE( base == "[DP-2]" );
+	REQUIRE( hint.empty() );
+}
+
+TEST_CASE("BuildDisplaySelectionKey", "[display_selection]") {
+	REQUIRE( BuildDisplaySelectionKey("Dell AW3423DW", "DP-1", false) == "Dell AW3423DW" );
+	REQUIRE( BuildDisplaySelectionKey("Dell AW3423DW", "DP-1", true) == "Dell AW3423DW [DP-1]" );
+}
+
+TEST_CASE("SplitDisplaySelectionKey", "[display_selection]") {
+	std::string base, hint;
+
+	SplitDisplaySelectionKey("Dell AW3423DW", base, hint);
+	REQUIRE( base == "Dell AW3423DW" );
+	REQUIRE( hint.empty() );
+
+	SplitDisplaySelectionKey("Dell AW3423DW [DP-1]", base, hint);
+	REQUIRE( base == "Dell AW3423DW" );
+	REQUIRE( hint == "DP-1" );
+
+	SplitDisplaySelectionKey("[DP-2]", base, hint);
+	REQUIRE( base == "[DP-2]" );
+	REQUIRE( hint.empty() );
+}
+
+TEST_CASE("ResolveDisplaySelection picks the named connector for identical twins", "[display_selection]") {
+	std::vector<DisplaySelectionCandidate> twins = {
+		{ "DP-1", "Dell AW3423DW" },
+		{ "DP-2", "Dell AW3423DW" },
+	};
+
+	REQUIRE( ResolveDisplaySelection("Dell AW3423DW [DP-1]", twins) == 0u );
+	REQUIRE( ResolveDisplaySelection("Dell AW3423DW [DP-2]", twins) == 1u );
+
+	REQUIRE( ResolveDisplaySelection("Dell AW3423DW", twins) == 0u );
+
+	REQUIRE( ResolveDisplaySelection("Dell AW3423DW [DP-9]", twins) == 0u );
+
+	std::vector<DisplaySelectionCandidate> triplets = {
+		{ "DP-1", "Dell AW3423DW" },
+		{ "DP-2", "Dell AW3423DW" },
+		{ "DP-3", "Dell AW3423DW" },
+	};
+	REQUIRE( ResolveDisplaySelection("Dell AW3423DW [DP-3]", triplets) == 2u );
+}
+
+TEST_CASE("ResolveDisplaySelection keeps identifier match primary over the hint", "[display_selection]") {
+	std::vector<DisplaySelectionCandidate> mixed = {
+		{ "DP-1", "Dell AW3423DW" },
+		{ "DP-2", "LG ULTRAGEAR+ 175706" },
+	};
+	REQUIRE( ResolveDisplaySelection("Dell AW3423DW [DP-2]", mixed) == 0u );
+}
+
+TEST_CASE("ResolveDisplaySelection matches a unique monitor by identifier", "[display_selection]") {
+	std::vector<DisplaySelectionCandidate> mixed = {
+		{ "DP-1", "Dell AW3423DW" },
+		{ "DP-2", "LG ULTRAGEAR+ 175706" },
+	};
+
+	REQUIRE( ResolveDisplaySelection("LG ULTRAGEAR+ 175706", mixed) == 1u );
+
+	REQUIRE( ResolveDisplaySelection("Sony Bravia", mixed) == std::nullopt );
+
+	REQUIRE( ResolveDisplaySelection("", mixed) == std::nullopt );
+}
+
+TEST_CASE("ResolveDisplaySelection handles a model that itself ends in brackets", "[display_selection]") {
+	REQUIRE( BuildDisplayIdentifier(false, "Aperture Science", "Monitor [Pro]", "DP-1", 0, "") == "Aperture Science Monitor [Pro]" );
+
+	std::vector<DisplaySelectionCandidate> bracketed = {
+		{ "DP-1", "Aperture Science Monitor [Pro]" },
+		{ "DP-2", "Aperture Science Monitor [Pro]" },
+	};
+
+	REQUIRE( ResolveDisplaySelection("Aperture Science Monitor [Pro]", bracketed) == 0u );
+	REQUIRE( ResolveDisplaySelection("Aperture Science Monitor [Pro] [DP-2]", bracketed) == 1u );
+}


### PR DESCRIPTION
The goal for this PR is to provide runtime controls to select a preferred display in the DRM backend without relying on the commandline argument -O. The exact details are explained in the commits, but generally this is what's expected:

```
❯ gamescopectl
gamescopectl version 3.16.24-4-gbb82e16 (gcc 16.1.1)
gamescope_control info:
  - Connector Name: DP-3
  - Display Make: Dell Inc.
  - Display Model: Dell AW3423DW
  - Display Flags: 0x6
  - ValidRefreshRates: 175
  Available Displays:
  - DP-3 (Dell Inc. Dell AW3423DW) - Flags: 0xe - Identifier: "Dell Inc. Dell AW3423DW 810309971" [current]
  - DP-1 (LG Electronics LG ULTRAGEAR+) - Flags: 0x6 - Identifier: "LG Electronics LG ULTRAGEAR+ 175706"
  Features:
  - Reshade Shaders (1) - Version: 1 - Flags: 0x0
  - Display Info (2) - Version: 1 - Flags: 0x0
  - Pixel Filter (3) - Version: 1 - Flags: 0x0
  - Refresh Cycle Only Change Refresh Rate (4) - Version: 1 - Flags: 0x0
  - Mura Correction (5) - Version: 1 - Flags: 0x0
  - Look (6) - Version: 1 - Flags: 0x0
  - Performance Query (7) - Version: 1 - Flags: 0x0
  - Display Selection (8) - Version: 1 - Flags: 0x0
You can execute any debug command in Gamescope using this tool.
For a list of commands and convars, use 'gamescopectl help'

❯ gamescopectl set_display LG

❯ gamescopectl
gamescopectl version 3.16.24-4-gbb82e16 (gcc 16.1.1)
gamescope_control info:
  - Connector Name: DP-1
  - Display Make: LG Electronics
  - Display Model: LG ULTRAGEAR+
  - Display Flags: 0x6
  - ValidRefreshRates: 165
  Available Displays:
  - DP-3 (Dell Inc. Dell AW3423DW) - Flags: 0x6 - Identifier: "Dell Inc. Dell AW3423DW 810309971"
  - DP-1 (LG Electronics LG ULTRAGEAR+) - Flags: 0xe - Identifier: "LG Electronics LG ULTRAGEAR+ 175706" [current]
  Features:
  - Reshade Shaders (1) - Version: 1 - Flags: 0x0
  - Display Info (2) - Version: 1 - Flags: 0x0
  - Pixel Filter (3) - Version: 1 - Flags: 0x0
  - Refresh Cycle Only Change Refresh Rate (4) - Version: 1 - Flags: 0x0
  - Mura Correction (5) - Version: 1 - Flags: 0x0
  - Look (6) - Version: 1 - Flags: 0x0
  - Performance Query (7) - Version: 1 - Flags: 0x0
  - Display Selection (8) - Version: 1 - Flags: 0x0
You can execute any debug command in Gamescope using this tool.
For a list of commands and convars, use 'gamescopectl help'
```

you can also run `gamescopectl set_display <connector name>` rather than substrings of the monitor identifiers. the choice from Steam is meant to be written to `~/.config/gamescope/display.cfg`, similar to `modes.cfg`, but `[HACK] DRMBackend: Temporarily write preferred-display file on set_display` moves this write into gamescope for testing purposes:

```
❯ cat ~/.config/gamescope/display.cfg
LG Electronics LG ULTRAGEAR+ 175706
```

there is an xatom path for this as well:
```
❯ DISPLAY=:0 xprop -root GAMESCOPE_DISPLAY_AVAILABLE_LIST
GAMESCOPE_DISPLAY_AVAILABLE_LIST(STRING) = "Dell Inc. Dell AW3423DW 810309971|DP-3|0x6|Dell Inc.|Dell AW3423DW\nLG Electronics LG ULTRAGEAR+ 175706|DP-1|0xe|LG Electronics|LG ULTRAGEAR+\n"

❯ DISPLAY=:0 xprop -root -f GAMESCOPE_DISPLAY_PREFERRED_IDENTIFIER 8s -set GAMESCOPE_DISPLAY_PREFERRED_IDENTIFIER "Dell Inc. Dell AW3423DW 810309971"
```

tests are included so it was easier to check the code around some of the weird edge cases. this is also why display_selection.h is its own header file, to pull into the testing framework.

marked as draft for now so additional testing can be done, but before bringing it out of draft I will drop hack commit.