### PR TITLE
steamcompmgr: place a screen-sized focus window at the origin

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4019,6 +4019,20 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 		ctx->focus.focusWindow->nudged = true;
 	}
 
+	// X confines the pointer to the screen, so a screen-sized focus window only
+	// sees all of it at the origin. Place it there once, a client that moves it
+	// afterwards keeps its position. Oversized windows stay put, clients centre
+	// those to keep the middle reachable.
+	const Rect rect = w->GetGeometry();
+
+	if ( !w->placed && rect.nWidth == ctx->root_width && rect.nHeight == ctx->root_height )
+	{
+		if ( rect.nX != 0 || rect.nY != 0 )
+			XMoveWindow(ctx->dpy, w->xwayland().id, 0, 0);
+
+		w->placed = true;
+	}
+
 	if ( win_has_game_id( w ) )
 	{
 		if ( window_is_fullscreen( ctx->focus.focusWindow ) || ctx->force_windows_fullscreen )
@@ -5205,6 +5219,7 @@ add_win(xwayland_ctx_t *ctx, Window id, Window prev, unsigned long sequence)
 	new_win->requestedWidth = 0;
 	new_win->requestedHeight = 0;
 	new_win->nudged = false;
+	new_win->placed = false;
 	new_win->ignoreOverrideRedirect = false;
 
 	wlserver_x11_surface_info_init( &new_win->xwayland().surface, ctx->xwayland_server, id );
@@ -5269,6 +5284,10 @@ configure_win(xwayland_ctx_t *ctx, XConfigureEvent *ce)
 			ctx->root_height = ce->height;
 			MakeFocusDirty();
 
+			// Screen-sized is relative to the screen, re-arm every placement.
+			for ( steamcompmgr_win_t *pWindow = ctx->list; pWindow; pWindow = pWindow->xwayland().next )
+				pWindow->placed = false;
+
 			gamescope_xwayland_server_t *root_server = wlserver_get_xwayland_server(0);
 			xwayland_ctx_t *root_ctx = root_server->ctx.get();
 			XDeleteProperty( root_ctx->dpy, root_ctx->root, root_ctx->atoms.gamescopeXWaylandModeControl );
@@ -5276,6 +5295,11 @@ configure_win(xwayland_ctx_t *ctx, XConfigureEvent *ce)
 		}
 		return;
 	}
+
+	// Resizing re-arms the placement. Moving does not, so we never fight a
+	// client that drags its window off.
+	if ( ce->width != w->xwayland().a.width || ce->height != w->xwayland().a.height )
+		w->placed = false;
 
 	w->xwayland().a.x = ce->x;
 	w->xwayland().a.y = ce->y;

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -151,6 +151,7 @@ struct steamcompmgr_win_t {
 	bool bHasHadNonSRGBColorSpace = false;
 
 	bool nudged = false;
+	bool placed = false;
 	bool ignoreOverrideRedirect = false;
 
 	bool unlockedForFrameCallback = false;


### PR DESCRIPTION
Xwayland turns pointer positions into root coordinates and X confines the pointer to the screen, so a focus window as large as the screen never sees input past whatever edge it hangs off. Nothing bounds checked it. It only kept working because the focus window was pinned at or beside the origin, first by the snap a563226d431d dropped and then by the orphaned nudge that 33f3776918b8 removed, so a client that centres itself and then grows to the screen size in place is now left hanging off it.

Put such a window at the origin, the only place all of it can be reached. Anything smaller keeps the position it asked for, since it is reachable wherever the client put it, and compositing already ignores the focus window's origin so none of this costs anything on screen. We place it once, and drop that once a resize or a screen size change makes covering the screen mean something different, so a client that just drags the window off keeps it rather than fighting us forever.

Fixes: https://github.com/ValveSoftware/gamescope/issues/2294