### PR TITLE
Fix a few cases of stuck keybinds

### DIFF
--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -1601,6 +1601,10 @@ bool wlsession_active()
 
 static void handle_session_active( struct wl_listener *listener, void *data )
 {
+	// Releases delivered while another VT owns input never reach us.
+	if ( !wlserver.wlr.session->active )
+		wlserver.mapPressedHotkeyKeys.clear();
+
 	GetBackend()->DirtyState( wlserver.wlr.session->active, wlserver.wlr.session->active );
 	wl_log.infof( "Session %s", wlserver.wlr.session->active ? "resumed" : "paused" );
 }

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -327,6 +327,10 @@ static void wlserver_handle_key(struct wl_listener *listener, void *data)
 		struct wlr_surface *new_kb_surf = steamcompmgr_get_server_input_surface( 0 );
 		if ( new_kb_surf )
 		{
+			// This key skips hotkey processing, so drop any press we
+			// recorded for it or the stale sym would wedge every binding.
+			wlserver.mapPressedHotkeyKeys.erase( { keyboard, keycode } );
+
 			wlserver_keyboardfocus( new_kb_surf, false );
 			wlr_seat_set_keyboard( wlserver.wlr.seat, keyboard );
 			wlr_seat_keyboard_notify_key( wlserver.wlr.seat, event->time_msec, event->keycode, event->state );

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -2370,23 +2370,37 @@ void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain )
 bool wlserver_process_hotkeys( wlr_keyboard *keyboard, uint32_t key, bool press )
 {
 	xkb_keycode_t keycode = key + 8;
-	xkb_keysym_t keysym = xkb_state_key_get_one_sym( keyboard->xkb_state, keycode );
 
-	keysym = NormalizeKeysymForHotkey( keysym );
-
-	static std::unordered_set<xkb_keysym_t> s_setPressedKeySyms;
+	// Remember the sym at press time so a release erases exactly what the press inserted.
 	if ( press )
 	{
-		s_setPressedKeySyms.emplace( keysym );
+		xkb_keysym_t keysym = xkb_state_key_get_one_sym( keyboard->xkb_state, keycode );
+		wlserver.mapPressedHotkeyKeys[ { keyboard, keycode } ] = NormalizeKeysymForHotkey( keysym );
 	}
 	else
 	{
-		s_setPressedKeySyms.erase( keysym );
+		auto it = wlserver.mapPressedHotkeyKeys.find( { keyboard, keycode } );
+
+		// A release we never saw the press for cannot end a binding.
+		if ( it == wlserver.mapPressedHotkeyKeys.end() )
+			return false;
+
+		xkb_keysym_t released = it->second;
+		wlserver.mapPressedHotkeyKeys.erase( it );
+
+		// Two keycodes can resolve to the same sym, so only a release that actually drops the sym can end a binding.
+		for ( const auto &[ deviceKey, uKeySym ] : wlserver.mapPressedHotkeyKeys )
+			if ( uKeySym == released )
+				return false;
 	}
+
+	std::unordered_set<xkb_keysym_t> setPressedKeySyms;
+	for ( const auto &[ deviceKey, uKeySym ] : wlserver.mapPressedHotkeyKeys )
+		setPressedKeySyms.emplace( uKeySym );
 
 	if ( log_binding.Enabled( LOG_DEBUG ) )
 	{
-		std::string sPressedKeySymsDebugName = ComputeDebugName( s_setPressedKeySyms );
+		std::string sPressedKeySymsDebugName = ComputeDebugName( setPressedKeySyms );
 		log_binding.debugf( "Looking for: [%s].", sPressedKeySymsDebugName.c_str() );
 	}
 
@@ -2406,7 +2420,7 @@ bool wlserver_process_hotkeys( wlr_keyboard *keyboard, uint32_t key, bool press 
 				if ( !pBinding->IsArmed() )
 					break;
 
-				if ( s_setPressedKeySyms != keybind.setKeySyms )
+				if ( setPressedKeySyms != keybind.setKeySyms )
 					continue;
 
 				if ( pBinding->Execute() )

--- a/src/wlserver.hpp
+++ b/src/wlserver.hpp
@@ -13,6 +13,8 @@
 #include <unordered_map>
 #include <optional>
 
+#include <xkbcommon/xkbcommon.h>
+
 #include "WaylandServer/WaylandDecls.h"
 #include "WaylandServer/WaylandServerLegacy.h"
 
@@ -199,6 +201,9 @@ struct wlserver_t {
     struct wlr_keyboard_group *keyboard_group;
     struct wl_listener keyboard_group_modifiers;
     struct wl_listener keyboard_group_key;
+
+    // Sym each held key resolved to at press time, keyed by device and keycode.
+    std::map<std::pair<struct wlr_keyboard *, xkb_keycode_t>, xkb_keysym_t> mapPressedHotkeyKeys;
 };
 
 extern struct wlserver_t wlserver;


### PR DESCRIPTION
Ran into a few different cases where our keybinds would die in gamescope-session until a restart, finally had a chance to track down where they were coming from.