### PR TITLE
CI: do not recursively check out reshade dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
             catch2 gcovr
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
+          submodules: true
       - name: Build with gcc
         run: |
           export CC=gcc CXX=g++


### PR DESCRIPTION
These dependencies are not required to build gamescope.