### PR TITLE
SDLBackend: fix abort caused by dropping thread

### DIFF
--- a/src/Backends/SDLBackend.cpp
+++ b/src/Backends/SDLBackend.cpp
@@ -133,6 +133,7 @@ namespace gamescope
 	{
 	public:
 		CSDLBackend();
+		~CSDLBackend();
 
 		/////////////
 		// IBackend
@@ -398,6 +399,13 @@ namespace gamescope
 	{
 	}
 
+	CSDLBackend::~CSDLBackend() {
+		SDL_Event event = { .type = SDL_QUIT };
+		SDL_PushEvent(&event);
+		if (m_SDLThread.joinable())
+			m_SDLThread.join();
+	}
+
 	bool CSDLBackend::Init()
 	{
 		m_eSDLInit.wait( SDLInitState::SDLInit_Waiting );
@@ -649,6 +657,7 @@ namespace gamescope
 
 			switch( event.type )
 			{
+				case SDL_QUIT: return;
 				case SDL_CLIPBOARDUPDATE:
 				{
 					char *pClipBoard = SDL_GetClipboardText();


### PR DESCRIPTION
My own attempt, without adding custom events like in #1335

Fixes #1305