### PR TITLE
Correctly handle numlock and capslock state on Wayland Backend

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -10,6 +10,7 @@
 #include "refresh_rate.h"
 #include "waitable.h"
 #include "Utils/TempFiles.h"
+#include "Utils/Xkb.h"
 
 #include <cstring>
 #include <unordered_map>
@@ -554,7 +555,7 @@ namespace gamescope
         xkb_keymap *m_pXkbKeymap = nullptr;
 
         uint32_t m_uKeyModifiers = 0;
-        uint32_t m_uModMask[ GAMESCOPE_WAYLAND_MOD_COUNT ];
+        uint32_t m_uModMask[ GAMESCOPE_WAYLAND_MOD_COUNT ] = { 0 };
 
         double m_flScrollAccum[2] = { 0.0, 0.0 };
         uint32_t m_uAxisSource = WL_POINTER_AXIS_SOURCE_WHEEL;
@@ -3175,7 +3176,7 @@ namespace gamescope
         m_pXkbKeymap = pKeymap;
 
         for ( uint32_t i = 0; i < GAMESCOPE_WAYLAND_MOD_COUNT; i++ )
-            m_uModMask[ i ] = 1u << xkb_keymap_mod_get_index( m_pXkbKeymap, WaylandModifierToXkbModifierName( ( WaylandModifierIndex ) i ) );
+            m_uModMask[ i ] = XkbKeymapModMask( m_pXkbKeymap, WaylandModifierToXkbModifierName( ( WaylandModifierIndex ) i ) );
     }
     void CWaylandInputThread::Wayland_Keyboard_Enter( wl_keyboard *pKeyboard, uint32_t uSerial, wl_surface *pSurface, wl_array *pKeys )
     {
@@ -3236,6 +3237,13 @@ namespace gamescope
     void CWaylandInputThread::Wayland_Keyboard_Modifiers( wl_keyboard *pKeyboard, uint32_t uSerial, uint32_t uModsDepressed, uint32_t uModsLatched, uint32_t uModsLocked, uint32_t uGroup )
     {
         m_uKeyModifiers = uModsDepressed | uModsLatched | uModsLocked;
+
+        bool bNumLocked = uModsLocked & m_uModMask[ GAMESCOPE_WAYLAND_MOD_NUM ];
+        bool bCapsLocked = uModsLocked & m_uModMask[ GAMESCOPE_WAYLAND_MOD_CAPS ];
+
+        wlserver_lock();
+        wlserver_set_virtual_keyboard_modifiers( bNumLocked, bCapsLocked );
+        wlserver_unlock();
     }
     void CWaylandInputThread::Wayland_Keyboard_RepeatInfo( wl_keyboard *pKeyboard, int32_t nRate, int32_t nDelay )
     {

--- a/src/Utils/Xkb.cpp
+++ b/src/Utils/Xkb.cpp
@@ -1,0 +1,16 @@
+#include "Xkb.h"
+
+namespace gamescope
+{
+    uint32_t XkbKeymapModMask( xkb_keymap *keymap, const char *name )
+    {
+        if ( !keymap )
+            return 0u;
+
+        xkb_mod_index_t index = xkb_keymap_mod_get_index( keymap, name );
+        if ( index == XKB_MOD_INVALID || index >= 32)
+            return 0u;
+
+        return 1u << index;
+    }
+}

--- a/src/Utils/Xkb.h
+++ b/src/Utils/Xkb.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <xkbcommon/xkbcommon.h>
+
+namespace gamescope
+{
+    uint32_t XkbKeymapModMask( xkb_keymap *keymap, const char *name );
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -101,6 +101,7 @@ src = [
   'Utils/TempFiles.cpp',
   'Utils/Version.cpp',
   'Utils/Process.cpp',
+  'Utils/Xkb.cpp',
   'Script/Script.cpp',
   'BufferMemo.cpp',
   'steamcompmgr.cpp',

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -14,7 +14,6 @@
 #include <linux/input-event-codes.h>
 
 #include <X11/extensions/XTest.h>
-#include <xkbcommon/xkbcommon.h>
 
 #include "WaylandServer/WaylandResource.h"
 #include "WaylandServer/WaylandProtocol.h"
@@ -68,6 +67,7 @@
 #include "commit.h"
 #include "Timeline.h"
 #include "Utils/NonCopyable.h"
+#include "Utils/Xkb.h"
 
 #if HAVE_PIPEWIRE
 #include "pipewire.hpp"
@@ -2416,6 +2416,32 @@ bool wlserver_process_hotkeys( wlr_keyboard *keyboard, uint32_t key, bool press 
 	}
 
 	return false;
+}
+
+void wlserver_set_virtual_keyboard_modifiers( bool bNumLocked, bool bCapsLocked )
+{
+	assert( wlserver_is_lock_held() );
+
+	struct wlr_keyboard *keyboard = wlserver.wlr.virtual_keyboard_device;
+	if ( keyboard == nullptr || keyboard->xkb_state == nullptr )
+		return;
+
+    uint32_t numLockMask = gamescope::XkbKeymapModMask(keyboard->keymap, XKB_MOD_NAME_NUM);
+    uint32_t capsLockMask = gamescope::XkbKeymapModMask(keyboard->keymap, XKB_MOD_NAME_CAPS);
+    uint32_t locked = keyboard->modifiers.locked;
+
+    locked = bNumLocked ? locked | numLockMask : locked & ~numLockMask;
+    locked = bCapsLocked ? locked | capsLockMask : locked & ~capsLockMask;
+
+	wlr_keyboard_notify_modifiers( keyboard,
+                                   keyboard->modifiers.depressed,
+                                   keyboard->modifiers.latched,
+                                   locked,
+                                   keyboard->modifiers.group );
+	wlr_seat_set_keyboard( wlserver.wlr.seat, keyboard );
+	wlr_seat_keyboard_notify_modifiers( wlserver.wlr.seat, &keyboard->modifiers );
+
+	bump_input_counter();
 }
 
 void wlserver_key( uint32_t key, bool press, uint32_t time )

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -242,6 +242,7 @@ bool wlserver_is_lock_held(void);
 
 void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain = true );
 void wlserver_key( uint32_t key, bool press, uint32_t time );
+void wlserver_set_virtual_keyboard_modifiers( bool bNumLocked, bool bCapsLocked );
 
 void wlserver_mousefocus( struct wlr_surface *wlrsurface, int x = 0, int y = 0 );
 void wlserver_clear_dropdowns();


### PR DESCRIPTION
Fix #969 (Numlock state is not respected) on Wayland with `--backend wayland`.

I'm also working on a fix on Wayland with `--backend sdl`.