### PR TITLE
layer: don't bypass Xwayland for offscreen client windows in Wine

### DIFF
--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -428,19 +428,52 @@ namespace GamescopeWSILayer {
       return hdrOutput && hdrAllowed;
     }
 
-    bool canBypassXWayland() {
+    bool canBypassXWayland(bool hdrColorspace = false) {
       if (isWayland())
         return true;
 
       auto rect = xcb::getWindowRect(connection, window);
-      auto largestObscuringWindowSize = xcb::getLargestObscuringChildWindowSize(connection, window);
-      auto toplevelWindow = xcb::getToplevelWindow(connection, window);
-      if (!rect || !largestObscuringWindowSize || !toplevelWindow) {
+      if (!rect) {
         fprintf(stderr, "[Gamescope WSI] canBypassXWayland: failed to get window info for window 0x%x.\n", window);
         return false;
       }
 
       cachedWindowRect = *rect;
+
+      // Never bypass windows Wine presents offscreen to GDI-blit onto the
+      // real toplevel: marked with _WINE_ALLOW_FLIP=0 or parented under
+      // Wine's unnamed 1x1 dummy window. The blit can only carry SDR, so
+      // an HDR colorspace always bypasses. Wine also detaches while a
+      // toplevel is transiently unmapped and refusing there wedges games
+      // polling for HDR formats.
+      if (!hdrColorspace) {
+        auto allowFlip = xcb::getPropertyValue<uint32_t>(connection, window, "_WINE_ALLOW_FLIP");
+        if (allowFlip) {
+          if (*allowFlip == 0) {
+#if GAMESCOPE_WSI_BYPASS_DEBUG
+            fprintf(stderr, "[Gamescope WSI] Not bypassing: _WINE_ALLOW_FLIP is 0 for window 0x%x.\n", window);
+#endif
+            return false;
+          }
+        } else if (auto parent = xcb::getParentWindow(connection, window)) {
+          auto parentRect = xcb::getWindowRect(connection, *parent);
+          if (parentRect && parentRect->extent.width == 1 && parentRect->extent.height == 1 &&
+              xcb::isOverrideRedirect(connection, *parent) &&
+              !xcb::hasProperty(connection, *parent, XCB_ATOM_WM_CLASS)) {
+#if GAMESCOPE_WSI_BYPASS_DEBUG
+            fprintf(stderr, "[Gamescope WSI] Not bypassing: window 0x%x is parked under Wine dummy parent 0x%x.\n", window, *parent);
+#endif
+            return false;
+          }
+        }
+      }
+
+      auto largestObscuringWindowSize = xcb::getLargestObscuringChildWindowSize(connection, window);
+      auto toplevelWindow = xcb::getToplevelWindow(connection, window);
+      if (!largestObscuringWindowSize || !toplevelWindow) {
+        fprintf(stderr, "[Gamescope WSI] canBypassXWayland: failed to get window info for window 0x%x.\n", window);
+        return false;
+      }
 
       auto toplevelRect = xcb::getWindowRect(connection, *toplevelWindow);
       if (!toplevelRect) {
@@ -508,6 +541,7 @@ namespace GamescopeWSILayer {
     VkPresentModeKHR presentMode;
     VkExtent2D extent;
     uint32_t serverId = 0;
+    bool isHdrColorspace = false;
     bool retired = false;
 
     std::unique_ptr<std::mutex> presentTimingMutex = std::make_unique<std::mutex>();
@@ -793,7 +827,10 @@ namespace GamescopeWSILayer {
       const bool canBypass = gamescopeSurface->canBypassXWayland();
       VkSurfaceKHR selectedSurface = canBypass ? surface : gamescopeSurface->fallbackSurface;
 
-      if (!canBypass || !gamescopeSurface->shouldExposeHDR())
+      // HDR skips the Wine offscreen gate, so expose HDR formats whenever
+      // an HDR colorspace could bypass, even if SDR currently can't.
+      if (!gamescopeSurface->shouldExposeHDR() ||
+          !(canBypass || gamescopeSurface->canBypassXWayland(true)))
         return pDispatch->GetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, selectedSurface, pSurfaceFormatCount, pSurfaceFormats);
 
       return vkroots::helpers::append(
@@ -819,7 +856,10 @@ namespace GamescopeWSILayer {
       const bool canBypass = gamescopeSurface->canBypassXWayland();
       surfaceInfo.surface = canBypass ? surfaceInfo.surface : gamescopeSurface->fallbackSurface;
 
-      if (!canBypass || !gamescopeSurface->shouldExposeHDR())
+      // HDR skips the Wine offscreen gate, so expose HDR formats whenever
+      // an HDR colorspace could bypass, even if SDR currently can't.
+      if (!gamescopeSurface->shouldExposeHDR() ||
+          !(canBypass || gamescopeSurface->canBypassXWayland(true)))
         return pDispatch->GetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, &surfaceInfo, pSurfaceFormatCount, pSurfaceFormats);
 
       return vkroots::helpers::append(
@@ -1115,7 +1155,11 @@ namespace GamescopeWSILayer {
         return pDispatch->CreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
       }
 
-      const bool canBypass = gamescopeSurface->canBypassXWayland();
+      // Only the colorspaces we expose in s_ExtraHDRSurfaceFormat2s count as
+      // HDR. Other non-sRGB colorspaces are still SDR content Wine can blit.
+      const bool hdrColorspace = pCreateInfo->imageColorSpace == VK_COLOR_SPACE_HDR10_ST2084_EXT ||
+                                  pCreateInfo->imageColorSpace == VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT;
+      const bool canBypass = gamescopeSurface->canBypassXWayland(hdrColorspace);
 
       VkSwapchainCreateInfoKHR swapchainInfo = *pCreateInfo;
 
@@ -1240,6 +1284,7 @@ namespace GamescopeWSILayer {
           .presentMode         = pCreateInfo->presentMode, // The new present mode.
           .extent              = pCreateInfo->imageExtent,
           .serverId            = serverId,
+          .isHdrColorspace     = hdrColorspace,
         });
         gamescopeSwapchain->pastPresentTimings.reserve(MaxPastPresentationTimes);
 
@@ -1430,7 +1475,7 @@ namespace GamescopeWSILayer {
             continue;
           }
 
-          const bool canBypass = gamescopeSurface->canBypassXWayland();
+          const bool canBypass = gamescopeSurface->canBypassXWayland(gamescopeSwapchain->isHdrColorspace);
           if (canBypass != gamescopeSwapchain->isBypassingXWayland) {
             if (canBypass) {
               if (!(gamescopeSurface->flags & GamescopeLayerClient::Flag::NoSuboptimal))

--- a/layer/xcb_helpers.hpp
+++ b/layer/xcb_helpers.hpp
@@ -59,6 +59,61 @@ namespace xcb {
     return getPropertyValue<T>(connection, *atom);
   }
 
+  template <typename T>
+  static std::optional<T> getPropertyValue(xcb_connection_t* connection, xcb_window_t window, std::string_view name) {
+    static_assert(sizeof(T) % 4 == 0);
+
+    std::optional<xcb_atom_t> atom = getAtom(connection, name);
+    if (!atom)
+      return std::nullopt;
+
+    xcb_get_property_cookie_t cookie = xcb_get_property(connection, false, window, *atom, XCB_ATOM_CARDINAL, 0, sizeof(T) / sizeof(uint32_t));
+    auto reply = Reply<xcb_get_property_reply_t>{ xcb_get_property_reply(connection, cookie, nullptr) };
+    if (!reply) {
+      fprintf(stderr, "[Gamescope WSI] getPropertyValue: xcb_get_property failed for window 0x%x.\n", window);
+      return std::nullopt;
+    }
+
+    // An absent property is expected, eg. on non-Wine windows.
+    if (reply->type != XCB_ATOM_CARDINAL || xcb_get_property_value_length(reply.get()) < int(sizeof(T)))
+      return std::nullopt;
+
+    T value = *reinterpret_cast<const T *>(xcb_get_property_value(reply.get()));
+    return value;
+  }
+
+  static std::optional<xcb_window_t> getParentWindow(xcb_connection_t* connection, xcb_window_t window) {
+    xcb_query_tree_cookie_t cookie = xcb_query_tree(connection, window);
+    auto reply = Reply<xcb_query_tree_reply_t>{ xcb_query_tree_reply(connection, cookie, nullptr) };
+    if (!reply) {
+      fprintf(stderr, "[Gamescope WSI] getParentWindow: xcb_query_tree failed for window 0x%x.\n", window);
+      return std::nullopt;
+    }
+    if (reply->root == window || reply->parent == reply->root)
+      return std::nullopt;
+    return reply->parent;
+  }
+
+  static bool isOverrideRedirect(xcb_connection_t* connection, xcb_window_t window) {
+    xcb_get_window_attributes_cookie_t cookie = xcb_get_window_attributes(connection, window);
+    auto reply = Reply<xcb_get_window_attributes_reply_t>{ xcb_get_window_attributes_reply(connection, cookie, nullptr) };
+    if (!reply) {
+      fprintf(stderr, "[Gamescope WSI] isOverrideRedirect: xcb_get_window_attributes failed for window 0x%x.\n", window);
+      return false;
+    }
+    return reply->override_redirect;
+  }
+
+  static bool hasProperty(xcb_connection_t* connection, xcb_window_t window, xcb_atom_t atom) {
+    xcb_get_property_cookie_t cookie = xcb_get_property(connection, false, window, atom, XCB_GET_PROPERTY_TYPE_ANY, 0, 0);
+    auto reply = Reply<xcb_get_property_reply_t>{ xcb_get_property_reply(connection, cookie, nullptr) };
+    if (!reply) {
+      fprintf(stderr, "[Gamescope WSI] hasProperty: xcb_get_property failed for window 0x%x.\n", window);
+      return false;
+    }
+    return reply->type != XCB_NONE;
+  }
+
   static std::optional<xcb_window_t> getToplevelWindow(xcb_connection_t* connection, xcb_window_t window) {
     for (;;) {
       xcb_query_tree_cookie_t cookie = xcb_query_tree(connection, window);


### PR DESCRIPTION
Wine presents some client windows offscreen and GDI-blits the result onto the real toplevel. This happens for both cross-process presentation, and clipped child windows. Such windows are reparented under a hidden 1x1 dummy parent. Bypassing XWayland for them starves the X pixmap the blit copies from, so the window Wine actually shows stays black.

Two commits exposed this independently. a563226 stopped snapping focus windows to (0, 0), which had kept the Star Citizen launcher (CEF) on the direct presentation path. 7b340f5 allowed bypass under a 1x1 toplevel, which moved already-parked windows (Zenless Zone Zero) off the XCB fallback that had been feeding the blit.

Honor _WINE_ALLOW_FLIP=0 where Wine sets it, and detect the parked configuration structurally for cross-process windows, which never get the property. Refuse bypass only after caching the window rect, so the out-of-date emulation on window resize keeps working. We also need to exempt the HDR colorspaces we expose, as the blit can only carry SDR and this would regress AC Black Flag Resynced back to a broken state. The gate is not exempted for GAMESCOPE_WSI_FORCE_BYPASS, as bypassing a parked window can never produce visible output.

Fixes: 7b340f51e655 ("layer: don't fail bypass under a 1x1 toplevel")
Fixes: a563226d431d ("steamcompmgr: do not forcefully snap focus windows to (0, 0)")