### PR TITLE
sdl: ignore synthetic keyup events during key repeat

### DIFF
--- a/src/Backends/SDLBackend.cpp
+++ b/src/Backends/SDLBackend.cpp
@@ -802,6 +802,18 @@ namespace gamescope
 					if ( event.key.repeat )
 						break;
 
+					// Ignore synthetic repeat KEYUPs when SDL still reports the key down.
+					if ( event.type == SDL_KEYUP )
+					{
+						const uint8_t *pKeyboardState = SDL_GetKeyboardState( nullptr );
+						SDL_Scancode scancode = event.key.keysym.scancode;
+						if ( pKeyboardState &&
+							 scancode >= 0 &&
+							 scancode < SDL_NUM_SCANCODES &&
+							 pKeyboardState[ scancode ] )
+							break;
+					}
+
 					wlserver_lock();
 					wlserver_key( key, event.type == SDL_KEYDOWN, fake_timestamp );
 					wlserver_unlock();


### PR DESCRIPTION
On the SDL backend, holding a key can generate KEYUP events even while the key is still physically held.
Gamescope already ignores repeated KEYDOWN events, but these KEYUPs were still forwarded to wlserver, causing spurious release notifications.

Filter SDL_KEYUP by checking SDL_GetKeyboardState(): if SDL still reports the scancode as pressed, treat the KEYUP as synthetic repeat noise and drop it.