### PR TITLE
Warframe launcher fixes

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -1929,20 +1929,20 @@ LiftoffStateCacheEntry FrameInfoToLiftoffStateCacheEntry( struct drm_t *drm, con
 {
 	LiftoffStateCacheEntry entry{};
 
-	entry.nLayerCount = frameInfo->layerCount;
+	entry.nLayerCount = frameInfo->layers.count();
 	for ( int i = 0; i < entry.nLayerCount; i++ )
 	{
-		const uint16_t srcWidth  = frameInfo->layers[ i ].tex->width();
-		const uint16_t srcHeight = frameInfo->layers[ i ].tex->height();
+		const uint16_t srcWidth  = frameInfo->layers.get( i ).tex->width();
+		const uint16_t srcHeight = frameInfo->layers.get( i ).tex->height();
 
-		int32_t crtcX = -frameInfo->layers[ i ].offset.x;
-		int32_t crtcY = -frameInfo->layers[ i ].offset.y;
-		uint64_t crtcW = srcWidth / frameInfo->layers[ i ].scale.x;
-		uint64_t crtcH = srcHeight / frameInfo->layers[ i ].scale.y;
+		int32_t crtcX = -frameInfo->layers.get( i ).offset.x;
+		int32_t crtcY = -frameInfo->layers.get( i ).offset.y;
+		uint64_t crtcW = srcWidth / frameInfo->layers.get( i ).scale.x;
+		uint64_t crtcH = srcHeight / frameInfo->layers.get( i ).scale.y;
 
 		if (g_bRotated && g_uOutputRotation == 0)
 		{
-			int64_t imageH = frameInfo->layers[ i ].tex->contentHeight() / frameInfo->layers[ i ].scale.y;
+			int64_t imageH = frameInfo->layers.get( i ).tex->contentHeight() / frameInfo->layers.get( i ).scale.y;
 
 			const int32_t x = crtcX;
 			const uint64_t w = crtcW;
@@ -1952,15 +1952,15 @@ LiftoffStateCacheEntry FrameInfoToLiftoffStateCacheEntry( struct drm_t *drm, con
 			crtcH = w;
 		}
 
-		entry.layerState[i].zpos  = frameInfo->layers[ i ].zpos;
+		entry.layerState[i].zpos  = frameInfo->layers.get( i ).zpos;
 		entry.layerState[i].srcW  = srcWidth  << 16;
 		entry.layerState[i].srcH  = srcHeight << 16;
 		entry.layerState[i].crtcX = crtcX;
 		entry.layerState[i].crtcY = crtcY;
 		entry.layerState[i].crtcW = crtcW;
 		entry.layerState[i].crtcH = crtcH;
-		entry.layerState[i].opacity = frameInfo->layers[i].opacity * 0xffff;
-		entry.layerState[i].ycbcr = frameInfo->layers[i].isYcbcr();
+		entry.layerState[i].opacity = frameInfo->layers.get( i ).opacity * 0xffff;
+		entry.layerState[i].ycbcr = frameInfo->layers.get( i ).isYcbcr();
 		if ( entry.layerState[i].ycbcr )
 		{
 			entry.layerState[i].colorEncoding = drm_get_color_encoding( g_ForcedNV12ColorSpace );
@@ -1969,9 +1969,9 @@ LiftoffStateCacheEntry FrameInfoToLiftoffStateCacheEntry( struct drm_t *drm, con
 		}
 		else
 		{
-			entry.layerState[i].colorspace = frameInfo->layers[ i ].colorspace;
+			entry.layerState[i].colorspace = frameInfo->layers.get( i ).colorspace;
 		}
-		entry.layerState[i].eAlphaBlendingMode = frameInfo->layers[i].eAlphaBlendingMode;
+		entry.layerState[i].eAlphaBlendingMode = frameInfo->layers.get( i ).eAlphaBlendingMode;
 	}
 
 	return entry;
@@ -2634,13 +2634,13 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 			return -EINVAL;
 	}
 
-	bool bSinglePlane = frameInfo->layerCount < 2 && cv_drm_single_plane_optimizations;
+	bool bSinglePlane = frameInfo->layers.count() < 2 && cv_drm_single_plane_optimizations;
 
 	for ( int i = 0; i < k_nMaxLayers; i++ )
 	{
-		if ( i < frameInfo->layerCount )
+		if ( i < frameInfo->layers.count() )
 		{
-			const FrameInfo_t::Layer_t *pLayer = &frameInfo->layers[ i ];
+			const FrameInfo_t::Layer_t *pLayer = &frameInfo->layers.get( i );
 			gamescope::CDRMFb *pDrmFb = static_cast<gamescope::CDRMFb *>( (pLayer->tex && pLayer->tex->GetBackendFb()) ? pLayer->tex->GetBackendFb()->EnsureImported() : nullptr );
 
 			if ( pDrmFb == nullptr )
@@ -2657,11 +2657,11 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 			drm->m_FbIdsInRequest.emplace_back( pDrmFb );
 
 			liftoff_layer_set_property( drm->lo_layers[ i ], "zpos", entry.layerState[i].zpos );
-			liftoff_layer_set_property( drm->lo_layers[ i ], "alpha", frameInfo->layers[ i ].opacity * 0xffff);
+			liftoff_layer_set_property( drm->lo_layers[ i ], "alpha", frameInfo->layers.get( i ).opacity * 0xffff);
 
 			if ( entry.layerState[i].zpos != g_zposBase )
 			{
-				liftoff_layer_set_property( drm->lo_layers[ i ], "pixel blend mode", (uint64_t) frameInfo->layers[i].eAlphaBlendingMode );
+				liftoff_layer_set_property( drm->lo_layers[ i ], "pixel blend mode", (uint64_t) frameInfo->layers.get( i ).eAlphaBlendingMode );
 			}
 			else
 			{
@@ -2698,7 +2698,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_W", entry.layerState[i].crtcW);
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_H", entry.layerState[i].crtcH);
 
-			if ( frameInfo->layers[i].applyColorMgmt )
+			if ( frameInfo->layers.get( i ).applyColorMgmt )
 			{
 				bool bYCbCr = entry.layerState[i].ycbcr;
 
@@ -2780,8 +2780,8 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 				else
 					liftoff_layer_set_property( drm->lo_layers[ i ], "AMD_PLANE_BLEND_TF", AMDGPU_TRANSFER_FUNCTION_DEFAULT );
 
-				if (!cv_drm_debug_disable_ctm && frameInfo->layers[i].ctm != nullptr)
-					liftoff_layer_set_property( drm->lo_layers[ i ], "AMD_PLANE_CTM", frameInfo->layers[i].ctm->GetBlobValue() );
+				if (!cv_drm_debug_disable_ctm && frameInfo->layers.get( i ).ctm != nullptr)
+					liftoff_layer_set_property( drm->lo_layers[ i ], "AMD_PLANE_CTM", frameInfo->layers.get( i ).ctm->GetBlobValue() );
 				else
 					liftoff_layer_set_property( drm->lo_layers[ i ], "AMD_PLANE_CTM", 0 );
 			}
@@ -2824,7 +2824,7 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 	if ( ret == -EPERM && !attempted_in_fence_fallback && !cv_drm_debug_disable_in_fence_fd )
 	{
 		attempted_in_fence_fallback = true;
-		for ( int i = 0; i < frameInfo->layerCount; i++ )
+		for ( int i = 0; i < frameInfo->layers.count(); i++ )
 		{
 			liftoff_layer_set_property( drm->lo_layers[ i ], "IN_FENCE_FD", -1 );
 		}
@@ -2855,9 +2855,9 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo, boo
 	}
 
 	if ( ret == 0 )
-		drm_log.debugf( "can drm present %i layers", frameInfo->layerCount );
+		drm_log.debugf( "can drm present %i layers", frameInfo->layers.count() );
 	else
-		drm_log.debugf( "can NOT drm present %i layers", frameInfo->layerCount );
+		drm_log.debugf( "can NOT drm present %i layers", frameInfo->layers.count() );
 
 	return ret;
 }
@@ -2997,7 +2997,7 @@ int drm_prepare( struct drm_t *drm, bool async, const struct FrameInfo_t *frameI
 	assert( drm->req == nullptr );
 	drm->req = drmModeAtomicAlloc();
 
-	bool bSinglePlane = frameInfo->layerCount < 2 && cv_drm_single_plane_optimizations;
+	bool bSinglePlane = frameInfo->layers.count() < 2 && cv_drm_single_plane_optimizations;
 
 	if ( drm_supports_color_mgmt( &g_DRM ) && frameInfo->applyOutputColorMgmt )
 	{
@@ -3627,23 +3627,23 @@ namespace gamescope
 			drm_log.debugf( "CDRMBackend::Present Begin: %lu -> delta: %lu", ulNow, ulNow - s_ulLastTime );
 			s_ulLastTime = ulNow;
 
-			bool bWantsPartialComposite = pFrameInfo->layerCount >= 3 && !kDisablePartialComposition;
+			bool bWantsPartialComposite = pFrameInfo->layers.count() >= 3 && !kDisablePartialComposition;
 
 			static bool s_bWasFirstFrame = true;
 			bool bWasFirstFrame = s_bWasFirstFrame;
 			s_bWasFirstFrame = false;
 
 			bool bDrewCursor = false;
-			for ( uint32_t i = 0; i < k_nMaxLayers; i++ )
+			for ( int i = 0; i < pFrameInfo->layers.count(); i++ )
 			{
-				if ( pFrameInfo->layers[i].zpos == g_zposCursor )
+				if ( pFrameInfo->layers.get( i ).zpos == g_zposCursor )
 				{
 					bDrewCursor = true;
 					break;
 				}
 			}
 
-			bool bLayer0ScreenSize = close_enough(pFrameInfo->layers[0].scale.x, 1.0f) && close_enough(pFrameInfo->layers[0].scale.y, 1.0f);
+			bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
 			bool bNeedsCompositeFromFilter = (g_upscaleFilter == GamescopeUpscaleFilter::NEAREST || g_upscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
 
@@ -3663,12 +3663,12 @@ namespace gamescope
 			{
 				bNeedsFullComposite |= g_bHDRItmEnable;
 				if ( !SupportsColorManagement() )
-					bNeedsFullComposite |= ( pFrameInfo->layerCount > 1 || pFrameInfo->layers[0].colorspace != GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ );
+					bNeedsFullComposite |= ( pFrameInfo->layers.count() > 1 || pFrameInfo->layers.get( 0 ).colorspace != GAMESCOPE_APP_TEXTURE_COLORSPACE_HDR10_PQ );
 			}
 			else
 			{
 				if ( !SupportsColorManagement() )
-					bNeedsFullComposite |= ColorspaceIsHDR( pFrameInfo->layers[0].colorspace );
+					bNeedsFullComposite |= ColorspaceIsHDR( pFrameInfo->layers.get( 0 ).colorspace );
 			}
 
 			bNeedsFullComposite |= !!(g_uCompositeDebug & CompositeDebugFlag::Heatmap);
@@ -3697,8 +3697,8 @@ namespace gamescope
 				// Scanout + Planes Path
 				m_bWasPartialCompositing = false;
 				m_bWasCompositing = false;
-				if ( pFrameInfo->layerCount == 2 )
-					m_nLastSingleOverlayZPos = pFrameInfo->layers[1].zpos;
+				if ( pFrameInfo->layers.count() == 2 )
+					m_nLastSingleOverlayZPos = pFrameInfo->layers.get( 1 ).zpos;
 
 				return Commit( pFrameInfo );
 			}
@@ -3709,7 +3709,7 @@ namespace gamescope
 
 			FrameInfo_t compositeFrameInfo = *pFrameInfo;
 
-			if ( compositeFrameInfo.layerCount == 1 )
+			if ( compositeFrameInfo.layers.count() == 1 )
 			{
 				// If we failed to flip a single plane then
 				// we definitely need to composite for some reason...
@@ -3720,7 +3720,7 @@ namespace gamescope
 			{
 				// If we want to partial composite, fallback to full
 				// composite if we have mismatching colorspaces in our overlays.
-				// This is 2, and we do i-1 so 1...layerCount. So AFTER we have removed baseplane.
+				// This is 2, and we do i-1 so 1...layers.count(). So AFTER we have removed baseplane.
 				// Overlays only.
 				//
 				// Josh:
@@ -3731,9 +3731,9 @@ namespace gamescope
 				// We can't just point it to random BDA or whatever, it has to be uploaded slowly
 				// thru registers which is SUPER SLOW.
 				// This avoids stutter.
-				for ( int i = 2; i < compositeFrameInfo.layerCount; i++ )
+				for ( int i = 2; i < compositeFrameInfo.layers.count(); i++ )
 				{
-					if ( pFrameInfo->layers[i - 1].colorspace != pFrameInfo->layers[i].colorspace )
+					if ( pFrameInfo->layers.get( i - 1 ).colorspace != pFrameInfo->layers.get( i ).colorspace )
 					{
 						bNeedsFullComposite = true;
 						break;
@@ -3752,9 +3752,9 @@ namespace gamescope
 			// from our frameinfo to composite.
 			if ( !bNeedsFullComposite )
 			{
-				for ( int i = 1; i < compositeFrameInfo.layerCount; i++ )
-					compositeFrameInfo.layers[i - 1] = compositeFrameInfo.layers[i];
-				compositeFrameInfo.layerCount -= 1;
+				for ( int i = 1; i < compositeFrameInfo.layers.count(); i++ )
+					compositeFrameInfo.layers.get( i - 1 ) = compositeFrameInfo.layers.get( i );
+				compositeFrameInfo.layers.pop();
 
 				// When doing partial composition, apply the shaper + 3D LUT stuff
 				// at scanout.
@@ -3790,9 +3790,8 @@ namespace gamescope
 			if ( bNeedsFullComposite )
 			{
 				presentCompFrameInfo.applyOutputColorMgmt = false;
-				presentCompFrameInfo.layerCount = 1;
-
-				FrameInfo_t::Layer_t *baseLayer = &presentCompFrameInfo.layers[ 0 ];
+				FrameInfo_t::Layer_t *baseLayer = presentCompFrameInfo.layers.push();
+				assert( baseLayer );
 				baseLayer->scale.x = 1.0;
 				baseLayer->scale.y = 1.0;
 				baseLayer->opacity = 1.0;
@@ -3812,12 +3811,13 @@ namespace gamescope
 				if ( m_bWasPartialCompositing || !bDefer )
 				{
 					presentCompFrameInfo.applyOutputColorMgmt = g_ColorMgmt.pending.enabled;
-					presentCompFrameInfo.layerCount = 2;
+					FrameInfo_t::Layer_t *baseLayer = presentCompFrameInfo.layers.push();
+					assert( baseLayer );
+					*baseLayer = pFrameInfo->layers.get( 0 );
+					baseLayer->zpos = g_zposBase;
 
-					presentCompFrameInfo.layers[ 0 ] = pFrameInfo->layers[ 0 ];
-					presentCompFrameInfo.layers[ 0 ].zpos = g_zposBase;
-
-					FrameInfo_t::Layer_t *overlayLayer = &presentCompFrameInfo.layers[ 1 ];
+					FrameInfo_t::Layer_t *overlayLayer = presentCompFrameInfo.layers.push();
+					assert( overlayLayer );
 					overlayLayer->scale.x = 1.0;
 					overlayLayer->scale.y = 1.0;
 					overlayLayer->opacity = 1.0;
@@ -3830,35 +3830,34 @@ namespace gamescope
 					// Partial composition stuff has the same colorspace.
 					// So read that from the composite frame info
 					overlayLayer->ctm = nullptr;
-					overlayLayer->colorspace = compositeFrameInfo.layers[0].colorspace;
+					overlayLayer->colorspace = compositeFrameInfo.layers.get( 0 ).colorspace;
 				}
 				else
 				{
 					// Use whatever overlay we had last while waiting for the
 					// partial composition to have anything queued.
 					presentCompFrameInfo.applyOutputColorMgmt = g_ColorMgmt.pending.enabled;
-					presentCompFrameInfo.layerCount = 1;
-
-					presentCompFrameInfo.layers[ 0 ] = pFrameInfo->layers[ 0 ];
-					presentCompFrameInfo.layers[ 0 ].zpos = g_zposBase;
+					FrameInfo_t::Layer_t *baseLayer = presentCompFrameInfo.layers.push();
+					assert( baseLayer );
+					*baseLayer = pFrameInfo->layers.get( 0 );
+					baseLayer->zpos = g_zposBase;
 
 					const FrameInfo_t::Layer_t *lastPresentedOverlayLayer = nullptr;
-					for (int i = 0; i < pFrameInfo->layerCount; i++)
+					for (int i = 0; i < pFrameInfo->layers.count(); i++)
 					{
-						if ( pFrameInfo->layers[i].zpos == m_nLastSingleOverlayZPos )
+						if ( pFrameInfo->layers.get( i ).zpos == m_nLastSingleOverlayZPos )
 						{
-							lastPresentedOverlayLayer = &pFrameInfo->layers[i];
+							lastPresentedOverlayLayer = &pFrameInfo->layers.get( i );
 							break;
 						}
 					}
 
 					if ( lastPresentedOverlayLayer )
 					{
-						FrameInfo_t::Layer_t *overlayLayer = &presentCompFrameInfo.layers[ 1 ];
+						FrameInfo_t::Layer_t *overlayLayer = presentCompFrameInfo.layers.push();
+						assert( overlayLayer );
 						*overlayLayer = *lastPresentedOverlayLayer;
 						overlayLayer->zpos = g_zposOverlay;
-
-						presentCompFrameInfo.layerCount = 2;
 					}
 				}
 
@@ -4209,4 +4208,3 @@ int HackyDRMPresent( const FrameInfo_t *pFrameInfo, bool bAsync )
 {
 	return static_cast<gamescope::CDRMBackend *>( GetBackend() )->Present( pFrameInfo, bAsync );
 }
-

--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -1602,7 +1602,7 @@ namespace gamescope
         bool bNeedsFullComposite = false;
 
         // TODO: Dedupe some of this composite check code between us and drm.cpp
-        bool bLayer0ScreenSize = close_enough(pFrameInfo->layers[0].scale.x, 1.0f) && close_enough(pFrameInfo->layers[0].scale.y, 1.0f);
+        bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
         bool bNeedsCompositeFromFilter = (g_upscaleFilter == GamescopeUpscaleFilter::NEAREST || g_upscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
 
@@ -1620,7 +1620,7 @@ namespace gamescope
             bNeedsFullComposite |= g_bHDRItmEnable;
 
         if ( !m_pBackend->SupportsColorManagement() )
-            bNeedsFullComposite |= ColorspaceIsHDR( pFrameInfo->layers[0].colorspace );
+            bNeedsFullComposite |= ColorspaceIsHDR( pFrameInfo->layers.get( 0 ).colorspace );
 
         bNeedsFullComposite |= !!(g_uCompositeDebug & CompositeDebugFlag::Heatmap);
 
@@ -1632,9 +1632,9 @@ namespace gamescope
         if ( !bNeedsFullComposite )
         {
             bool bNeedsBacking = true;
-            if ( pFrameInfo->layerCount >= 1 )
+            if ( pFrameInfo->layers.count() >= 1 )
             {
-                if ( pFrameInfo->layers[0].isScreenSize() && ( !pFrameInfo->layers[0].hasAlpha() || cv_vr_transparent_backing ) )
+                if ( pFrameInfo->layers.get( 0 ).isScreenSize() && ( !pFrameInfo->layers.get( 0 ).hasAlpha() || cv_vr_transparent_backing ) )
                     bNeedsBacking = false;
             }
 
@@ -1660,7 +1660,7 @@ namespace gamescope
 
             for ( int i = 0; i < 8 && uCurrentPlane < 8; i++ )
             {
-                const FrameInfo_t::Layer_t *pLayer = i < pFrameInfo->layerCount ? &pFrameInfo->layers[i] : nullptr;
+                const FrameInfo_t::Layer_t *pLayer = i < pFrameInfo->layers.count() ? &pFrameInfo->layers.get( i ) : nullptr;
                 if ( pLayer && pLayer->zpos == g_zposCursor )
                 {
                     bool bUsingPhysicalMouse = m_pBackend->GetCurrentMouseConnector() == this && !m_bUsingVRMouse;

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -1065,7 +1065,7 @@ namespace gamescope
         else
         {
             // TODO: Dedupe some of this composite check code between us and drm.cpp
-            bool bLayer0ScreenSize = close_enough(pFrameInfo->layers[0].scale.x, 1.0f) && close_enough(pFrameInfo->layers[0].scale.y, 1.0f);
+            bool bLayer0ScreenSize = close_enough(pFrameInfo->layers.get( 0 ).scale.x, 1.0f) && close_enough(pFrameInfo->layers.get( 0 ).scale.y, 1.0f);
 
             bool bNeedsCompositeFromFilter = (g_upscaleFilter == GamescopeUpscaleFilter::NEAREST || g_upscaleFilter == GamescopeUpscaleFilter::PIXEL) && !bLayer0ScreenSize;
 
@@ -1082,19 +1082,19 @@ namespace gamescope
                 bNeedsFullComposite |= g_bHDRItmEnable;
 
             if ( !m_pBackend->SupportsColorManagement() )
-                bNeedsFullComposite |= ColorspaceIsHDR( pFrameInfo->layers[0].colorspace );
+                bNeedsFullComposite |= ColorspaceIsHDR( pFrameInfo->layers.get( 0 ).colorspace );
 
             bNeedsFullComposite |= !!(g_uCompositeDebug & CompositeDebugFlag::Heatmap);
 
             if ( !bNeedsFullComposite )
             {
                 bool bNeedsBacking = true;
-                if ( pFrameInfo->layerCount >= 1 )
+                if ( pFrameInfo->layers.count() >= 1 )
                 {
-                    if ( pFrameInfo->layers[0].isScreenSize() &&
-                         close_enough( pFrameInfo->layers[0].offset.x, 0.0f ) &&
-                         close_enough( pFrameInfo->layers[0].offset.y, 0.0f ) &&
-                         !pFrameInfo->layers[0].hasAlpha() )
+                    if ( pFrameInfo->layers.get( 0 ).isScreenSize() &&
+                         close_enough( pFrameInfo->layers.get( 0 ).offset.x, 0.0f ) &&
+                         close_enough( pFrameInfo->layers.get( 0 ).offset.y, 0.0f ) &&
+                         !pFrameInfo->layers.get( 0 ).hasAlpha() )
                         bNeedsBacking = false;
                 }
 
@@ -1119,7 +1119,7 @@ namespace gamescope
                 }
 
                 for ( int i = 0; i < 8 && uCurrentPlane < 8; i++ )
-                    m_Planes[uCurrentPlane++].Present( i < pFrameInfo->layerCount ? &pFrameInfo->layers[i] : nullptr );
+                    m_Planes[uCurrentPlane++].Present( i < pFrameInfo->layers.count() ? &pFrameInfo->layers.get( i ) : nullptr );
             }
             else
             {

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -3742,8 +3742,8 @@ struct BlitPushData_t
 		u_alphaMode = 0;
 		u_rotation = rotation;
 
-		for (int i = 0; i < frameInfo->layerCount; i++) {
-			const FrameInfo_t::Layer_t *layer = &frameInfo->layers[i];
+		for (int i = 0; i < frameInfo->layers.count(); i++) {
+			const FrameInfo_t::Layer_t *layer = &frameInfo->layers.get( i );
 			scale[i] = layer->scale;
 			offset[i] = layer->offsetPixelCenter();
 			opacity[i] = layer->opacity;
@@ -3879,17 +3879,17 @@ struct RcasPushData_t
 		uvec4_t tmp;
 		FsrRcasCon(&tmp.x, sharpness);
 		u_rotation = rotation;
-		u_layer0Offset.x = uint32_t(int32_t(frameInfo->layers[0].offset.x));
-		u_layer0Offset.y = uint32_t(int32_t(frameInfo->layers[0].offset.y));
+		u_layer0Offset.x = uint32_t(int32_t(frameInfo->layers.get( 0 ).offset.x));
+		u_layer0Offset.y = uint32_t(int32_t(frameInfo->layers.get( 0 ).offset.y));
 		u_borderMask = frameInfo->borderMask() >> 1u;
 		u_frameId = s_frameId++;
 		u_c1 = tmp.x;
 		u_shaderFilter = 0;
 		u_alphaMode = 0;
 
-		for (int i = 0; i < frameInfo->layerCount; i++)
+		for (int i = 0; i < frameInfo->layers.count(); i++)
 		{
-			const FrameInfo_t::Layer_t *layer = &frameInfo->layers[i];
+			const FrameInfo_t::Layer_t *layer = &frameInfo->layers.get( i );
 
             if (i == 0 || layer->isScreenSize() || (layer->filter == GamescopeUpscaleFilter::LINEAR && layer->viewConvertsToLinearAutomatically()))
                 u_shaderFilter |= ((uint32_t)GamescopeUpscaleFilter::FROM_VIEW) << (i * 4);
@@ -3912,7 +3912,7 @@ struct RcasPushData_t
 				};
 			}
 
-			u_opacity[i] = frameInfo->layers[i].opacity;
+			u_opacity[i] = frameInfo->layers.get( i ).opacity;
 		}
 
 		u_linearToNits = g_flInternalDisplayBrightnessNits;
@@ -3920,10 +3920,10 @@ struct RcasPushData_t
 		u_itmSdrNits = g_flHDRItmSdrNits;
 		u_itmTargetNits = g_flHDRItmTargetNits;
 
-		for (uint32_t i = 1; i < k_nMaxLayers; i++)
+		for (int i = 1; i < frameInfo->layers.count(); i++)
 		{
-			u_scale[i - 1] = frameInfo->layers[i].scale;
-			u_offset[i - 1] = frameInfo->layers[i].offsetPixelCenter();
+			u_scale[i - 1] = frameInfo->layers.get( i ).scale;
+			u_offset[i - 1] = frameInfo->layers.get( i ).offsetPixelCenter();
 		}
 	}
 };
@@ -3948,9 +3948,9 @@ struct NisPushData_t
 
 void bind_all_layers(CVulkanCmdBuffer* cmdBuffer, const struct FrameInfo_t *frameInfo)
 {
-	for ( int i = 0; i < frameInfo->layerCount; i++ )
+	for ( int i = 0; i < frameInfo->layers.count(); i++ )
 	{
-		const FrameInfo_t::Layer_t *layer = &frameInfo->layers[i];
+		const FrameInfo_t::Layer_t *layer = &frameInfo->layers.get( i );
 
 		bool nearest = layer->isScreenSize()
                     || layer->filter == GamescopeUpscaleFilter::NEAREST
@@ -3961,7 +3961,7 @@ void bind_all_layers(CVulkanCmdBuffer* cmdBuffer, const struct FrameInfo_t *fram
 		cmdBuffer->setSamplerNearest(i, nearest);
 		cmdBuffer->setSamplerUnnormalized(i, true);
 	}
-	for (uint32_t i = frameInfo->layerCount; i < VKR_SAMPLER_SLOTS; i++)
+	for (uint32_t i = frameInfo->layers.count(); i < VKR_SAMPLER_SLOTS; i++)
 	{
 		cmdBuffer->bindTexture(i, nullptr);
 	}
@@ -3978,7 +3978,7 @@ std::optional<uint64_t> vulkan_screenshot( const struct FrameInfo_t *frameInfo, 
 	for (uint32_t i = 0; i < EOTF_Count; i++)
 		cmdBuffer->bindColorMgmtLuts(i, frameInfo->shaperLut[i], frameInfo->lut3D[i]);
 
-	cmdBuffer->bindPipeline( g_device.pipeline(SHADER_TYPE_BLIT, frameInfo->layerCount, frameInfo->ycbcrMask(), 0u, frameInfo->colorspaceMask(), outputTF ));
+	cmdBuffer->bindPipeline( g_device.pipeline(SHADER_TYPE_BLIT, frameInfo->layers.count(), frameInfo->ycbcrMask(), 0u, frameInfo->colorspaceMask(), outputTF ));
 	bind_all_layers(cmdBuffer.get(), frameInfo);
 	cmdBuffer->bindTarget(pScreenshotTexture);
 	cmdBuffer->uploadConstants<BlitPushData_t>(frameInfo);
@@ -4036,15 +4036,15 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 	g_pLastReshadeEffect = nullptr;
 	if (!g_reshade_effect.empty())
 	{
-		if (frameInfo->layers[0].tex)
+		if (frameInfo->layers.get( 0 ).tex)
 		{
 			ReshadeEffectKey key
 			{
 				.path             = g_reshade_effect,
-				.bufferWidth      = frameInfo->layers[0].tex->width(),
-				.bufferHeight     = frameInfo->layers[0].tex->height(),
-				.bufferColorSpace = frameInfo->layers[0].colorspace,
-				.bufferFormat     = frameInfo->layers[0].tex->format(),
+				.bufferWidth      = frameInfo->layers.get( 0 ).tex->width(),
+				.bufferHeight     = frameInfo->layers.get( 0 ).tex->height(),
+				.bufferColorSpace = frameInfo->layers.get( 0 ).colorspace,
+				.bufferFormat     = frameInfo->layers.get( 0 ).tex->format(),
 				.techniqueIdx     = g_reshade_technique_idx,
 			};
 
@@ -4053,7 +4053,7 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 			if (pipeline != nullptr)
 			{
-				uint64_t seq = pipeline->execute(frameInfo->layers[0].tex, &frameInfo->layers[0].tex);
+				uint64_t seq = pipeline->execute(frameInfo->layers.get( 0 ).tex, &frameInfo->layers.get( 0 ).tex);
 				g_device.wait(seq);
 			}
 		}
@@ -4079,17 +4079,17 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 	if ( frameInfo->useFSRLayer0 )
 	{
-		uint32_t inputX = frameInfo->layers[0].tex->width();
-		uint32_t inputY = frameInfo->layers[0].tex->height();
+		uint32_t inputX = frameInfo->layers.get( 0 ).tex->width();
+		uint32_t inputY = frameInfo->layers.get( 0 ).tex->height();
 
-		uint32_t tempX = frameInfo->layers[0].integerWidth();
-		uint32_t tempY = frameInfo->layers[0].integerHeight();
+		uint32_t tempX = frameInfo->layers.get( 0 ).integerWidth();
+		uint32_t tempY = frameInfo->layers.get( 0 ).integerHeight();
 
 		update_tmp_images(tempX, tempY);
 
 		cmdBuffer->bindPipeline(g_device.pipeline(SHADER_TYPE_EASU));
 		cmdBuffer->bindTarget(g_output.tmpOutput);
-		cmdBuffer->bindTexture(0, frameInfo->layers[0].tex);
+		cmdBuffer->bindTexture(0, frameInfo->layers.get( 0 ).tex);
 		cmdBuffer->setTextureSrgb(0, true);
 		cmdBuffer->setSamplerUnnormalized(0, false);
 		cmdBuffer->setSamplerNearest(0, false);
@@ -4099,7 +4099,7 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 		cmdBuffer->dispatch(div_roundup(tempX, pixelsPerGroup), div_roundup(tempY, pixelsPerGroup));
 
-		cmdBuffer->bindPipeline(g_device.pipeline(SHADER_TYPE_RCAS, frameInfo->layerCount, frameInfo->ycbcrMask() & ~1, 0u, frameInfo->colorspaceMask(), outputTF ));
+		cmdBuffer->bindPipeline(g_device.pipeline(SHADER_TYPE_RCAS, frameInfo->layers.count(), frameInfo->ycbcrMask() & ~1, 0u, frameInfo->colorspaceMask(), outputTF ));
 		bind_all_layers(cmdBuffer.get(), frameInfo);
 		cmdBuffer->bindTexture(0, g_output.tmpOutput);
 		cmdBuffer->setTextureSrgb(0, true);
@@ -4112,11 +4112,11 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 	}
 	else if ( frameInfo->useNISLayer0 )
 	{
-		uint32_t inputX = frameInfo->layers[0].tex->width();
-		uint32_t inputY = frameInfo->layers[0].tex->height();
+		uint32_t inputX = frameInfo->layers.get( 0 ).tex->width();
+		uint32_t inputY = frameInfo->layers.get( 0 ).tex->height();
 
-		uint32_t tempX = frameInfo->layers[0].integerWidth();
-		uint32_t tempY = frameInfo->layers[0].integerHeight();
+		uint32_t tempX = frameInfo->layers.get( 0 ).integerWidth();
+		uint32_t tempY = frameInfo->layers.get( 0 ).integerHeight();
 
 		update_tmp_images(tempX, tempY);
 
@@ -4124,7 +4124,7 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 		cmdBuffer->bindPipeline(g_device.pipeline(SHADER_TYPE_NIS));
 		cmdBuffer->bindTarget(g_output.tmpOutput);
-		cmdBuffer->bindTexture(0, frameInfo->layers[0].tex);
+		cmdBuffer->bindTexture(0, frameInfo->layers.get( 0 ).tex);
 		cmdBuffer->setTextureSrgb(0, true);
 		cmdBuffer->setSamplerUnnormalized(0, false);
 		cmdBuffer->setSamplerNearest(0, false);
@@ -4142,11 +4142,11 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 		cmdBuffer->dispatch(div_roundup(tempX, pixelsPerGroupX), div_roundup(tempY, pixelsPerGroupY));
 
 		struct FrameInfo_t nisFrameInfo = *frameInfo;
-		nisFrameInfo.layers[0].tex = g_output.tmpOutput;
-		nisFrameInfo.layers[0].scale.x = 1.0f;
-		nisFrameInfo.layers[0].scale.y = 1.0f;
+		nisFrameInfo.layers.get( 0 ).tex = g_output.tmpOutput;
+		nisFrameInfo.layers.get( 0 ).scale.x = 1.0f;
+		nisFrameInfo.layers.get( 0 ).scale.y = 1.0f;
 
-		cmdBuffer->bindPipeline( g_device.pipeline(SHADER_TYPE_BLIT, nisFrameInfo.layerCount, nisFrameInfo.ycbcrMask(), 0u, nisFrameInfo.colorspaceMask(), outputTF ));
+		cmdBuffer->bindPipeline( g_device.pipeline(SHADER_TYPE_BLIT, nisFrameInfo.layers.count(), nisFrameInfo.ycbcrMask(), 0u, nisFrameInfo.colorspaceMask(), outputTF ));
 		bind_all_layers(cmdBuffer.get(), &nisFrameInfo);
 		cmdBuffer->bindTarget(compositeImage);
 		cmdBuffer->uploadConstants<BlitPushData_t>(&nisFrameInfo, uOutputRotation);
@@ -4163,14 +4163,14 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 		uint32_t blur_layer_count = 1;
 		// Also blur the override on top if we have one.
-		if (frameInfo->layerCount >= 2 && frameInfo->layers[1].zpos == g_zposOverride)
+		if (frameInfo->layers.count() >= 2 && frameInfo->layers.get( 1 ).zpos == g_zposOverride)
 			blur_layer_count++;
 
 		cmdBuffer->bindPipeline(g_device.pipeline(type, blur_layer_count, frameInfo->ycbcrMask() & 0x3u, 0, frameInfo->colorspaceMask(), outputTF ));
 		cmdBuffer->bindTarget(g_output.tmpOutput);
 		for (uint32_t i = 0; i < blur_layer_count; i++)
 		{
-			cmdBuffer->bindTexture(i, frameInfo->layers[i].tex);
+			cmdBuffer->bindTexture(i, frameInfo->layers.get( i ).tex);
 			cmdBuffer->setTextureSrgb(i, false);
 			cmdBuffer->setSamplerUnnormalized(i, true);
 			cmdBuffer->setSamplerNearest(i, false);
@@ -4181,10 +4181,10 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 		cmdBuffer->dispatch(div_roundup(currentOutputWidth, pixelsPerGroup), div_roundup(currentOutputHeight, pixelsPerGroup));
 
-		bool useSrgbView = frameInfo->layers[0].colorspace == GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR;
+		bool useSrgbView = frameInfo->layers.get( 0 ).colorspace == GAMESCOPE_APP_TEXTURE_COLORSPACE_LINEAR;
 
 		type = frameInfo->blurLayer0 == BLUR_MODE_COND ? SHADER_TYPE_BLUR_COND : SHADER_TYPE_BLUR;
-		cmdBuffer->bindPipeline(g_device.pipeline(type, frameInfo->layerCount, frameInfo->ycbcrMask(), blur_layer_count, frameInfo->colorspaceMask(), outputTF ));
+		cmdBuffer->bindPipeline(g_device.pipeline(type, frameInfo->layers.count(), frameInfo->ycbcrMask(), blur_layer_count, frameInfo->colorspaceMask(), outputTF ));
 		bind_all_layers(cmdBuffer.get(), frameInfo);
 		cmdBuffer->bindTarget(compositeImage);
 		cmdBuffer->bindTexture(VKR_BLUR_EXTRA_SLOT, g_output.tmpOutput);
@@ -4196,7 +4196,7 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 	}
 	else
 	{
-		cmdBuffer->bindPipeline( g_device.pipeline(SHADER_TYPE_BLIT, frameInfo->layerCount, frameInfo->ycbcrMask(), 0u, frameInfo->colorspaceMask(), outputTF ));
+		cmdBuffer->bindPipeline( g_device.pipeline(SHADER_TYPE_BLIT, frameInfo->layers.count(), frameInfo->ycbcrMask(), 0u, frameInfo->colorspaceMask(), outputTF ));
 		bind_all_layers(cmdBuffer.get(), frameInfo);
 		cmdBuffer->bindTarget(compositeImage);
 		cmdBuffer->uploadConstants<BlitPushData_t>(frameInfo, uOutputRotation);

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -293,7 +293,6 @@ struct FrameInfo_t
 	bool applyOutputColorMgmt; // drm only
 	EOTF outputEncodingEOTF;
 
-	int layerCount;
 	struct Layer_t
 	{
 		gamescope::Rc<CVulkanTexture> tex;
@@ -356,31 +355,73 @@ struct FrameInfo_t
 			float y = offset.y + 0.5f / scale.y;
 			return { x, y };
 		}
-	} layers[ k_nMaxLayers ];
+	};
+
+	class LayerStack_t
+	{
+	public:
+		Layer_t *push()
+		{
+			if ( m_nCount >= k_nMaxLayers )
+				return nullptr;
+
+			return &m_Layers[ m_nCount++ ];
+		}
+
+		void pop()
+		{
+			assert( m_nCount > 0 );
+			m_nCount--;
+		}
+
+		void truncate( int nCount )
+		{
+			assert( nCount >= 0 && nCount <= m_nCount );
+			m_nCount = nCount;
+		}
+
+		int count() const { return m_nCount; }
+
+		Layer_t &get( int nIndex )
+		{
+			assert( nIndex >= 0 && nIndex < m_nCount );
+			return m_Layers[ nIndex ];
+		}
+
+		const Layer_t &get( int nIndex ) const
+		{
+			assert( nIndex >= 0 && nIndex < m_nCount );
+			return m_Layers[ nIndex ];
+		}
+
+	private:
+		Layer_t m_Layers[ k_nMaxLayers ];
+		int m_nCount = 0;
+	} layers;
 
 	uint32_t borderMask() const {
 		uint32_t result = 0;
-		for (int i = 0; i < layerCount; i++)
+		for (int i = 0; i < layers.count(); i++)
 		{
-			if (layers[ i ].blackBorder)
+			if (layers.get( i ).blackBorder)
 				result |= 1 << i;
 		}
 		return result;
 	}
 	uint32_t ycbcrMask() const {
 		uint32_t result = 0;
-		for (int i = 0; i < layerCount; i++)
+		for (int i = 0; i < layers.count(); i++)
 		{
-			if (layers[ i ].isYcbcr())
+			if (layers.get( i ).isYcbcr())
 				result |= 1 << i;
 		}
 		return result;
 	}
 	uint32_t colorspaceMask() const {
 		uint32_t result = 0;
-		for (int i = 0; i < layerCount; i++)
+		for (int i = 0; i < layers.count(); i++)
 		{
-result |= layers[ i ].colorspace << (i * GamescopeAppTextureColorspace_Bits);
+			result |= layers.get( i ).colorspace << (i * GamescopeAppTextureColorspace_Bits);
 		}
 		return result;
 	}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2309,6 +2309,8 @@ static void update_touch_scaling( const struct FrameInfo_t *frameInfo )
 }
 
 #if HAVE_PIPEWIRE
+static void pick_decoration_windows( focus_t *pFocus );
+
 static void paint_pipewire()
 {
 	static struct pipewire_buffer *s_pPipewireBuffer = nullptr;
@@ -2362,6 +2364,7 @@ static void paint_pipewire()
 
 			std::vector<uint32_t> vecAppIds{ uint32_t( ulFocusAppId ) };
 			pick_primary_focus_and_override( &s_PipewireFocus, None, vecPossibleFocusWindows, false, vecAppIds, 0, gamescope::VirtualConnectorStrategies::SteamControlled );
+			pick_decoration_windows( &s_PipewireFocus );
 		}
 		pFocus = &s_PipewireFocus;
 	}
@@ -2380,16 +2383,25 @@ static void paint_pipewire()
 	// If the commits are the same as they were last time, don't repaint and don't push a new buffer on the stream.
 	static uint64_t s_ulLastFocusCommitId = 0;
 	static uint64_t s_ulLastOverrideCommitId = 0;
+	static uint64_t s_ulLastDecorationCommitId = 0;
 
 	uint64_t ulFocusCommitId = window_last_done_commit_id( pFocus->focusWindow );
 	uint64_t ulOverrideCommitId = window_last_done_commit_id( pFocus->overrideWindow );
 
+	// Combine the decoration commits so damage to any of them, or a change
+	// in the set itself, pushes a new frame.
+	uint64_t ulDecorationCommitId = 0;
+	for ( steamcompmgr_win_t *decoration : pFocus->decorationWindows )
+		ulDecorationCommitId = ulDecorationCommitId * 31 + window_last_done_commit_id( decoration );
+
 	if ( ulFocusCommitId == s_ulLastFocusCommitId &&
-	     ulOverrideCommitId == s_ulLastOverrideCommitId )
+	     ulOverrideCommitId == s_ulLastOverrideCommitId &&
+	     ulDecorationCommitId == s_ulLastDecorationCommitId )
 		return;
 
 	s_ulLastFocusCommitId = ulFocusCommitId;
 	s_ulLastOverrideCommitId = ulOverrideCommitId;
+	s_ulLastDecorationCommitId = ulDecorationCommitId;
 
 	uint32_t uWidth = s_pPipewireBuffer->texture->width();
 	uint32_t uHeight = s_pPipewireBuffer->texture->height();
@@ -2407,6 +2419,21 @@ static void paint_pipewire()
 
 	if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
 		paint_window( pFocus->overrideWindow, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
+
+	if ( !pFocus->focusWindow->isSteamStreamingClient )
+	{
+		// Leave room for the overlay painted below.
+		const int nReservedLayers = ( !ulFocusAppId && pFocus->overlayWindow && pFocus->overlayWindow->opacity ) ? 1 : 0;
+
+		for ( steamcompmgr_win_t *decoration : pFocus->decorationWindows )
+		{
+			if ( frameInfo.layers.count() >= k_nMaxLayers - nReservedLayers )
+				break;
+
+			if ( decoration->opacity )
+				paint_window( decoration, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, decoration );
+		}
+	}
 
 	if ( !ulFocusAppId && pFocus->overlayWindow && pFocus->overlayWindow->opacity )
 	{
@@ -2659,6 +2686,36 @@ paint_all( global_focus_t *pFocus, bool async )
 		// wlserver_mousefocus window.
 		//update_touch_scaling( &frameInfo );
 	}
+
+	// Decorations (eg. Xalia's highlight) paint like overrides, above them.
+	if ( w && !w->isSteamStreamingClient && cv_paint_override_redirect_plane )
+	{
+		// Leave room for the layers painted after decorations, so a pile of
+		// helper windows cannot push out the Steam overlay or the cursor.
+		// The mura plane is not reserved and yields when the frame is full.
+		int nReservedLayers = 1; // cursor
+		if ( externalOverlay && externalOverlay->opacity && cv_paint_external_overlay_plane )
+			nReservedLayers++;
+		if ( cv_paint_steam_overlay_plane &&
+			 ( ( overlay && overlay->opacity ) ||
+			   ( !GetBackend()->UsesVulkanSwapchain() && GetBackend()->IsSessionBased() ) ) )
+			nReservedLayers++;
+		if ( notification && notification->opacity )
+			nReservedLayers++;
+
+		for ( steamcompmgr_win_t *decoration : pFocus->decorationWindows )
+		{
+			if ( frameInfo.layers.count() >= k_nMaxLayers - nReservedLayers )
+			{
+				focus_log.debugf( "Dropping remaining decoration windows, out of layers" );
+				break;
+			}
+
+			if ( decoration->opacity )
+				paint_window( decoration, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, decoration );
+		}
+	}
+
 	// If we have any layers that aren't a cursor or overlay, then we have valid contents for presentation.
 	const bool bValidContents = frameInfo.layers.count() > 0;
 
@@ -2966,6 +3023,14 @@ paint_all( global_focus_t *pFocus, bool async )
 				paint_window( pFocus->focusWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, 0, 1.0f, pFocus->overrideWindow );
 				if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
 					paint_window( pFocus->overrideWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
+				if ( !pFocus->focusWindow->isSteamStreamingClient )
+				{
+					for ( steamcompmgr_win_t *decoration : pFocus->decorationWindows )
+					{
+						if ( decoration->opacity )
+							paint_window( decoration, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, decoration );
+					}
+				}
 
 				oScreenshotSeq = vulkan_screenshot( &screenshotFrameInfo, pScreenshotTexture, nullptr );
 
@@ -3502,6 +3567,25 @@ is_focus_priority_greater( steamcompmgr_win_t *a, steamcompmgr_win_t *b )
 	return false;
 }
 
+static bool windows_share_app( steamcompmgr_win_t *a, steamcompmgr_win_t *b )
+{
+	return ( a->appID != 0 && a->appID == b->appID ) ||
+		( a->steamAppID != 0 && a->steamAppID == b->steamAppID );
+}
+
+static bool is_same_app_override_decoration( steamcompmgr_win_t *candidate, steamcompmgr_win_t *focus )
+{
+	if ( !focus || candidate->pid == focus->pid || !windows_share_app( candidate, focus ) )
+		return false;
+
+	// Xalia's cross-process highlight is a non-interactive, transparent layered
+	// popup. Keep it out of the input-bearing override slot without rejecting
+	// cross-process popups such as WebView2 dropdowns.
+	const uint32_t uDecorationStyle = WS_EX_LAYERED | WS_EX_TRANSPARENT;
+	return win_is_override_redirect( candidate ) && candidate->hasHwndStyleEx &&
+		( candidate->hwndStyleEx & uDecorationStyle ) == uDecorationStyle;
+}
+
 static bool is_good_override_candidate( steamcompmgr_win_t *override, steamcompmgr_win_t* focus )
 {
 	// Some Chrome/Edge dropdowns (ie. FH5 xbox login) will automatically close themselves if you
@@ -3510,14 +3594,54 @@ static bool is_good_override_candidate( steamcompmgr_win_t *override, steamcompm
 	if ( !focus )
 		return false;
 
-	// The pids should probably match for a dropdown to be a good candidate for this window,
-	// unless a non-zero appID says they are the same app (eg. Xalia's highlight overlay).
-	if (override->pid != focus->pid && (focus->appID == 0 || override->appID != focus->appID))
+	auto rect = override->GetGeometry();
+
+	// Non-interactive same-app helpers get painted as decorations instead.
+	// Other same-app cross-process popups still need the override's input path.
+	if ( is_same_app_override_decoration( override, focus ) )
 		return false;
 
-	auto rect = override->GetGeometry();
+	if ( override->pid != focus->pid && !windows_share_app( override, focus ) )
+		return false;
+
 	return override != focus && (rect.nX + rect.nWidth) > 0 && (rect.nY + rect.nHeight) > 0;
-} 
+}
+
+// Same-app override-redirect windows from another process (eg. Xalia's
+// highlight overlay) are decorations, not dropdowns. Paint them on top of
+// the focused window so they coexist with its popups instead of fighting
+// them for the override slot.
+static void pick_decoration_windows( focus_t *pFocus )
+{
+	pFocus->decorationWindows.clear();
+
+	if ( !pFocus->focusWindow || pFocus->focusWindow->type != steamcompmgr_win_type_t::XWAYLAND )
+		return;
+
+	xwayland_ctx_t *pFocusCtx = pFocus->focusWindow->xwayland().ctx;
+	for ( steamcompmgr_win_t *w = pFocusCtx->list; w; w = w->xwayland().next )
+	{
+		if ( !is_same_app_override_decoration( w, pFocus->focusWindow ) || w == pFocus->overrideWindow )
+			continue;
+
+		if ( w->isOverlay || w->isExternalOverlay )
+			continue;
+
+		if ( w->xwayland().a.map_state != IsViewable || w->xwayland().a.c_class != InputOutput ||
+			 w->opacity <= TRANSLUCENT )
+			continue;
+
+		// Skip helpers parked off-screen.
+		auto rect = w->GetGeometry();
+		if ( rect.nX + rect.nWidth <= 0 || rect.nY + rect.nHeight <= 0 )
+			continue;
+
+		pFocus->decorationWindows.push_back( w );
+	}
+
+	// ctx->list runs top to bottom, we paint the other way.
+	std::reverse( pFocus->decorationWindows.begin(), pFocus->decorationWindows.end() );
+}
 
 static void
 handle_desktop_window(steamcompmgr_win_t *w);
@@ -4258,6 +4382,11 @@ determine_and_apply_focus( global_focus_t *pFocus )
 		pFocus->externalOverlayWindow = g_steamcompmgr_xdg_focus.externalOverlayWindow;
 	}
 
+	pick_decoration_windows( pFocus );
+
+	if ( pFocus->decorationWindows != previousLocalFocus.decorationWindows )
+		hasRepaintNonBasePlane = true;
+
 	bool bUseOverlay = gamescope::VirtualConnectorIsSingleOutput() || gamescope::VirtualConnectorKeyIsSteam( pFocus->ulVirtualFocusKey );
 	if ( !bUseOverlay )
 	{
@@ -4295,6 +4424,7 @@ determine_and_apply_focus( global_focus_t *pFocus )
 					pFocus->keyboardFocusWindow = queryWindow;
 
 					pFocus->overrideWindow = nullptr;
+					pFocus->decorationWindows.clear();
 				}
 
 				if ( queryWindow->oulTargetVROverlay && *queryWindow->oulTargetVROverlay == ulFocusedMouseOverlayVR )
@@ -4305,6 +4435,7 @@ determine_and_apply_focus( global_focus_t *pFocus )
 					//pFocus->inputFocusWindow = queryWindow;
 
 					pFocus->overrideWindow = nullptr;
+					pFocus->decorationWindows.clear();
 				}
 			}
 		}
@@ -4835,10 +4966,11 @@ map_win(xwayland_ctx_t* ctx, Window id, unsigned long sequence)
 
 	w->isSteamStreamingClient = get_prop(ctx, w->xwayland().id, ctx->atoms.steamStreamingClientAtom, 0);
 	w->isSteamStreamingClientVideo = get_prop(ctx, w->xwayland().id, ctx->atoms.steamStreamingClientVideoAtom, 0);
+	w->steamAppID = get_prop(ctx, w->xwayland().id, ctx->atoms.gameAtom, 0);
 
 	if ( steamMode == true )
 	{
-		uint32_t appID = get_prop(ctx, w->xwayland().id, ctx->atoms.gameAtom, 0);
+		uint32_t appID = w->steamAppID;
 
 		if ( w->appID != 0 && appID != 0 && w->appID != appID )
 		{
@@ -5421,6 +5553,8 @@ destroy_win(xwayland_ctx_t *ctx, Window id, bool gone, bool fade)
 			pFocus->overrideWindow = nullptr;
 		if (x11_win(pFocus->fadeWindow) == id && gone)
 			pFocus->fadeWindow = nullptr;
+		if (gone)
+			std::erase_if(pFocus->decorationWindows, [id](steamcompmgr_win_t *w) { return x11_win(w) == id; });
 	}
 		
 	MakeFocusDirty();
@@ -6074,6 +6208,7 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 		if (w)
 		{
 			uint32_t appID = get_prop(ctx, w->xwayland().id, ctx->atoms.gameAtom, 0);
+			w->steamAppID = appID;
 
 			if ( w->appID != 0 && appID != 0 && w->appID != appID )
 			{
@@ -6680,6 +6815,12 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 					pFocus->overrideWindow->xwayland().ctx == server->ctx.get())
 					pFocus->overrideWindow = nullptr;
 
+				std::erase_if(pFocus->decorationWindows, [&](steamcompmgr_win_t *pDecoration)
+				{
+					return pDecoration->type == steamcompmgr_win_type_t::XWAYLAND &&
+						pDecoration->xwayland().ctx == server->ctx.get();
+				});
+
 				if (pFocus->keyboardFocusWindow &&
 					pFocus->keyboardFocusWindow->type == steamcompmgr_win_type_t::XWAYLAND &&
 					pFocus->keyboardFocusWindow->xwayland().ctx == server->ctx.get())
@@ -6948,7 +7089,8 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 					focusWindow_pid = w->pid;
 				}
 
-				if ( w == pFocus->overrideWindow )
+				if ( w == pFocus->overrideWindow ||
+					 std::find( pFocus->decorationWindows.begin(), pFocus->decorationWindows.end(), w ) != pFocus->decorationWindows.end() )
 				{
 					hasRepaintNonBasePlane = true;
 				}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4031,10 +4031,8 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 
 	pick_primary_focus_and_override( &ctx->focus, ctx->focusControlWindow, vecPossibleFocusWindows, false, vecFocuscontrolAppIDs, ulKey, eStrategy );
 
-	if ( !ctx->focus.overrideWindowMouse )
-	{
-		ctx->focus.overrideWindowMouse = ctx->focus.overrideWindow;
-	}
+	// The VR mouse connector path below may pick a different mouse override.
+	ctx->focus.overrideWindowMouse = ctx->focus.overrideWindow;
 
 	if ( inputFocus == NULL )
 	{

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2708,7 +2708,7 @@ paint_all( global_focus_t *pFocus, bool async )
 
 	// The gate also budgets the override painted right below, which is unguarded.
 	if ( pFocus->overrideUnderlayWindow && w && !w->isSteamStreamingClient && cv_paint_override_redirect_plane &&
-		 frameInfo.layerCount + ( override ? 1 : 0 ) < k_nMaxLayers - nReservedLayers )
+		 frameInfo.layers.count() + ( override ? 1 : 0 ) < k_nMaxLayers - nReservedLayers )
 	{
 		paint_window(pFocus->overrideUnderlayWindow, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, override);
 	}
@@ -3677,7 +3677,11 @@ carry_override_underlay( focus_t *pFocus, steamcompmgr_win_t *pPreviousOverride,
 		 pPreviousOverride != pFocus->focusWindow &&
 		 pPreviousOverride->pid == pFocus->focusWindow->pid &&
 		 is_good_override_candidate( pPreviousOverride, pFocus->focusWindow ) )
+	{
 		pFocus->overrideUnderlayWindow = pPreviousOverride;
+		focus_log.debugf( "Override underlay set: %s (%x)",
+			pFocus->overrideUnderlayWindow->debug_name(), pFocus->overrideUnderlayWindow->id() );
+	}
 
 	if ( pFocus->overrideUnderlayWindow )
 	{
@@ -3686,7 +3690,11 @@ carry_override_underlay( focus_t *pFocus, steamcompmgr_win_t *pPreviousOverride,
 			 underlay->type != steamcompmgr_win_type_t::XWAYLAND ||
 			 underlay->xwayland().a.map_state != IsViewable ||
 			 !is_good_override_candidate( underlay, pFocus->focusWindow ) )
+		{
+			if ( underlay != pFocus->overrideWindow )
+				focus_log.debugf( "Override underlay dropped: %s (%x)", underlay->debug_name(), underlay->id() );
 			pFocus->overrideUnderlayWindow = nullptr;
+		}
 	}
 }
 
@@ -4413,6 +4421,16 @@ determine_and_apply_focus( global_focus_t *pFocus )
 	gameFocused = pick_primary_focus_and_override( pFocus, root_ctx->focusControlWindow, vecPossibleFocusWindows, true, vecFocuscontrolAppIDs,
 		pFocus->ulVirtualFocusKey,
 		gamescope::cv_backend_virtual_connector_strategy );
+
+	if ( pFocus->overrideWindow != previousLocalFocus.overrideWindow )
+	{
+		if ( pFocus->overrideWindow )
+			focus_log.debugf( "Override pick: %s (%x) override_redirect=%d pid=%d",
+				pFocus->overrideWindow->debug_name(), pFocus->overrideWindow->id(),
+				(int)win_is_override_redirect( pFocus->overrideWindow ), pFocus->overrideWindow->pid );
+		else
+			focus_log.debugf( "Override pick: none" );
+	}
 
 	carry_override_underlay( pFocus, previousLocalFocus.overrideWindow, previousLocalFocus.overrideUnderlayWindow );
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -1969,9 +1969,9 @@ void MouseCursor::paint(steamcompmgr_win_t *window, steamcompmgr_win_t *fit, str
 	scaledX = scaledX - (m_hotspotX * cursor_scale);
 	scaledY = scaledY - (m_hotspotY * cursor_scale);
 
-	int curLayer = frameInfo->layerCount++;
-
-	FrameInfo_t::Layer_t *layer = &frameInfo->layers[ curLayer ];
+	FrameInfo_t::Layer_t *layer = frameInfo->layers.push();
+	if ( !layer )
+		return;
 
 	layer->opacity = 1.0;
 
@@ -2029,9 +2029,9 @@ std::array< BaseLayerInfo_t, HELD_COMMIT_COUNT > g_CachedPlanes = {};
 static void
 paint_cached_base_layer(const gamescope::Rc<commit_t>& commit, const BaseLayerInfo_t& base, struct FrameInfo_t *frameInfo, float flOpacityScale, bool bOverrideOpacity )
 {
-	int curLayer = frameInfo->layerCount++;
-
-	FrameInfo_t::Layer_t *layer = &frameInfo->layers[ curLayer ];
+	FrameInfo_t::Layer_t *layer = frameInfo->layers.push();
+	if ( !layer )
+		return;
 
 	layer->scale.x = base.scale[0];
 	layer->scale.y = base.scale[1];
@@ -2111,9 +2111,9 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 	// Base plane will stay as tex=0 if we don't have contents yet, which will
 	// make us fall back to compositing and use the Vulkan null texture
 
-	int curLayer = frameInfo->layerCount++;
-
-	FrameInfo_t::Layer_t *layer = &frameInfo->layers[ curLayer ];
+	FrameInfo_t::Layer_t *layer = frameInfo->layers.push();
+	if ( !layer )
+		return nullptr;
 
 	layer->filter = ( flags & PaintWindowFlag::NoFilter ) ? GamescopeUpscaleFilter::LINEAR : g_upscaleFilter;
 
@@ -2299,13 +2299,13 @@ static bool is_fading_out()
 
 static void update_touch_scaling( const struct FrameInfo_t *frameInfo )
 {
-	if ( !frameInfo->layerCount )
+	if ( !frameInfo->layers.count() )
 		return;
 
-	focusedWindowScaleX = frameInfo->layers[ frameInfo->layerCount - 1 ].scale.x;
-	focusedWindowScaleY = frameInfo->layers[ frameInfo->layerCount - 1 ].scale.y;
-	focusedWindowOffsetX = frameInfo->layers[ frameInfo->layerCount - 1 ].offset.x;
-	focusedWindowOffsetY = frameInfo->layers[ frameInfo->layerCount - 1 ].offset.y;
+	focusedWindowScaleX = frameInfo->layers.get( frameInfo->layers.count() - 1 ).scale.x;
+	focusedWindowScaleY = frameInfo->layers.get( frameInfo->layers.count() - 1 ).scale.y;
+	focusedWindowOffsetX = frameInfo->layers.get( frameInfo->layers.count() - 1 ).offset.x;
+	focusedWindowOffsetY = frameInfo->layers.get( frameInfo->layers.count() - 1 ).offset.y;
 }
 
 #if HAVE_PIPEWIRE
@@ -2584,7 +2584,7 @@ paint_all( global_focus_t *pFocus, bool async )
 					}
 				}
 				
-				int nOldLayerCount = frameInfo.layerCount;
+				int nOldLayerCount = frameInfo.layers.count();
 
 				uint32_t flags = 0;
 				if ( !bHasVideoUnderlay )
@@ -2595,8 +2595,8 @@ paint_all( global_focus_t *pFocus, bool async )
 				
 				// paint UI unless it's fully hidden, which it communicates to us through opacity=0
 				// we paint it to extract scaling coefficients above, then remove the layer if one was added
-				if ( w->opacity == TRANSLUCENT && bHasVideoUnderlay && nOldLayerCount < frameInfo.layerCount )
-					frameInfo.layerCount--;
+				if ( w->opacity == TRANSLUCENT && bHasVideoUnderlay && nOldLayerCount < frameInfo.layers.count() )
+					frameInfo.layers.pop();
 			}
 			else
 			{
@@ -2623,7 +2623,7 @@ paint_all( global_focus_t *pFocus, bool async )
 					// Just draw focused window as normal, be it Steam or the game
 					paint_window(w, w, &frameInfo, pFocus->cursor, PaintWindowFlag::BasePlane | PaintWindowFlag::DrawBorders, 1.0f, override);
 
-					bool needsScaling = frameInfo.layers[0].scale.x < 0.999f && frameInfo.layers[0].scale.y < 0.999f;
+					bool needsScaling = frameInfo.layers.get( 0 ).scale.x < 0.999f && frameInfo.layers.get( 0 ).scale.y < 0.999f;
 					frameInfo.useFSRLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::FSR && needsScaling;
 					frameInfo.useNISLayer0 = g_upscaleFilter == GamescopeUpscaleFilter::NIS && needsScaling;
 				}
@@ -2659,9 +2659,8 @@ paint_all( global_focus_t *pFocus, bool async )
 		// wlserver_mousefocus window.
 		//update_touch_scaling( &frameInfo );
 	}
-
 	// If we have any layers that aren't a cursor or overlay, then we have valid contents for presentation.
-	const bool bValidContents = frameInfo.layerCount > 0;
+	const bool bValidContents = frameInfo.layers.count() > 0;
 
   	if (externalOverlay && cv_paint_external_overlay_plane )
 	{
@@ -2688,13 +2687,12 @@ paint_all( global_focus_t *pFocus, bool async )
 		else if ( !GetBackend()->UsesVulkanSwapchain() && GetBackend()->IsSessionBased() )
 		{
 			auto tex = vulkan_get_hacky_blank_texture();
-			if ( tex != nullptr )
+			if ( tex != nullptr && frameInfo.layers.count() < k_nMaxLayers )
 			{
 				// HACK! HACK HACK HACK
 				// To avoid stutter when toggling the overlay on 
-				int curLayer = frameInfo.layerCount++;
-
-				FrameInfo_t::Layer_t *layer = &frameInfo.layers[ curLayer ];
+				FrameInfo_t::Layer_t *layer = frameInfo.layers.push();
+				assert( layer );
 
 
 				layer->scale.x = g_nOutputWidth == tex->width() ? 1.0f : tex->width() / (float)g_nOutputWidth;
@@ -2748,7 +2746,7 @@ paint_all( global_focus_t *pFocus, bool async )
 	bool blurFading = blurFadeTime < g_BlurFadeDuration;
 	BlurMode currentBlurMode = blurFading ? std::max(g_BlurMode, g_BlurModeOld) : g_BlurMode;
 
-	if (currentBlurMode && !(frameInfo.layerCount <= 1 && currentBlurMode == BLUR_MODE_COND))
+	if (currentBlurMode && !(frameInfo.layers.count() <= 1 && currentBlurMode == BLUR_MODE_COND))
 	{
 		frameInfo.blurLayer0 = currentBlurMode;
 		frameInfo.blurRadius = g_BlurRadius;
@@ -2808,13 +2806,12 @@ paint_all( global_focus_t *pFocus, bool async )
 		}
 	}
 
-	bool bDoMuraCompensation = is_mura_correction_enabled() && frameInfo.layerCount && cv_paint_mura_plane;
+	bool bDoMuraCompensation = is_mura_correction_enabled() && frameInfo.layers.count() && frameInfo.layers.count() < k_nMaxLayers && cv_paint_mura_plane;
 	if ( bDoMuraCompensation )
 	{
 		auto& MuraCorrectionImage = s_MuraCorrectionImage[GetBackend()->GetScreenType()];
-		int curLayer = frameInfo.layerCount++;
-
-		FrameInfo_t::Layer_t *layer = &frameInfo.layers[ curLayer ];
+		FrameInfo_t::Layer_t *layer = frameInfo.layers.push();
+		assert( layer );
 
 		layer->applyColorMgmt = false;
 		layer->scale = vec2_t{ 1.0f, 1.0f };
@@ -2888,8 +2885,8 @@ paint_all( global_focus_t *pFocus, bool async )
 		if ( pScreenshotTexture )
 		{
 			bool bHDRScreenshot = path.extension() == ".avif" &&
-								  frameInfo.layerCount > 0 &&
-								  ColorspaceIsHDR( frameInfo.layers[0].colorspace ) &&
+								  frameInfo.layers.count() > 0 &&
+								  ColorspaceIsHDR( frameInfo.layers.get( 0 ).colorspace ) &&
 								  oScreenshotInfo->eScreenshotType != GAMESCOPE_CONTROL_SCREENSHOT_TYPE_SCREEN_BUFFER;
 
 			if ( drmCaptureFormat == DRM_FORMAT_NV12 || oScreenshotInfo->eScreenshotType != GAMESCOPE_CONTROL_SCREENSHOT_TYPE_SCREEN_BUFFER )
@@ -2905,11 +2902,11 @@ paint_all( global_focus_t *pFocus, bool async )
 				if ( oScreenshotInfo->eScreenshotType == GAMESCOPE_CONTROL_SCREENSHOT_TYPE_BASE_PLANE_ONLY )
 				{
 					// Remove everything but base planes from the screenshot.
-					for (int i = 0; i < frameInfo.layerCount; i++)
+					for (int i = 0; i < frameInfo.layers.count(); i++)
 					{
-						if (frameInfo.layers[i].zpos >= (int)g_zposExternalOverlay)
+						if (frameInfo.layers.get( i ).zpos >= (int)g_zposExternalOverlay)
 						{
-							frameInfo.layerCount = i;
+							frameInfo.layers.truncate( i );
 							break;
 						}
 					}
@@ -2919,11 +2916,11 @@ paint_all( global_focus_t *pFocus, bool async )
 					if ( is_mura_correction_enabled() )
 					{
 						// Remove the last layer which is for mura...
-						for (int i = 0; i < frameInfo.layerCount; i++)
+						for (int i = 0; i < frameInfo.layers.count(); i++)
 						{
-							if (frameInfo.layers[i].zpos >= (int)g_zposMuraCorrection)
+							if (frameInfo.layers.get( i ).zpos >= (int)g_zposMuraCorrection)
 							{
-								frameInfo.layerCount = i;
+								frameInfo.layers.truncate( i );
 								break;
 							}
 						}
@@ -3222,7 +3219,7 @@ paint_all( global_focus_t *pFocus, bool async )
 
 
 	gpuvis_trace_end_ctx_printf( paintID, "paint_all" );
-	gpuvis_trace_printf( "paint_all %i layers", (int)frameInfo.layerCount );
+	gpuvis_trace_printf( "paint_all %i layers", (int)frameInfo.layers.count() );
 }
 
 /* Get prop from window

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2064,6 +2064,7 @@ namespace PaintWindowFlag
 	static const uint32_t NoScale = 1u << 4;
 	static const uint32_t NoFilter = 1u << 5;
 	static const uint32_t CoverageMode = 1u << 6;
+	static const uint32_t ClampToOutput = 1u << 7;
 }
 using PaintWindowFlags = uint32_t;
 
@@ -2165,6 +2166,15 @@ paint_window_commit( const gamescope::Rc<commit_t> &lastCommit, steamcompmgr_win
 	// Compositing ignores the base window's origin, so position overrides relative to it.
 	int32_t winOffsetX = w->GetGeometry().nX - scaleW->GetGeometry().nX;
 	int32_t winOffsetY = w->GetGeometry().nY - scaleW->GetGeometry().nY;
+
+	// Some clients position dropdowns slightly outside the output and close them
+	// if the window manager moves them. Leave their X11 geometry alone and clamp
+	// only the composited position.
+	if ( flags & PaintWindowFlag::ClampToOutput )
+	{
+		winOffsetX = std::max( winOffsetX, 0 );
+		winOffsetY = std::max( winOffsetY, 0 );
+	}
 
 	bool offset = ( ( winOffsetX || winOffsetY ) && w != scaleW );
 
@@ -2432,7 +2442,8 @@ static void paint_pipewire()
 		paint_window( pFocus->overrideUnderlayWindow, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
 
 	if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
-		paint_window( pFocus->overrideWindow, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
+		paint_window( pFocus->overrideWindow, pFocus->focusWindow, &frameInfo, nullptr,
+			PaintWindowFlag::NoFilter | PaintWindowFlag::ClampToOutput, 1.0f, pFocus->overrideWindow );
 
 	if ( !pFocus->focusWindow->isSteamStreamingClient )
 	{
@@ -2715,7 +2726,8 @@ paint_all( global_focus_t *pFocus, bool async )
 
 	if ( override && w && !w->isSteamStreamingClient && cv_paint_override_redirect_plane )
 	{
-		paint_window(override, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, override);
+		paint_window(override, w, &frameInfo, pFocus->cursor,
+			PaintWindowFlag::NoFilter | PaintWindowFlag::ClampToOutput, 1.0f, override);
 		// Don't update touch scaling for frameInfo. We don't ever make it our
 		// wlserver_mousefocus window.
 		//update_touch_scaling( &frameInfo );
@@ -3045,7 +3057,8 @@ paint_all( global_focus_t *pFocus, bool async )
 				if ( pFocus->overrideUnderlayWindow && !pFocus->focusWindow->isSteamStreamingClient )
 					paint_window( pFocus->overrideUnderlayWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
 				if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
-					paint_window( pFocus->overrideWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
+					paint_window( pFocus->overrideWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr,
+						PaintWindowFlag::NoFilter | PaintWindowFlag::ClampToOutput, 1.0f, pFocus->overrideWindow );
 				if ( !pFocus->focusWindow->isSteamStreamingClient )
 				{
 					for ( steamcompmgr_win_t *decoration : pFocus->decorationWindows )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2310,6 +2310,10 @@ static void update_touch_scaling( const struct FrameInfo_t *frameInfo )
 
 #if HAVE_PIPEWIRE
 static void pick_decoration_windows( focus_t *pFocus );
+static void carry_override_underlay( focus_t *pFocus, steamcompmgr_win_t *pPreviousOverride, steamcompmgr_win_t *pPreviousUnderlay );
+
+// Swept on window destroy so the repick can carry its override pointers forward.
+static focus_t s_PipewireFocus{};
 
 static void paint_pipewire()
 {
@@ -2357,14 +2361,17 @@ static void paint_pipewire()
 			s_ulLastFocusAppId = ulFocusAppId;
 		}
 
-		static focus_t s_PipewireFocus{};
 		if ( s_PipewireFocus.IsDirty() || bAppIdChange )
 		{
 			std::vector<steamcompmgr_win_t *> vecPossibleFocusWindows = GetGlobalPossibleFocusWindows();
 
+			steamcompmgr_win_t *pPreviousOverride = s_PipewireFocus.overrideWindow;
+			steamcompmgr_win_t *pPreviousUnderlay = s_PipewireFocus.overrideUnderlayWindow;
+
 			std::vector<uint32_t> vecAppIds{ uint32_t( ulFocusAppId ) };
 			pick_primary_focus_and_override( &s_PipewireFocus, None, vecPossibleFocusWindows, false, vecAppIds, 0, gamescope::VirtualConnectorStrategies::SteamControlled );
 			pick_decoration_windows( &s_PipewireFocus );
+			carry_override_underlay( &s_PipewireFocus, pPreviousOverride, pPreviousUnderlay );
 		}
 		pFocus = &s_PipewireFocus;
 	}
@@ -2383,10 +2390,12 @@ static void paint_pipewire()
 	// If the commits are the same as they were last time, don't repaint and don't push a new buffer on the stream.
 	static uint64_t s_ulLastFocusCommitId = 0;
 	static uint64_t s_ulLastOverrideCommitId = 0;
+	static uint64_t s_ulLastUnderlayCommitId = 0;
 	static uint64_t s_ulLastDecorationCommitId = 0;
 
 	uint64_t ulFocusCommitId = window_last_done_commit_id( pFocus->focusWindow );
 	uint64_t ulOverrideCommitId = window_last_done_commit_id( pFocus->overrideWindow );
+	uint64_t ulUnderlayCommitId = window_last_done_commit_id( pFocus->overrideUnderlayWindow );
 
 	// Combine the decoration commits so damage to any of them, or a change
 	// in the set itself, pushes a new frame.
@@ -2396,11 +2405,13 @@ static void paint_pipewire()
 
 	if ( ulFocusCommitId == s_ulLastFocusCommitId &&
 	     ulOverrideCommitId == s_ulLastOverrideCommitId &&
+	     ulUnderlayCommitId == s_ulLastUnderlayCommitId &&
 	     ulDecorationCommitId == s_ulLastDecorationCommitId )
 		return;
 
 	s_ulLastFocusCommitId = ulFocusCommitId;
 	s_ulLastOverrideCommitId = ulOverrideCommitId;
+	s_ulLastUnderlayCommitId = ulUnderlayCommitId;
 	s_ulLastDecorationCommitId = ulDecorationCommitId;
 
 	uint32_t uWidth = s_pPipewireBuffer->texture->width();
@@ -2416,6 +2427,9 @@ static void paint_pipewire()
 
 	// Paint the windows we have onto the Pipewire stream.
 	paint_window( pFocus->focusWindow, pFocus->focusWindow, &frameInfo, nullptr, 0, 1.0f, pFocus->overrideWindow );
+
+	if ( pFocus->overrideUnderlayWindow && !pFocus->focusWindow->isSteamStreamingClient )
+		paint_window( pFocus->overrideUnderlayWindow, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
 
 	if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
 		paint_window( pFocus->overrideWindow, pFocus->focusWindow, &frameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
@@ -2679,6 +2693,26 @@ paint_all( global_focus_t *pFocus, bool async )
 	// with an offset.
 	// Josh: No override if we're streaming video
 	// as we will have too many layers. Better to be safe than sorry.
+	// Leave room for the layers painted after these, so an underlay and a pile of helper windows
+	// cannot push out the Steam overlay or the cursor. The mura plane is not reserved and yields
+	// when the frame is full.
+	int nReservedLayers = 1; // cursor
+	if ( externalOverlay && externalOverlay->opacity && cv_paint_external_overlay_plane )
+		nReservedLayers++;
+	if ( cv_paint_steam_overlay_plane &&
+		 ( ( overlay && overlay->opacity ) ||
+		   ( !GetBackend()->UsesVulkanSwapchain() && GetBackend()->IsSessionBased() ) ) )
+		nReservedLayers++;
+	if ( notification && notification->opacity )
+		nReservedLayers++;
+
+	// The gate also budgets the override painted right below, which is unguarded.
+	if ( pFocus->overrideUnderlayWindow && w && !w->isSteamStreamingClient && cv_paint_override_redirect_plane &&
+		 frameInfo.layerCount + ( override ? 1 : 0 ) < k_nMaxLayers - nReservedLayers )
+	{
+		paint_window(pFocus->overrideUnderlayWindow, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, override);
+	}
+
 	if ( override && w && !w->isSteamStreamingClient && cv_paint_override_redirect_plane )
 	{
 		paint_window(override, w, &frameInfo, pFocus->cursor, PaintWindowFlag::NoFilter, 1.0f, override);
@@ -2690,19 +2724,6 @@ paint_all( global_focus_t *pFocus, bool async )
 	// Decorations (eg. Xalia's highlight) paint like overrides, above them.
 	if ( w && !w->isSteamStreamingClient && cv_paint_override_redirect_plane )
 	{
-		// Leave room for the layers painted after decorations, so a pile of
-		// helper windows cannot push out the Steam overlay or the cursor.
-		// The mura plane is not reserved and yields when the frame is full.
-		int nReservedLayers = 1; // cursor
-		if ( externalOverlay && externalOverlay->opacity && cv_paint_external_overlay_plane )
-			nReservedLayers++;
-		if ( cv_paint_steam_overlay_plane &&
-			 ( ( overlay && overlay->opacity ) ||
-			   ( !GetBackend()->UsesVulkanSwapchain() && GetBackend()->IsSessionBased() ) ) )
-			nReservedLayers++;
-		if ( notification && notification->opacity )
-			nReservedLayers++;
-
 		for ( steamcompmgr_win_t *decoration : pFocus->decorationWindows )
 		{
 			if ( frameInfo.layers.count() >= k_nMaxLayers - nReservedLayers )
@@ -3021,6 +3042,8 @@ paint_all( global_focus_t *pFocus, bool async )
 				currentOutputHeight = uScreenshotHeight;
 
 				paint_window( pFocus->focusWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, 0, 1.0f, pFocus->overrideWindow );
+				if ( pFocus->overrideUnderlayWindow && !pFocus->focusWindow->isSteamStreamingClient )
+					paint_window( pFocus->overrideUnderlayWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
 				if ( pFocus->overrideWindow && !pFocus->focusWindow->isSteamStreamingClient )
 					paint_window( pFocus->overrideWindow, pFocus->focusWindow, &screenshotFrameInfo, nullptr, PaintWindowFlag::NoFilter, 1.0f, pFocus->overrideWindow );
 				if ( !pFocus->focusWindow->isSteamStreamingClient )
@@ -3641,6 +3664,30 @@ static void pick_decoration_windows( focus_t *pFocus )
 
 	// ctx->list runs top to bottom, we paint the other way.
 	std::reverse( pFocus->decorationWindows.begin(), pFocus->decorationWindows.end() );
+}
+
+// A dialog should not blink out while its own popup (eg. a combo box list or a nested
+// message box) takes the override slot, so keep the previous override painted beneath it.
+static void
+carry_override_underlay( focus_t *pFocus, steamcompmgr_win_t *pPreviousOverride, steamcompmgr_win_t *pPreviousUnderlay )
+{
+	pFocus->overrideUnderlayWindow = pPreviousUnderlay;
+	if ( pFocus->focusWindow && pFocus->overrideWindow && pPreviousOverride &&
+		 pFocus->overrideWindow != pPreviousOverride &&
+		 pPreviousOverride != pFocus->focusWindow &&
+		 pPreviousOverride->pid == pFocus->focusWindow->pid &&
+		 is_good_override_candidate( pPreviousOverride, pFocus->focusWindow ) )
+		pFocus->overrideUnderlayWindow = pPreviousOverride;
+
+	if ( pFocus->overrideUnderlayWindow )
+	{
+		steamcompmgr_win_t *underlay = pFocus->overrideUnderlayWindow;
+		if ( !pFocus->overrideWindow || underlay == pFocus->overrideWindow ||
+			 underlay->type != steamcompmgr_win_type_t::XWAYLAND ||
+			 underlay->xwayland().a.map_state != IsViewable ||
+			 !is_good_override_candidate( underlay, pFocus->focusWindow ) )
+			pFocus->overrideUnderlayWindow = nullptr;
+	}
 }
 
 static void
@@ -4367,6 +4414,8 @@ determine_and_apply_focus( global_focus_t *pFocus )
 		pFocus->ulVirtualFocusKey,
 		gamescope::cv_backend_virtual_connector_strategy );
 
+	carry_override_underlay( pFocus, previousLocalFocus.overrideWindow, previousLocalFocus.overrideUnderlayWindow );
+
 	// Pick overlay/notifications from root ctx
 	pFocus->overlayWindow = root_ctx->focus.overlayWindow;
 	pFocus->externalOverlayWindow = root_ctx->focus.externalOverlayWindow;
@@ -4383,9 +4432,6 @@ determine_and_apply_focus( global_focus_t *pFocus )
 	}
 
 	pick_decoration_windows( pFocus );
-
-	if ( pFocus->decorationWindows != previousLocalFocus.decorationWindows )
-		hasRepaintNonBasePlane = true;
 
 	bool bUseOverlay = gamescope::VirtualConnectorIsSingleOutput() || gamescope::VirtualConnectorKeyIsSteam( pFocus->ulVirtualFocusKey );
 	if ( !bUseOverlay )
@@ -4424,6 +4470,7 @@ determine_and_apply_focus( global_focus_t *pFocus )
 					pFocus->keyboardFocusWindow = queryWindow;
 
 					pFocus->overrideWindow = nullptr;
+					pFocus->overrideUnderlayWindow = nullptr;
 					pFocus->decorationWindows.clear();
 				}
 
@@ -4435,11 +4482,17 @@ determine_and_apply_focus( global_focus_t *pFocus )
 					//pFocus->inputFocusWindow = queryWindow;
 
 					pFocus->overrideWindow = nullptr;
+					pFocus->overrideUnderlayWindow = nullptr;
 					pFocus->decorationWindows.clear();
 				}
 			}
 		}
 	}
+
+	// After the VR forwarder has had its say, since it clears both.
+	if ( pFocus->decorationWindows != previousLocalFocus.decorationWindows ||
+		 pFocus->overrideUnderlayWindow != previousLocalFocus.overrideUnderlayWindow )
+		hasRepaintNonBasePlane = true;
 
 	// Pick cursor from our input focus window
 
@@ -5549,14 +5602,25 @@ destroy_win(xwayland_ctx_t *ctx, Window id, bool gone, bool fade)
 			pFocus->overlayWindow = nullptr;
 		if (x11_win(pFocus->notificationWindow) == id && gone)
 			pFocus->notificationWindow = nullptr;
-		if (x11_win(pFocus->overrideWindow) == id && gone)
+		// These are dereferenced on a later focus pass, and finish_destroy_win frees the window
+		// whether or not it is gone, so clear them either way.
+		if (x11_win(pFocus->overrideWindow) == id)
 			pFocus->overrideWindow = nullptr;
+		if (x11_win(pFocus->overrideUnderlayWindow) == id)
+			pFocus->overrideUnderlayWindow = nullptr;
 		if (x11_win(pFocus->fadeWindow) == id && gone)
 			pFocus->fadeWindow = nullptr;
-		if (gone)
-			std::erase_if(pFocus->decorationWindows, [id](steamcompmgr_win_t *w) { return x11_win(w) == id; });
+		std::erase_if(pFocus->decorationWindows, [id](steamcompmgr_win_t *w) { return x11_win(w) == id; });
 	}
-		
+
+#if HAVE_PIPEWIRE
+	// The pipewire repick dereferences these when carrying the underlay.
+	if (x11_win(s_PipewireFocus.overrideWindow) == id)
+		s_PipewireFocus.overrideWindow = nullptr;
+	if (x11_win(s_PipewireFocus.overrideUnderlayWindow) == id)
+		s_PipewireFocus.overrideUnderlayWindow = nullptr;
+#endif
+
 	MakeFocusDirty();
 
 	finish_destroy_win(ctx, id, gone);
@@ -6815,6 +6879,11 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 					pFocus->overrideWindow->xwayland().ctx == server->ctx.get())
 					pFocus->overrideWindow = nullptr;
 
+				if (pFocus->overrideUnderlayWindow &&
+					pFocus->overrideUnderlayWindow->type == steamcompmgr_win_type_t::XWAYLAND &&
+					pFocus->overrideUnderlayWindow->xwayland().ctx == server->ctx.get())
+					pFocus->overrideUnderlayWindow = nullptr;
+
 				std::erase_if(pFocus->decorationWindows, [&](steamcompmgr_win_t *pDecoration)
 				{
 					return pDecoration->type == steamcompmgr_win_type_t::XWAYLAND &&
@@ -6835,6 +6904,18 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
 					pFocus->cursor->getCtx() == server->ctx.get())
 					pFocus->cursor = nullptr;
 			}
+
+#if HAVE_PIPEWIRE
+			if (s_PipewireFocus.overrideWindow &&
+				s_PipewireFocus.overrideWindow->type == steamcompmgr_win_type_t::XWAYLAND &&
+				s_PipewireFocus.overrideWindow->xwayland().ctx == server->ctx.get())
+				s_PipewireFocus.overrideWindow = nullptr;
+
+			if (s_PipewireFocus.overrideUnderlayWindow &&
+				s_PipewireFocus.overrideUnderlayWindow->type == steamcompmgr_win_type_t::XWAYLAND &&
+				s_PipewireFocus.overrideUnderlayWindow->xwayland().ctx == server->ctx.get())
+				s_PipewireFocus.overrideUnderlayWindow = nullptr;
+#endif
 
 			wlserver_lock();
 			g_SteamCompMgrWaiter.RemoveWaitable( server->ctx.get() );
@@ -7089,7 +7170,7 @@ bool handle_done_commit( steamcompmgr_win_t *w, xwayland_ctx_t *ctx, uint64_t co
 					focusWindow_pid = w->pid;
 				}
 
-				if ( w == pFocus->overrideWindow ||
+				if ( w == pFocus->overrideWindow || w == pFocus->overrideUnderlayWindow ||
 					 std::find( pFocus->decorationWindows.begin(), pFocus->decorationWindows.end(), w ) != pFocus->decorationWindows.end() )
 				{
 					hasRepaintNonBasePlane = true;
@@ -8334,6 +8415,8 @@ void steamcompmgr_check_xdg(bool vblank, uint64_t vblank_idx)
 				pFocus->notificationWindow = nullptr;
 			if (pFocus->overrideWindow && pFocus->overrideWindow->type == steamcompmgr_win_type_t::XDG)
 				pFocus->overrideWindow = nullptr;
+			if (pFocus->overrideUnderlayWindow && pFocus->overrideUnderlayWindow->type == steamcompmgr_win_type_t::XDG)
+				pFocus->overrideUnderlayWindow = nullptr;
 			if (pFocus->fadeWindow && pFocus->fadeWindow->type == steamcompmgr_win_type_t::XDG)
 				pFocus->fadeWindow = nullptr;
 			if (pFocus->keyboardFocusWindow && pFocus->keyboardFocusWindow->type == steamcompmgr_win_type_t::XDG)

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -114,6 +114,7 @@ struct steamcompmgr_win_t {
 	bool isSteamStreamingClientVideo = false;
 	uint32_t inputFocusMode = 0;
 	uint32_t appID = 0;
+	uint32_t steamAppID = 0;
 	bool isOverlay = false;
 	bool isExternalOverlay = false;
 

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -33,6 +33,8 @@ struct focus_t
 	steamcompmgr_win_t				*externalOverlayWindow = nullptr;
 	steamcompmgr_win_t				*notificationWindow = nullptr;
 	steamcompmgr_win_t				*overrideWindow = nullptr;
+	// The previous override, kept painted beneath a new one. Global focus only.
+	steamcompmgr_win_t				*overrideUnderlayWindow = nullptr;
 	steamcompmgr_win_t				*overrideWindowMouse = nullptr;
 	// Same-app helpers from other processes (eg. Xalia's highlight), painted above the override.
 	std::vector<steamcompmgr_win_t*>	decorationWindows;

--- a/src/xwayland_ctx.hpp
+++ b/src/xwayland_ctx.hpp
@@ -34,6 +34,8 @@ struct focus_t
 	steamcompmgr_win_t				*notificationWindow = nullptr;
 	steamcompmgr_win_t				*overrideWindow = nullptr;
 	steamcompmgr_win_t				*overrideWindowMouse = nullptr;
+	// Same-app helpers from other processes (eg. Xalia's highlight), painted above the override.
+	std::vector<steamcompmgr_win_t*>	decorationWindows;
 	bool			outdatedInteractiveFocus = false;
 	bool			bResetToCorner = false;
 	bool			bResetToCenter = false;


### PR DESCRIPTION
who doesn't love more launcher fixes :frog: 

Fixes a regression which caused only a Xalia overlay highlight to be drawn while hiding the settings window it belonged to in Warframe. Also improves the general Warframe launcher experience by no longer hiding the settings window when a drop-down box is opened, which does not occur on KDE Plasma or on Windows.