### PR TITLE
Utils: move the Parse and Split helpers out of convar.h into separate headers

### DIFF
--- a/src/Apps/gamescope_hotkey_example.cpp
+++ b/src/Apps/gamescope_hotkey_example.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 #include <span>
 #include <optional>
-#include "convar.h"
 #include "Utils/Version.h"
 
 #include <span>

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -32,6 +32,7 @@
 #include "color_helpers.h"
 #include "Utils/Defer.h"
 #include "Utils/Parsers.h"
+#include "Utils/String.h"
 #include "drm_include.h"
 #include "edid.h"
 #include "gamescope_shared.h"

--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -31,6 +31,7 @@
 #include "backend.h"
 #include "color_helpers.h"
 #include "Utils/Defer.h"
+#include "Utils/Parsers.h"
 #include "drm_include.h"
 #include "edid.h"
 #include "gamescope_shared.h"
@@ -4209,4 +4210,3 @@ int HackyDRMPresent( const FrameInfo_t *pFrameInfo, bool bAsync )
 {
 	return static_cast<gamescope::CDRMBackend *>( GetBackend() )->Present( pFrameInfo, bAsync );
 }
-

--- a/src/Script/Script.cpp
+++ b/src/Script/Script.cpp
@@ -3,6 +3,7 @@
 #include "color_helpers.h"
 #include "../log.hpp"
 #include "Utils/DirHelpers.h"
+#include "Utils/String.h"
 
 #include <filesystem>
 #include <algorithm>

--- a/src/Utils/Parsers.h
+++ b/src/Utils/Parsers.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace gamescope
+{
+    template <typename T>
+    inline std::optional<T> Parse( std::string_view chars )
+    {
+        T obj;
+        auto result = std::from_chars( chars.begin(), chars.end(), obj );
+        if ( result.ec == std::errc{} )
+            return obj;
+        else
+            return std::nullopt;
+    }
+
+    template <>
+    inline std::optional<bool> Parse( std::string_view chars )
+    {
+        std::optional<uint32_t> oNumber = Parse<uint32_t>( chars );
+        if ( oNumber )
+            return !!*oNumber;
+
+        if ( chars == "true" )
+            return true;
+        else
+            return false;
+    }
+}

--- a/src/Utils/Parsers.h
+++ b/src/Utils/Parsers.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <optional>
 #include <string_view>
