### PR TITLE
render: prefer a discrete GPU when no device is pinned

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -345,6 +345,15 @@ bool CVulkanDevice::selectPhysDev(VkSurfaceKHR surface)
 		bTryComputeOnly = false;
 	}
 
+	// Track whether the currently-selected device is discrete, so that when no
+	// device is explicitly preferred we upgrade from an integrated GPU to a
+	// discrete one. Without this, on hybrid systems (e.g. an AMD iGPU alongside
+	// a discrete NVIDIA/AMD GPU) the headless/standalone path with no surface to
+	// filter against would pick whichever device enumerates first — frequently
+	// the iGPU — and composite on the wrong, slower GPU.
+	const bool bHavePreferredDevice = ( g_preferVendorID != 0 || g_preferDeviceID != 0 );
+	bool bSelectedIsDiscrete = false;
+
 	for (auto cphysDev : physDevs)
 	{
 		VkPhysicalDeviceProperties deviceProperties;
@@ -370,9 +379,16 @@ bool CVulkanDevice::selectPhysDev(VkSurfaceKHR surface)
 
 		if (generalIndex != ~0u || computeOnlyIndex != ~0u)
 		{
-			// Select the device if it's the first one or the preferred one
-			if (!m_physDev ||
-			    (g_preferVendorID == deviceProperties.vendorID && g_preferDeviceID == deviceProperties.deviceID))
+			const bool bIsPreferred = bHavePreferredDevice &&
+			    g_preferVendorID == deviceProperties.vendorID &&
+			    g_preferDeviceID == deviceProperties.deviceID;
+			const bool bIsDiscrete = deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+			// Upgrade integrated -> discrete only when the user hasn't pinned a device.
+			const bool bDiscreteUpgrade = !bHavePreferredDevice && m_physDev && !bSelectedIsDiscrete && bIsDiscrete;
+
+			// Select the device if it's the first one, the preferred one, or a
+			// discrete GPU superseding an integrated pick.
+			if (!m_physDev || bIsPreferred || bDiscreteUpgrade)
 			{
 				// if we have a surface, check that the queue family can actually present on it
 				if (surface) {
@@ -397,6 +413,7 @@ bool CVulkanDevice::selectPhysDev(VkSurfaceKHR surface)
 				m_queueFamily = computeOnlyIndex == ~0u ? generalIndex : computeOnlyIndex;
 				m_generalQueueFamily = generalIndex;
 				m_physDev = cphysDev;
+				bSelectedIsDiscrete = bIsDiscrete;
 
 				/* When Intel uses compute-only queue for Gamescope composition, some games
 				 * experience performance loss. Using the general queue alleviates the issue


### PR DESCRIPTION
## Problem

On hybrid systems (an integrated GPU alongside a discrete one), `CVulkanDevice::selectPhysDev()` has no `VkSurface` to filter against on the headless/standalone path, so it selects whichever physical device enumerates first. That is frequently the **integrated** GPU, so gamescope composites on the slower GPU.

Reproduced on an **RTX 5090 + AMD Raphael iGPU** (driver 610): standalone gamescope selected `RADV RAPHAEL_MENDOCINO` (the iGPU) instead of the 5090:

```
vulkan: selecting physical device 'AMD Ryzen 9 9950X3D ... (RADV RAPHAEL_MENDOCINO)'
```

## Fix

When the user has **not** pinned a device via `--prefer-vk-device`, upgrade an integrated selection to a discrete GPU. Explicit `--prefer-vk-device` and the surface-presentation check still take precedence.

After:
```
vulkan: selecting physical device 'NVIDIA GeForce RTX 5090': queue family 2
```

## Notes

- Nested selection is unchanged (the surface-present filter already picks the correct device there; verified still selects the 5090 nested).
- No new options; pure default-behaviour improvement for hybrid systems.
- 20-line change in the existing selection loop.