### PR TITLE
steamcompmgr: remove duplicated cursor warp from keyboard focus block

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4299,28 +4299,6 @@ determine_and_apply_focus( global_focus_t *pFocus )
 			}
 		}
 
-		if ( pFocus->inputFocusWindow )
-		{
-			// Cannot simply XWarpPointer here as we immediately go on to
-			// do wlserver_mousefocus and need to update m_x and m_y of the cursor.
-			if ( pFocus->inputFocusWindow->GetFocus()->bResetToCorner )
-			{
-				wlserver_lock();
-				wlserver_mousewarp( pFocus->inputFocusWindow->GetGeometry().nWidth / 2, pFocus->inputFocusWindow->GetGeometry().nHeight / 2, 0, true );
-				wlserver_fake_mouse_pos( pFocus->inputFocusWindow->GetGeometry().nWidth - 1, pFocus->inputFocusWindow->GetGeometry().nHeight - 1 );
-				wlserver_unlock();
-			}
-			else if ( pFocus->inputFocusWindow->GetFocus()->bResetToCenter )
-			{
-				wlserver_lock();
-				wlserver_mousewarp( pFocus->inputFocusWindow->GetGeometry().nWidth / 2, pFocus->inputFocusWindow->GetGeometry().nHeight / 2, 0, true );
-				wlserver_unlock();
-			}
-
-			pFocus->inputFocusWindow->GetFocus()->bResetToCorner = false;
-			pFocus->inputFocusWindow->GetFocus()->bResetToCenter = false;
-		}
-
 		s_ulPreviousGlobalFocusKey = pFocus->ulVirtualFocusKey;
 	}
 


### PR DESCRIPTION
93cf2b4 split focus handling into separate keyboard and mouse blocks, but added a second copy of the bResetToCorner/Center warp to the new keyboard block. The keyboard block runs before pointer focus is handed to the new window via wlserver_mousefocus, so on handhelds the warp is delivered to the still-focused game and can warp the camera when opening the QAM.

Keep the warp only in the mouse focus block, where it runs after the pointer handoff.

Closes: https://github.com/ValveSoftware/SteamOS/issues/2441