### PR TITLE
steamcompmgr: return the nudged focus window where the client had it

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4008,7 +4008,9 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 
 	if (!ctx->focus.focusWindow->nudged)
 	{
-		XMoveWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, 1, 1);
+		Rect rect = ctx->focus.focusWindow->GetGeometry();
+		XMoveWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, rect.nX + 1, rect.nY + 1);
+		XMoveWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, rect.nX, rect.nY);
 		ctx->focus.focusWindow->nudged = true;
 	}
 


### PR DESCRIPTION
This nudge was half of a pair. It moved a newly focused window off (0, 0) so that the conditional snap on the next line, which could not fire for a window already sitting there, would move it back. a563226d431d dropped that snap so windows asking for a position keep it, but the snap was also the nudge's return trip, so every newly focused window was left parked on (1,1).

Wine can fight that placement in an unbounded reconfigure loop, and for a window larger than the screen it pushes the far edge past where Wine delivers input. This stops some of the buttons in Marvel Rivals' launcher from being interactable, and it also causes flickering in World of Warcraft.

Do the round trip on the client's own position, so the window keeps the placement it asked for. Nudging to a fixed spot would also be a no-op, and so force nothing, for a window already sitting there. We restore the last position we saw, so a client configure still in flight when we nudge would be undone.

Fixes: https://github.com/ValveSoftware/gamescope/issues/2241