### PR TITLE
Use a backing surface for letter-boxing

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1085,7 +1085,10 @@ namespace gamescope
                 bool bNeedsBacking = true;
                 if ( pFrameInfo->layerCount >= 1 )
                 {
-                    if ( pFrameInfo->layers[0].isScreenSize() && !pFrameInfo->layers[0].hasAlpha() )
+                    if ( pFrameInfo->layers[0].isScreenSize() &&
+                         close_enough( pFrameInfo->layers[0].offset.x, 0.0f ) &&
+                         close_enough( pFrameInfo->layers[0].offset.y, 0.0f ) &&
+                         !pFrameInfo->layers[0].hasAlpha() )
                         bNeedsBacking = false;
                 }
 


### PR DESCRIPTION
When using --force-grab-cursor in nested mode, the cursor is rendered with an offset equal to the size of the top and/or left empty space around the inner client. This is because MouseCursor::paint explicitly adds padding to account for the difference between output size and window size, but the cursor is attached to the window surface (so coordinates need to be relative to to the window, not the output).

Enable a backing surface when we're letter-boxing, so that the window geometry matches the output geometry, rendering the cursor in the right location.

Fixes: https://github.com/ValveSoftware/gamescope/issues/1748