### PR TITLE
rendervulkan: do not detach, and stop the pipeline compilation thread at exit

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
-#include <thread>
 #include <dlfcn.h>
 #include "vulkan_include.h"
 #include "Utils/Algorithm.h"
@@ -317,8 +316,7 @@ bool CVulkanDevice::BInit(VkInstance instance, VkSurfaceKHR surface)
 
 	m_bInitialized = true;
 
-	std::thread piplelineThread([this](){compileAllPipelines();});
-	piplelineThread.detach();
+	m_pipelineThread = std::jthread([this](std::stop_token st){compileAllPipelines(st);});
 
 	g_reshadeManager.init(this);
 
@@ -1183,7 +1181,7 @@ VkPipeline CVulkanDevice::compilePipeline(uint32_t layerCount, uint32_t ycbcrMas
 	return result;
 }
 
-void CVulkanDevice::compileAllPipelines()
+void CVulkanDevice::compileAllPipelines(std::stop_token st)
 {
 	pthread_setname_np( pthread_self(), "gamescope-shdr" );
 
@@ -1212,6 +1210,7 @@ void CVulkanDevice::compileAllPipelines()
 					{
 						std::lock_guard<std::mutex> lock(m_pipelineMutex);
 						PipelineInfo_t key = {info.shaderType, layerCount, ycbcrMask, blur_layers, info.compositeDebug};
+						if (st.stop_requested()) return;
 						auto result = m_pipelineMap.emplace(std::make_pair(key, newPipeline));
 						if (!result.second)
 							vk.DestroyPipeline(device(), newPipeline, nullptr);

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -11,6 +11,7 @@
 #include <bitset>
 #include <mutex>
 #include <optional>
+#include <thread>
 
 #include "main.hpp"
 
@@ -846,7 +847,7 @@ protected:
 	bool createShaders();
 	bool createScratchResources();
 	VkPipeline compilePipeline(uint32_t layerCount, uint32_t ycbcrMask, ShaderType type, uint32_t blur_layer_count, uint32_t composite_debug, uint32_t colorspace_mask, uint32_t output_eotf, bool itm_enable);
-	void compileAllPipelines();
+	void compileAllPipelines(std::stop_token st);
 
 	VkDevice m_device = nullptr;
 	VkPhysicalDevice m_physDev = nullptr;
@@ -900,6 +901,7 @@ protected:
 
 private:
 	std::vector<VkExtensionProperties> m_supportedExts;
+	std::jthread m_pipelineThread;
 };
 
 struct TextureState


### PR DESCRIPTION
If the selected backend fails to initialize, gamescope exits early. If main() returns while the pipeline thread is busy compiling shaders, it might try to emplace a pipeline into the map of a deleted object (the static g_device), causing a crash.

This change breaks out of the shader compilation loop at exit, thus saving unnecessary work, and ensuring gamescope exits cleanly.