### PR TITLE
Remote play streaming fixes

### DIFF
--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -87,6 +87,11 @@ static void calculate_capture_size()
 			s_nCaptureHeight = s_nRequestedHeight;
 		}
 	}
+
+	// NV12 is 4:2:0 subsampled and only valid at even dimensions, but the ratio math can round odd.
+	constexpr uint32_t kCaptureAlign = 2;
+	s_nCaptureWidth = SPA_ROUND_UP_N(s_nCaptureWidth, kCaptureAlign);
+	s_nCaptureHeight = SPA_ROUND_UP_N(s_nCaptureHeight, kCaptureAlign);
 }
 
 static void build_format_params(struct spa_pod_builder *builder, spa_video_format format, std::vector<const struct spa_pod *> &params) {

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -9139,12 +9139,13 @@ steamcompmgr_main(int argc, char **argv)
 			// Juuust in case pageflip handler doesn't happen
 			// so we don't stop vblanking forever.
 			GetVBlankTimer().ArmNextVBlank( true );
+		}
 
 #if HAVE_PIPEWIRE
-			if ( pipewire_is_streaming() )
-				paint_pipewire();
+		// Drive on vblank, not the timer: under VRR the timer starves (page flips re-arm it).
+		if ( vblank && pipewire_is_streaming() )
+			paint_pipewire();
 #endif
-		}
 
 		update_vrr_atoms(root_ctx, false, &flush_root);
 


### PR DESCRIPTION
Couple of fixes for remote play using a SteamOS PC as a host:

- Fix crash when streaming from a 5120x2160p display resolution to an iPhone Air with "Enhanced 4K" Steam Link streaming quality
- Fix remote play not consistently rendering the output stream on the client device when VRR is enabled and active