### PR TITLE
rendervulkan: Add missing private booleans.

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -189,6 +189,8 @@ struct wsi_memory_allocate_info {
     VkStructureType sType;
     const void *pNext;
     bool implicit_sync;
+    bool dma_buf_sync_file;
+    bool reserved[6]; // To avoid issues down the line.
 };
 
 // DRM doesn't always have 32bit floating point formats, so add our own if necessary


### PR DESCRIPTION
RADV would potentially be reading garbage from dma_buf_sync_file, which could accidentally trip implicit sync for imported buffers.