### PR TITLE
rendervulkan: Fix FD leak when vkAllocateMemory fails to import a DMABuf handle

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -2339,6 +2339,12 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 		if ( res != VK_SUCCESS )
 		{
 			vk_errorf( res, "vkAllocateMemory failed" );
+			if ( pDMA != nullptr )
+			{
+				// When import doesn't succeed, the driver hasn't taken ownership of the FD
+				// Close it so it doesn't become an FD leak
+				close( importMemoryInfo.fd );
+			}
 			return false;
 		}
 


### PR DESCRIPTION
The driver only takes ownership on VK_SUCCESS, which means it is up to the compositor to handle the ownership semantics, thus manually closing the FD.

This only fixes the leak, it doesn't fix another underlying problem that when `vulkan_create_texture_from_wlr_buffer` fails to import a DMABuf from a wayland buffer, it will continue forward and crash due to dereferencing a nullptr `commit->vulkanTex` but there's more work there.