+#include <strings.h>
 
 namespace gamescope
 {
@@ -25,7 +26,7 @@ namespace gamescope
         if ( oNumber )
             return !!*oNumber;
 
-        if ( chars == "true" )
+        if ( strcasecmp ( chars.data(), "true" ) == 0 )
             return true;
         else
             return false;

--- a/src/Utils/Process.cpp
+++ b/src/Utils/Process.cpp
@@ -1,8 +1,9 @@
 #include "Process.h"
-#include "../Utils/Algorithm.h"
 #include "../convar.h"
 #include "../log.hpp"
+#include "../Utils/Algorithm.h"
 #include "../Utils/Defer.h"
+#include "../Utils/Parsers.h"
 
 #include <algorithm>
 #include <array>

--- a/src/Utils/Process.cpp
+++ b/src/Utils/Process.cpp
@@ -1,9 +1,9 @@
 #include "Process.h"
-#include "../convar.h"
 #include "../log.hpp"
 #include "../Utils/Algorithm.h"
 #include "../Utils/Defer.h"
 #include "../Utils/Parsers.h"
+#include "../Utils/String.h"
 
 #include <algorithm>
 #include <array>

--- a/src/Utils/String.h
+++ b/src/Utils/String.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string_view>
+#include <vector>
+
+namespace gamescope
+{
+	inline void Split( std::vector<std::string_view> &tokens, std::string_view string, std::string_view delims = " " )
+    {
+        size_t end = 0;
+        for ( size_t start = 0; start < string.size() && end != std::string_view::npos; start = end + 1 )
+        {
+            end = string.find_first_of( delims, start );
+
+            if ( start != end )
+                tokens.emplace_back( string.substr( start, end-start ) );
+        }
+    }
+
+    inline std::vector<std::string_view> Split( std::string_view string, std::string_view delims = " " )
+    {
+        std::vector<std::string_view> tokens;
+        Split( tokens, string, delims );
+        return tokens;
+    }
+}

--- a/src/WaylandServer/GamescopeActionBinding.h
+++ b/src/WaylandServer/GamescopeActionBinding.h
@@ -12,7 +12,6 @@
 #include <array>
 #include <unordered_set>
 
-#include "convar.h"
 #include "Utils/Algorithm.h"
 
 #include "wlr_begin.hpp"

--- a/src/convar.h
+++ b/src/convar.h
@@ -2,14 +2,11 @@
 
 #include <span>
 #include <string>
-#include <string_view>
-#include <optional>
-#include <charconv>
 #include <type_traits>
-#include <cstdint>
 #include <functional>
 
 #include "Utils/Dict.h"
+#include "Utils/Parsers.h"
 
 #include "log.hpp"
 
@@ -35,30 +32,6 @@ namespace gamescope
     inline std::string ToString( const std::string_view &svThing )
     {
         return std::string( svThing );
-    }
-
-    template <typename T>
-    inline std::optional<T> Parse( std::string_view chars )
-    {
-        T obj;
-        auto result = std::from_chars( chars.begin(), chars.end(), obj );
-        if ( result.ec == std::errc{} )
-            return obj;
-        else
-            return std::nullopt;
-    }
-
-    template <>
-    inline std::optional<bool> Parse( std::string_view chars )
-    {
-        std::optional<uint32_t> oNumber = Parse<uint32_t>( chars );
-        if ( oNumber )
-            return !!*oNumber;
-
-        if ( chars == "true" )
-            return true;
-        else
-            return false;
     }
 
     inline void Split( std::vector<std::string_view> &tokens, std::string_view string, std::string_view delims = " " )

--- a/src/convar.h
+++ b/src/convar.h
@@ -7,6 +7,7 @@
 
 #include "Utils/Dict.h"
 #include "Utils/Parsers.h"
+#include "Utils/String.h"
 
 #include "log.hpp"
 
@@ -32,25 +33,6 @@ namespace gamescope
     inline std::string ToString( const std::string_view &svThing )
     {
         return std::string( svThing );
-    }
-
-    inline void Split( std::vector<std::string_view> &tokens, std::string_view string, std::string_view delims = " " )
-    {
-        size_t end = 0;
-        for ( size_t start = 0; start < string.size() && end != std::string_view::npos; start = end + 1 )
-        {
-            end = string.find_first_of( delims, start );
-
-            if ( start != end )
-                tokens.emplace_back( string.substr( start, end-start ) );
-        }
-    }
-
-    inline std::vector<std::string_view> Split( std::string_view string, std::string_view delims = " " )
-    {
-        std::vector<std::string_view> tokens;
-        Split( tokens, string, delims );
-        return tokens;
     }
 
     namespace detail { struct ConVarScriptRegistrar; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,10 +28,11 @@
 #include "wlserver.hpp"
 #include "convar.h"
 #include "gpuvis_trace_utils.h"
+#include "Utils/Defer.h"
+#include "Utils/Parsers.h"
+#include "Utils/Process.h"
 #include "Utils/TempFiles.h"
 #include "Utils/Version.h"
-#include "Utils/Process.h"
-#include "Utils/Defer.h"
 
 #include "backends.h"
 #include "refresh_rate.h"

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -96,8 +96,9 @@
 #include "commit.h"
 #include "reshade_effect_manager.hpp"
 #include "BufferMemo.h"
-#include "Utils/Process.h"
 #include "Utils/Algorithm.h"
+#include "Utils/Parsers.h"
+#include "Utils/Process.h"
 
 #include "wlr_begin.hpp"
 #include "wlr/types/wlr_pointer_constraints_v1.h"

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -99,6 +99,7 @@
 #include "Utils/Algorithm.h"
 #include "Utils/Parsers.h"
 #include "Utils/Process.h"
+#include "Utils/String.h"
 
 #include "wlr_begin.hpp"
 #include "wlr/types/wlr_pointer_constraints_v1.h"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,7 @@ endforeach
 
 gamescope_tests = executable(
 	'gamescope_tests',
-	unittest_src + ['test_convar.cpp', 'test_process.cpp', 'test_utils_parsers.cpp'],
+	unittest_src + ['test_convar.cpp', 'test_process.cpp', 'test_utils_parsers.cpp', 'test_utils_string.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
@@ -16,3 +16,4 @@ gamescope_tests = executable(
 test('convar', gamescope_tests, args: ['[convar]'])
 test('utils/parsers', gamescope_tests, args: ['[parsers]'])
 test('utils/process', gamescope_tests, args: ['[process]'])
+test('utils/string', gamescope_tests, args: ['[string]'])

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,10 +8,11 @@ endforeach
 
 gamescope_tests = executable(
 	'gamescope_tests',
-	unittest_src + ['test_convar.cpp', 'test_process.cpp'],
+	unittest_src + ['test_convar.cpp', 'test_process.cpp', 'test_utils_parsers.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
 )
 test('convar', gamescope_tests, args: ['[convar]'])
-test('process', gamescope_tests, args: ['[process]'])
+test('utils/parsers', gamescope_tests, args: ['[parsers]'])
+test('utils/process', gamescope_tests, args: ['[process]'])

--- a/tests/test_utils_parsers.cpp
+++ b/tests/test_utils_parsers.cpp
@@ -1,0 +1,95 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <type_traits>
+
+#include "Utils/Parsers.h"
+
+using namespace gamescope;
+
+TEST_CASE("Utils/Parsers", "[parsers]") {
+    SECTION("int") {
+        REQUIRE(Parse<int>("42") == 42);
+        REQUIRE(Parse<int>("42,foo") == 42);
+        REQUIRE(Parse<int>("42 foo") == 42);
+        REQUIRE(Parse<int>("foo,42") == std::nullopt);
+        REQUIRE(Parse<int>("foo 42") == std::nullopt);
+        REQUIRE(Parse<int>("42,35") == 42);
+        REQUIRE(Parse<int>("-35") == -35);
+        REQUIRE(Parse<int>("000") == 0);
+        REQUIRE(Parse<int>("-00") == 0);
+        REQUIRE(Parse<int>("") == std::nullopt);
+    }
+
+    SECTION("uint") {
+        REQUIRE(Parse<uint>("42") == 42);
+        REQUIRE(Parse<uint>("42,foo") == 42);
+        REQUIRE(Parse<uint>("42 foo") == 42);
+        REQUIRE(Parse<uint>("foo,42") == std::nullopt);
+        REQUIRE(Parse<uint>("foo 42") == std::nullopt);
+        REQUIRE(Parse<uint>("42,35") == 42);
+        REQUIRE(Parse<uint>("-35") == std::nullopt);
+        REQUIRE(Parse<uint>("000") == 0);
+        REQUIRE(Parse<uint>("-00") == std::nullopt);
+        REQUIRE(Parse<uint>("") == std::nullopt);
+    }
+
+    SECTION("float") {
+        double eps = 0.0000001;
+        REQUIRE_THAT(*Parse<float>("3.14159"), Catch::Matchers::WithinRel(3.14159, eps));
+        REQUIRE_THAT(*Parse<float>("-42.3"), Catch::Matchers::WithinRel(-42.3, eps));
+        REQUIRE_THAT(*Parse<float>("42,3"), Catch::Matchers::WithinRel(42.0, eps));
+        REQUIRE_THAT(*Parse<float>("42,foo"), Catch::Matchers::WithinRel(42.0, eps));
+        REQUIRE(Parse<float>("foo,42.3") == std::nullopt);
+        REQUIRE(Parse<float>("foo 42.3") == std::nullopt);
+        REQUIRE(Parse<float>("pi") == std::nullopt);
+        REQUIRE(Parse<float>("") == std::nullopt);
+    }
+
+    SECTION("pid") {
+        REQUIRE(Parse<pid_t>("42") == 42);
+        REQUIRE(Parse<pid_t>("42,35,64") == 42);
+        REQUIRE(Parse<pid_t>("42 35 64") == 42);
+        REQUIRE(Parse<pid_t>("-42,35") == -42);
+        REQUIRE(Parse<pid_t>("000") == 0);
+        REQUIRE(Parse<pid_t>("-00") == 0);
+        REQUIRE(Parse<pid_t>("foo,42") == std::nullopt);
+        REQUIRE(Parse<pid_t>("foo 42") == std::nullopt);
+        REQUIRE(Parse<pid_t>("") == std::nullopt);
+    }
+
+    SECTION("enum") {
+        enum Something {
+            SOME_FOO = 1,
+            SOME_BAR = 2,
+            SOME_BAZ = 3,
+        };
+        REQUIRE(Parse<std::underlying_type<Something>::type>("0") == 0);
+        REQUIRE(Parse<std::underlying_type<Something>::type>("1") == SOME_FOO);
+        REQUIRE(Parse<std::underlying_type<Something>::type>("2") == SOME_BAR);
+        REQUIRE(Parse<std::underlying_type<Something>::type>("3") == SOME_BAZ);
+        REQUIRE(Parse<std::underlying_type<Something>::type>("4") == 4);
+        REQUIRE(Parse<std::underlying_type<Something>::type>("SOME_FOO") == std::nullopt);
+        REQUIRE(Parse<std::underlying_type<Something>::type>("") == std::nullopt);
+    }
+
+    SECTION("bool") {
+        REQUIRE(Parse<bool>("true") == true);
+        //REQUIRE(Parse<bool>("TRUE") == true);
+        //REQUIRE(Parse<bool>("True") == true);
+
+        REQUIRE(Parse<bool>("false") == false);
+        REQUIRE(Parse<bool>("FALSE") == false);
+        REQUIRE(Parse<bool>("False") == false);
+
+        REQUIRE(Parse<bool>("1") == true);
+        REQUIRE(Parse<bool>("1.0") == true);
+        REQUIRE(Parse<bool>("42") == true);
+        REQUIRE(Parse<bool>("-35") == false);
+        REQUIRE(Parse<bool>("0") == false);
+        REQUIRE(Parse<bool>("0.0") == false);
+        REQUIRE(Parse<bool>("0.1") == false);
+        REQUIRE(Parse<bool>("foo") == false);
+        REQUIRE(Parse<bool>("") == false);
+    }
+}

--- a/tests/test_utils_parsers.cpp
+++ b/tests/test_utils_parsers.cpp
@@ -75,8 +75,8 @@ TEST_CASE("Utils/Parsers", "[parsers]") {
 
     SECTION("bool") {
         REQUIRE(Parse<bool>("true") == true);
-        //REQUIRE(Parse<bool>("TRUE") == true);
-        //REQUIRE(Parse<bool>("True") == true);
+        REQUIRE(Parse<bool>("TRUE") == true);
+        REQUIRE(Parse<bool>("True") == true);
 
         REQUIRE(Parse<bool>("false") == false);
         REQUIRE(Parse<bool>("FALSE") == false);

--- a/tests/test_utils_string.cpp
+++ b/tests/test_utils_string.cpp
@@ -1,0 +1,27 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <string_view>
+#include <vector>
+
+#include "Utils/String.h"
+
+using namespace gamescope;
+using namespace std::string_view_literals;
+
+TEST_CASE("Utils/String", "[string]") {
+    SECTION("Split") {
+        REQUIRE(Split("foo bar baz") == std::vector<std::string_view>{ "foo", "bar", "baz" });
+        REQUIRE(Split("foo,bar;baz", ";,") == std::vector<std::string_view>{ "foo", "bar", "baz" });
+        REQUIRE(Split("foo   bar") == std::vector<std::string_view>{ "foo", "bar" });
+        REQUIRE(Split("  foo bar") == std::vector<std::string_view>{ "foo", "bar" });
+        REQUIRE(Split("foo bar  ") == std::vector<std::string_view>{ "foo", "bar" });
+        REQUIRE(Split("") == std::vector<std::string_view>{});
+        REQUIRE(Split("   ") == std::vector<std::string_view>{});
+        REQUIRE(Split("foobar") == std::vector<std::string_view>{ "foobar" });
+        REQUIRE(Split("foo,;bar", ",;") == std::vector<std::string_view>{ "foo", "bar" });
+
+        std::vector<std::string_view> tokens{ "baz" };
+        Split(tokens, "foo bar"sv);
+        REQUIRE(tokens == std::vector<std::string_view>{ "baz", "foo", "bar" });
+    }
+}


### PR DESCRIPTION
Additionally, make the parsing of a "true" value case-insensitive.