### PR TITLE
steamcompmgr: capture screenshots at render size, not output size

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2870,9 +2870,18 @@ paint_all( global_focus_t *pFocus, bool async )
 		else
 			xwm_log.errorf( "Unsupported extension for a screenshot: %s", path.extension().string().c_str() );
 
+		// Repaint base-plane-only screenshots at the game's render resolution to preserve supersampling.
+		const bool bRenderSizeScreenshot =
+			oScreenshotInfo->eScreenshotType == GAMESCOPE_CONTROL_SCREENSHOT_TYPE_BASE_PLANE_ONLY &&
+			drmCaptureFormat != DRM_FORMAT_NV12 &&
+			pFocus->focusWindow != nullptr;
+
+		const uint32_t uScreenshotWidth = bRenderSizeScreenshot ? g_nNestedWidth : g_nOutputWidth;
+		const uint32_t uScreenshotHeight = bRenderSizeScreenshot ? g_nNestedHeight : g_nOutputHeight;
+
 		gamescope::Rc<CVulkanTexture> pScreenshotTexture;
 		if ( drmCaptureFormat != DRM_FORMAT_INVALID )
-			pScreenshotTexture = vulkan_acquire_screenshot_texture( g_nOutputWidth, g_nOutputHeight, false, drmCaptureFormat );
+			pScreenshotTexture = vulkan_acquire_screenshot_texture( uScreenshotWidth, uScreenshotHeight, false, drmCaptureFormat );
 
 		if ( pScreenshotTexture )
 		{
@@ -2938,6 +2947,32 @@ paint_all( global_focus_t *pFocus, bool async )
 			else if ( oScreenshotInfo->eScreenshotType == GAMESCOPE_CONTROL_SCREENSHOT_TYPE_FULL_COMPOSITION ||
 					  oScreenshotInfo->eScreenshotType == GAMESCOPE_CONTROL_SCREENSHOT_TYPE_SCREEN_BUFFER )
 				oScreenshotSeq = vulkan_composite( &frameInfo, nullptr, false, pScreenshotTexture );
+			else if ( bRenderSizeScreenshot )
+			{
+				FrameInfo_t screenshotFrameInfo{};
+				screenshotFrameInfo.applyOutputColorMgmt = true;
+				screenshotFrameInfo.outputEncodingEOTF = bHDRScreenshot ? EOTF_PQ : EOTF_Gamma22;
+				for ( uint32_t nInputEOTF = 0; nInputEOTF < EOTF_Count; nInputEOTF++ )
+				{
+					auto& luts = bHDRScreenshot ? g_ScreenshotColorMgmtLutsHDR : g_ScreenshotColorMgmtLuts;
+					screenshotFrameInfo.lut3D[nInputEOTF] = luts[nInputEOTF].vk_lut3d;
+					screenshotFrameInfo.shaperLut[nInputEOTF] = luts[nInputEOTF].vk_lut1d;
+				}
+
+				const uint32_t uBackupWidth = currentOutputWidth;
+				const uint32_t uBackupHeight = currentOutputHeight;
+				currentOutputWidth = uScreenshotWidth;
+				currentOutputHeight = uScreenshotHeight;
+
+				paint_window( pFocus->focusWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, 0, 1.0f, pFocus->overrideWindow );
+				if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
+					paint_window( pFocus->overrideWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
+
+				oScreenshotSeq = vulkan_screenshot( &screenshotFrameInfo, pScreenshotTexture, nullptr );
+
+				currentOutputWidth = uBackupWidth;
+				currentOutputHeight = uBackupHeight;
+			}
 			else
 				oScreenshotSeq = vulkan_screenshot( &frameInfo, pScreenshotTexture, nullptr );
 


### PR DESCRIPTION
Base-plane-only screenshots were captured at the output resolution, so rendering a game above the display size for screenshot purposes was thrown away. Acquire the screenshot texture at the nested render size and repaint the focus and override windows at that size, the same way paint_pipewire() captures at an arbitrary size. This applies in both directions: an upscaled game is now captured at its smaller native render size with no scaler artifacts, matching the base_plane_only semantics of capturing just the game. The screen_buffer type still captures the displayed output 1:1. NV12 requests and screenshots with no focus window keep the output-size path.

Fixes: https://github.com/ValveSoftware/gamescope/issues/1996