### PR TITLE
DRMBackend: clear inherited CRTC color when enabling a CRTC

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -3059,6 +3059,17 @@ int drm_prepare( struct drm_t *drm, bool async, const struct FrameInfo_t *frameI
 			drm->pCRTC->GetProperties().ACTIVE->SetPendingValue( drm->req, 1u, true );
 			drm->pCRTC->GetProperties().MODE_ID->SetPendingValue( drm->req, drm->pending.mode_id ? drm->pending.mode_id->GetBlobValue() : 0lu, true );
 
+			// Clear color properties inherited from a previous DRM master (i.e. KDE's
+			// night light).
+			if ( drm->pCRTC->GetProperties().GAMMA_LUT )
+				drm->pCRTC->GetProperties().GAMMA_LUT->SetPendingValue( drm->req, 0, true );
+
+			if ( drm->pCRTC->GetProperties().DEGAMMA_LUT )
+				drm->pCRTC->GetProperties().DEGAMMA_LUT->SetPendingValue( drm->req, 0, true );
+
+			if ( drm->pCRTC->GetProperties().CTM )
+				drm->pCRTC->GetProperties().CTM->SetPendingValue( drm->req, 0, true );
+
 			if ( drm->pCRTC->GetProperties().VRR_ENABLED )
 				drm->pCRTC->GetProperties().VRR_ENABLED->SetPendingValue( drm->req, bVRREnabled, true );
 		}


### PR DESCRIPTION
A previous DRM master like KWin can leave a stale legacy GAMMA_LUT/CTM on a CRTC gamescope inherits, such as KDE's night light warming the panel. These are only reset in the modeset disable loop, which acts on CRTCs that are already active. When KWin's teardown leaves the CRTC inactive, it is skipped there and the enable path never cleared it, so gamescope lights it up still carrying the previous compositor's color and tints the session.

This can be triggered manually by running `steamosctl switch-to-game-mode` via ssh while logged into Plasma with its own night light enabled and active on a Steam Deck.

To fix this, clear GAMMA_LUT/DEGAMMA_LUT/CTM on the CRTC being enabled to avoid inheriting any unwanted color state.

Closes: https://github.com/ValveSoftware/steamos/issues/2469