### PR TITLE
(Duplicated)wayland: do not require sRGB transfer support for HDR

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -2028,8 +2028,6 @@ namespace gamescope
                     return false;
 
                 // Transfer Functions
-                if ( !Algorithm::Contains( m_WPColorManagerFeatures.eTransferFunctions, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB ) )
-                    return false;
                 if ( !Algorithm::Contains( m_WPColorManagerFeatures.eTransferFunctions, WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ ) )
                     return false;
 


### PR DESCRIPTION
## Summary

This relaxes the Wayland color-management capability check by no longer requiring `WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB` before exposing HDR support to clients.

## Motivation

On KDE Plasma/KWin 6.7, nested gamescope sees HDR enabled on the host compositor, but refuses to expose HDR formats to clients because the sRGB transfer function is not advertised in the way gamescope currently expects.

Before this change, gamescope reports:

```text
cv_hdr_enabled: true
bExposeHDRSupport: false
server hdr output enabled: false
hdr formats exposed to client: false
```

After this change, on the same system, gamescope reports:

```text
cv_hdr_enabled: true
bExposeHDRSupport: true
server hdr output enabled: true
hdr formats exposed to client: true
colorspace: VK_COLOR_SPACE_HDR10_ST2084_EXT
```

## Tested Setup

System:

```text
CachyOS
KDE Plasma/KWin 6.7.0
Wayland session
AMD Radeon RX 9070 XT, RADV
DisplayPort HDR display at 2560x1440@180 Hz
HDR enabled in KDE display settings
```

Game/application tested:

```text
Dune Awakening / DuneSandbox-Win64-Shipping.exe
Steam app id: 1172710
```

Launch options used:

```text
PROTON_ENABLE_HDR=1 ENABLE_HDR_WSI=1 ENABLE_GAMESCOPE_WSI=1 DXVK_HDR=1 gamescope -f -W 2560 -H 1440 -w 2560 -h 1440 -r 180 --hdr-enabled --adaptive-sync -- %command%
```

Also tested with the same gamescope launch path using both:

```text
Proton Experimental
proton-cachyos-slr / cachyos-11.0-20260601-slr
```

With both Proton builds, after this patch gamescope exposes HDR successfully:

```text
server hdr output enabled:     true
hdr formats exposed to client: true
colorspace: VK_COLOR_SPACE_HDR10_ST2084_EXT
```

The game log also keeps HDR enabled instead of reporting unsupported HDR output:

```text
r.HDR.EnableHDROutput ... Value remains '1'
```

Before this patch, the same game and launch options reached gamescope, but HDR was not exposed to the client:

```text
server hdr output enabled:     false
hdr formats exposed to client: false
colorspace: VK_COLOR_SPACE_SRGB_NONLINEAR_KHR
```

## Related

Refs: https://github.com/ValveSoftware/gamescope/issues/2221
