### PR TITLE
wlserver: Fix use-after-free retiring a destroyed gamescope_swapchain

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -684,6 +684,19 @@ void gamescope_xwayland_server_t::destroy_content_override( struct wlserver_x11_
 		destroy_content_override(iter->second);
 }
 
+void gamescope_xwayland_server_t::clear_content_override_swapchain( struct wl_resource *gamescope_swapchain_resource )
+{
+	for ( auto &iter : content_overrides )
+	{
+		if ( iter.second->gamescope_swapchain == gamescope_swapchain_resource )
+		{
+#ifdef GAMESCOPE_SWAPCHAIN_DEBUG
+			wl_log.infof( "clear_content_override_swapchain swapchain: %p co: %p", gamescope_swapchain_resource, iter.second );
+#endif
+			iter.second->gamescope_swapchain = nullptr;
+		}
+	}
+}
 
 static void content_override_handle_surface_destroy( struct wl_listener *listener, void *data )
 {
@@ -858,6 +871,10 @@ static void gamescope_swapchain_handle_resource_destroy( struct wl_resource *res
 #ifdef GAMESCOPE_SWAPCHAIN_DEBUG
 	wl_log.infof( "gamescope_swapchain_handle_resource_destroy swapchain: %p", resource );
 #endif
+	gamescope_xwayland_server_t *server = NULL;
+	for (size_t i = 0; (server = wlserver_get_xwayland_server(i)); i++)
+		server->clear_content_override_swapchain( resource );
+
 	wlserver_wl_surface_info *wl_surface_info = (wlserver_wl_surface_info *)wl_resource_get_user_data( resource );
 	if ( wl_surface_info )
 	{

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -79,6 +79,7 @@ public:
 	void handle_override_window_content( struct wl_client *client, struct wl_resource *gamescope_swapchain_resource, struct wlr_surface *surface, uint32_t x11_window );
 	void destroy_content_override( struct wlserver_x11_surface_info *x11_surface, struct wlr_surface *surf);
 	void destroy_content_override(struct wlserver_content_override *co);
+	void clear_content_override_swapchain( struct wl_resource *gamescope_swapchain_resource );
 
 	struct wl_client *get_client();
 	struct wlr_output *get_output();


### PR DESCRIPTION
co->gamescope_swapchain was only cleared via the x11_surface back-link, which is NULL for overrides registered before their window is known, so the swapchain could be freed while an override still pointed at it and the later surface destroy sent retired on freed memory. Clear it directly from the swapchain's destroy handler, keyed on the resource. The sweep covers all xwayland servers since the resource isn't bound to one server's content_overrides map.

Fixes a gamescope crash when exiting Forza Horizon 6 on a Legion Go 2:

```
0x00007fabe170b2df in wl_resource_post_event () from /usr/lib/libwayland-server.so.0
0x000055df96f73cb6 in gamescope_swapchain_send_retired (resource_=<optimized out>) at protocol/gamescope-swapchain-protocol.h:355
gamescope_xwayland_server_t::destroy_content_override (this=0x55dfa671e350, co=0x55dfa6981f70) at ../src/wlserver.cpp:658
0x00007fabe170a51e in wl_signal_emit_mutable () from /usr/lib/libwayland-server.so.0
0x000055df9705c486 in surface_handle_resource_destroy (resource=<optimized out>) at ../subprojects/wlroots/types/wlr_compositor.c:729
0x00007fabe170cbbb in ?? () from /usr/lib/libwayland-server.so.0
0x00007fabe170cdd2 in wl_client_destroy () from /usr/lib/libwayland-server.so.0
0x00007fabe170cfda in ?? () from /usr/lib/libwayland-server.so.0
0x00007fabe170c112 in wl_event_loop_dispatch () from /usr/lib/libwayland-server.so.0
0x000055df96ee3109 in wlserver_run () at ../src/wlserver.cpp:2217
main (argc=<optimized out>, argv=0x7fff388aa1b8) at ../src/main.cpp:1085
```