### PR TITLE
rendervulkan: fix memory leak reported by ASAN

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -290,6 +290,14 @@ uint32_t DRMFormatGetBPP( uint32_t nDRMFormat )
 	return false;
 }
 
+CVulkanDevice::~CVulkanDevice()
+{
+    for ( auto& s : m_samplerCache )
+        vk.DestroySampler( device(), s.second, nullptr );
+    for ( auto& p : m_pipelineMap )
+        vk.DestroyPipeline( device(), p.second, nullptr );
+}
+
 bool CVulkanDevice::BInit(VkInstance instance, VkSurfaceKHR surface)
 {
 	assert(instance);

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -767,6 +767,7 @@ struct VulkanTimelinePoint_t
 class CVulkanDevice
 {
 public:
+    ~CVulkanDevice();
 	bool BInit(VkInstance instance, VkSurfaceKHR surface);
 
 	VkSampler sampler(SamplerState key);


### PR DESCRIPTION
Freeing resources in containers.
Everything else more or less ok in rendervulkan code. Other leaks mostly in C or X11 code
where memory was implicitly allocated in functions like `strdup` or `Xsomething()` but never freed.

GCC setup example (gcc must be built with sanitize support)
```sh
meson setup -Db_sanitize=address -Db_lundef=false build-asan/
ninja -C build-asan/
```

Clang may additionally need
```meson
-Dc_link_args='-fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind'
-Dcpp_link_args='-fuse-ld=lld -rtlib=compiler-rt -unwindlib=libunwind'
```