### PR TITLE
rendervulkan: only enable VK_EXT_hdr_metadata alongside VK_KHR_swapchain

### DIFF
--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -561,6 +561,9 @@ bool CVulkanDevice::createDevice()
 
 		enabledExtensions.push_back( VK_KHR_PRESENT_ID_EXTENSION_NAME );
 		enabledExtensions.push_back( VK_KHR_PRESENT_WAIT_EXTENSION_NAME );
+
+		if ( supportsHDRMetadata )
+			enabledExtensions.push_back( VK_EXT_HDR_METADATA_EXTENSION_NAME );
 	}
 
 	if ( m_bSupportsModifiers )
@@ -578,9 +581,6 @@ bool CVulkanDevice::createDevice()
 #if 0
 	enabledExtensions.push_back( VK_KHR_MAINTENANCE_5_EXTENSION_NAME );
 #endif
-
-	if ( supportsHDRMetadata )
-		enabledExtensions.push_back( VK_EXT_HDR_METADATA_EXTENSION_NAME );
 
 	for ( auto& extension : GetBackend()->GetDeviceExtensions( physDev() ) )
 		enabledExtensions.push_back( extension );


### PR DESCRIPTION
We enabled VK_EXT_hdr_metadata whenever the physical device advertised it, even on backends that never create a Vulkan swapchain, which breaks the extension's dependency on VK_KHR_swapchain:

```
  Validation Error: [ VUID-vkCreateDevice-ppEnabledExtensionNames-01387 ]
  vkCreateDevice(): pCreateInfo->ppEnabledExtensionNames[6] Missing
  extension required to enable device extension VK_EXT_hdr_metadata:
   - VK_KHR_swapchain
```

Most drivers let that slide, Venus fails vkCreateDevice with VK_ERROR_EXTENSION_NOT_PRESENT and gamescope never starts. Only the SDL backend uses a Vulkan swapchain, and its vkSetHdrMetadataEXT call is the extension's only user, so move it in with the other swapchain extensions.

Closes: https://github.com/ValveSoftware/gamescope/issues/2281