### PR TITLE
script: Fix use-after-free in CScriptManager on shutdown

### DIFF
--- a/src/Script/Script.cpp
+++ b/src/Script/Script.cpp
@@ -54,8 +54,8 @@ namespace gamescope
 
     CScriptManager &CScriptManager::GlobalScriptScope()
     {
-        static CScriptManager s_State;
-        return s_State;
+        static CScriptManager *s_pState = new CScriptManager;
+        return *s_pState;
     }
 
     CScriptManager::CScriptManager()


### PR DESCRIPTION
The global CScriptManager is constructed during static initialization, before the function-local name strings sol creates while registering the convar usertypes. Statics are destroyed in reverse order, so at exit those strings die first and ~CScriptManager -> lua_close read the freed names.

To fix this, construct the manager on the heap and never destroy it.

Fixes: https://github.com/ValveSoftware/gamescope/issues/2198