### PR TITLE
steamcompmgr: Don't reject same-app override candidates on pid mismatch

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3449,8 +3449,9 @@ static bool is_good_override_candidate( steamcompmgr_win_t *override, steamcompm
 	if ( !focus )
 		return false;
 
-	// The pids should probably match for a dropdown to be a good candidate for this window.
-	if (override->pid != focus->pid)
+	// The pids should probably match for a dropdown to be a good candidate for this window,
+	// unless a non-zero appID says they are the same app (eg. Xalia's highlight overlay).
+	if (override->pid != focus->pid && (focus->appID == 0 || override->appID != focus->appID))
 		return false;
 
 	auto rect = override->GetGeometry();


### PR DESCRIPTION
fa3cd15c2 made is_good_override_candidate() require matching pids, which broke Xalia's selection highlight. The highlight is an override-redirect window from a helper process in the game's launch tree, so its pid never matches the focus window while its appID does.

Fix this by accepting candidates whose non-zero appID matches the focus window's. Cross-app and unattributable windows are still rejected, keeping the VR dropdown behavior.

cc @misyltoad since I don't have VR hardware to confirm this doesn't regress your change