### PR TITLE
wlserver: Expose wlr_data_device_manager

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -44,6 +44,7 @@
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_data_device.h>
 #include <wlr/util/region.h>
 #include "wlr_end.hpp"
 
@@ -2090,6 +2091,8 @@ bool wlserver_init( void ) {
 	}
 	wlserver.new_pointer_constraint.notify = handle_pointer_constraint;
 	wl_signal_add(&wlserver.constraints->events.new_constraint, &wlserver.new_pointer_constraint);
+
+	wlr_data_device_manager_create(wlserver.display);
 
 	wlserver.xdg_shell = wlr_xdg_shell_create(wlserver.display, 3);
 	if (!wlserver.xdg_shell)


### PR DESCRIPTION
I am trying to run Firefox on gamescope using wayland directly instead of xwayland. There are a number of issues to work through, but one of the most apparent ones is:

```sh
gamescope -- env MOZ_ENABLE_WAYLAND=1 GDK_BACKEND=wayland WAYLAND_DISPLAY=gamescope-0 DISPLAY= firefox
# ...
[875927, Main Thread] WARNING: gdk_seat_get_keyboard: assertion 'GDK_IS_SEAT (seat)' failed: 'glib warning', file toolkit/xre/nsSigHandlers.cpp:200
(firefox-default:875927): Gdk-CRITICAL **: 14:34:21.647: gdk_seat_get_keyboard: assertion 'GDK_IS_SEAT (seat)' failed
```

This happens because gamescope doesn't have `wlr_data_device_manager`. Since wlroots already implements it, we should only need to forward it. After this patch the warning dissapears.