### PR TITLE
drm: Ensures that we can use the DRM format on the vulkan device

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -699,9 +699,15 @@ static bool get_plane_formats( struct drm_t *drm, gamescope::CDRMPlane *pPlane, 
 
 static uint32_t pick_plane_format( const struct wlr_drm_format_set *formats, uint32_t Xformat, uint32_t Aformat )
 {
+	const VkFormatFeatureFlags neededFeatures = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT | VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
 	uint32_t result = DRM_FORMAT_INVALID;
 	for ( size_t i = 0; i < formats->len; i++ ) {
 		uint32_t fmt = formats->formats[i].format;
+
+		// Skip formats that we cannot use with the Vulkan device
+		if ( !vulkan_has_drm_modifiers_for_features( DRMFormatToVulkan(fmt, false), neededFeatures ) )
+			continue;
+
 		if ( fmt == Xformat ) {
 			// Prefer formats without alpha channel for main plane
 			result = fmt;

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -4262,6 +4262,36 @@ bool vulkan_has_drm_props()
 	return false;
 }
 
+bool vulkan_has_drm_modifiers_for_features(VkFormat format, VkFormatFeatureFlags features)
+{
+	if ( !g_device.supportsModifiers() )
+		return false;
+
+	VkDrmFormatModifierPropertiesListEXT modifierPropList = {
+		.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT,
+	};
+	VkFormatProperties2 formatProps = {
+		.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2,
+		.pNext = &modifierPropList,
+	};
+
+	g_device.vk.GetPhysicalDeviceFormatProperties2( g_device.physDev(), format, &formatProps );
+
+	if ( modifierPropList.drmFormatModifierCount == 0 )
+		return false;
+
+	std::vector<VkDrmFormatModifierPropertiesEXT> modifierProps(modifierPropList.drmFormatModifierCount);
+	modifierPropList.pDrmFormatModifierProperties = modifierProps.data();
+	g_device.vk.GetPhysicalDeviceFormatProperties2( g_device.physDev(), format, &formatProps );
+
+	for ( size_t j = 0; j < modifierProps.size(); j++ ) {
+		if ( ( modifierProps[j].drmFormatModifierTilingFeatures & features ) == features )
+			return true;
+	}
+
+	return false;
+}
+
 gamescope::Rc<CVulkanTexture> vulkan_get_last_output_image( bool partial, bool defer )
 {
 	// Get previous image ( +2 )

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -1008,4 +1008,6 @@ void vulkan_wait_idle();
 // Whether the driver implements VK_EXT_physical_device_drm
 bool vulkan_has_drm_props();
 
+bool vulkan_has_drm_modifiers_for_features(VkFormat format, VkFormatFeatureFlags features);
+
 extern CVulkanDevice g_device;


### PR DESCRIPTION
Gamescope now select the DRM format by checking if the vulkan driver
can support those formats with the required image usage bits.

This fixes NVK where nouveau kernel module reports support for
XRGB2101010 and ARGB2101010 but the hardware cannot support those
formats as image storage