### PR TITLE
Fix/child wayland display fallback

### DIFF
--- a/layer/VkLayer_FROG_gamescope_wsi.cpp
+++ b/layer/VkLayer_FROG_gamescope_wsi.cpp
@@ -779,8 +779,20 @@ namespace GamescopeWSILayer {
 
       GamescopeWaylandObjects waylandObjects = GamescopeWaylandObjects::get(pCreateInfo->display);
       if (!waylandObjects.valid()) {
-        fprintf(stderr, "[Gamescope WSI] Failed to get Wayland objects\n");
-        return VK_ERROR_SURFACE_LOST_KHR;
+        // ENABLE_GAMESCOPE_WSI is inherited by every descendant, so the app may
+        // legitimately be on another compositor. Let it through untouched.
+        fprintf(stderr, "[Gamescope WSI] Failed to get Wayland objects "
+                        "(wl_compositor: %s, gamescope_swapchain_factory_v2: %s), "
+                        "not a Gamescope compositor\n",
+                waylandObjects.compositor ? "yes" : "no",
+                waylandObjects.gamescopeSwapchainFactory ? "yes" : "no");
+
+        if (waylandObjects.compositor)
+          wl_compositor_destroy(waylandObjects.compositor);
+        if (waylandObjects.gamescopeSwapchainFactory)
+          gamescope_swapchain_factory_v2_destroy(waylandObjects.gamescopeSwapchainFactory);
+
+        return pDispatch->CreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
       }
 
       VkResult res = pDispatch->CreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1003,8 +1003,11 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	// Prevent our clients from connecting to the parent compositor
-	unsetenv("WAYLAND_DISPLAY");
+	// Prevent our clients from connecting to the parent compositor.
+	// Empty rather than unset: wl_display_connect(nullptr) falls back to "wayland-0"
+	// when WAYLAND_DISPLAY is absent, which is the parent on most setups. Empty is
+	// also the only other value the WSI layer still reads as "under gamescope".
+	setenv("WAYLAND_DISPLAY", "", 1);
 
 	// If DRM format modifiers aren't supported, prevent our clients from using
 	// DCC, as this can cause tiling artifacts.


### PR DESCRIPTION
Unsetting WAYLAND_DISPLAY does not hide the parent compositor from our clients. wl_display_connect(nullptr) falls back to the "wayland-0" socket name when the variable is absent, and that is what the parent is called on most setups, so a client that connects unconditionally rather than gating on WAYLAND_DISPLAY being set lands on the host compositor instead of our Xwayland.

The WSI layer is still enabled there through the inherited ENABLE_GAMESCOPE_WSI, finds no gamescope_swapchain_factory_v2 on the host display, and fails surface creation, which takes the client down with it:

    Selected WSI platform: wayland
    [Gamescope WSI] Failed to get Wayland objects
    [gamescope] [Info]  launch: Primary child shut down!

Set WAYLAND_DISPLAY to an empty string instead. libwayland then resolves it to "$XDG_RUNTIME_DIR/", a directory rather than a socket, so the connect fails and the client falls back to Xwayland as intended. Empty is the only usable value: isRunningUnderGamescope() rejects any WAYLAND_DISPLAY that is non-empty and differs from GAMESCOPE_WAYLAND_DISPLAY, so a bogus socket name would instead make already-installed layers disable themselves and send every swapchain down the "Hooking has failed somewhere!" path.

Also stop treating a display without those globals as fatal in the layer. ENABLE_GAMESCOPE_WSI is inherited by every descendant, so an application can legitimately be on another compositor. Fall back to the driver's CreateWaylandSurfaceKHR and name the missing global, as the bare "Failed to get Wayland objects" gives no hint that the display simply is not ours.