### PR TITLE
steamcompmgr: Reset focusWindow after entering iconic state.

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -5539,6 +5539,11 @@ handle_wm_change_state(xwayland_ctx_t *ctx, steamcompmgr_win_t *w, XClientMessag
 	if (state == ICCCM_ICONIC_STATE) {
 		xwm_log.debugf("Faking WM_CHANGE_STATE to ICONIC for window 0x%lx", w->xwayland().id);
 		set_wm_state( ctx, w->xwayland().id, ICCCM_ICONIC_STATE );
+		if (x11_win(ctx->focus.focusWindow) == w->xwayland().id)
+		{
+			ctx->focus.focusWindow = nullptr;
+			MakeFocusDirty();
+		}
 	} else {
 		xwm_log.debugf("Unhandled WM_CHANGE_STATE to %ld for window 0x%lx", state, w->xwayland().id);
 	}


### PR DESCRIPTION
After "0a09639d steamcompmgr: Accept any requested iconic state change.", a focus change is required to change the state of a window to ICCCM_NORMAL_STATE. However, ctx->focus.focusWindow is not changed. So, in DetermineAndApplyFocus(), the "if ( prevFocusWindow != ctx->focus.focusWindow )" fails, thus the window is not restored to ICCCM_NORMAL_STATE when expected.

Fix RPGMaker Engine games that freeze after minimization.