### PR TITLE
Backends/WaylandBackend: don't require the "SRGB" transfer function

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -2028,8 +2028,6 @@ namespace gamescope
                     return false;
 
                 // Transfer Functions
-                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eTransferFunctions, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB ) )
-                    return false;
                 if ( !Algorithm::Contains( m_WPColorManagerFeatures.eTransferFunctions, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ ) )
                     return false;
 


### PR DESCRIPTION
It's deprecated because it doesn't actually describe how sRGB content should be displayed. gamma22 should be used instead.

Since it's not actually used anywhere, perhaps we could also remove the check entirely?

closes #2221