### PR TITLE
layer: don't fail bypass under a 1x1 toplevel

### DIFF
--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -470,7 +470,11 @@ namespace GamescopeWSILayer {
       //
       // Some games like Halo Infinite, make a child window that is 1280x802px
       // I have no idea how that happens, or whether its an app or Wine bug or not.
-      if (*toplevelWindow != window) {
+      //
+      // Ignore a 1x1 toplevel: winex11 represents an empty window rect as
+      // a 1x1 X window, so it's not a real size to validate against.
+      if (*toplevelWindow != window &&
+          (toplevelRect->extent.width > 1 || toplevelRect->extent.height > 1)) {
         if (iabs(rect->offset.x) > 1 ||
             iabs(rect->offset.y) > 1 ||
             iabs(int32_t(toplevelRect->extent.width)  - int32_t(rect->extent.width)) > 2 ||


### PR DESCRIPTION
Wine uses a 1x1 X window to represent an empty window rect, and Assassin's Creed Black Flag Resynced passes through this state when switching from SDR to HDR. The toplevel goes 1x1 while the client window keeps its full size, and the game re-queries surface formats in a loop until an HDR10 format appears, so failing bypass here hides the HDR formats and leaves it hanging on a black screen.

A 1x1 toplevel is not a real size to validate the client window against, so ignore it.