### PR TITLE
Focus ring fixes for Steam

### DIFF
--- a/src/Backends/OpenVRBackend.cpp
+++ b/src/Backends/OpenVRBackend.cpp
@@ -1821,14 +1821,20 @@ namespace gamescope
         if ( g_bForceRelativeMouse )
             this->SetRelativeMouseMode( true );
         
-        if ( m_pBackend->m_oulCurrentSceneVirtualConnectorKey &&
-             GetVirtualConnectorKey() == *m_pBackend->m_oulCurrentSceneVirtualConnectorKey )
         {
-            MarkSceneAppShown( true );
-        }
+            // UpdateVisibility reads the focus connectors' planes, which the
+            // lock keeps alive against a concurrent connector destruction.
+            std::scoped_lock lock{ m_pBackend->m_mutActiveConnectors };
 
-        // Set the initial overlay visibility
-        MarkOverlayShown( vr::VROverlay()->IsOverlayVisible( GetPrimaryPlane()->GetOverlay() ) );
+            if ( m_pBackend->m_oulCurrentSceneVirtualConnectorKey &&
+                 GetVirtualConnectorKey() == *m_pBackend->m_oulCurrentSceneVirtualConnectorKey )
+            {
+                MarkSceneAppShown( true );
+            }
+
+            // Set the initial overlay visibility
+            MarkOverlayShown( vr::VROverlay()->IsOverlayVisible( GetPrimaryPlane()->GetOverlay() ) );
+        }
 
         return true;
     }
@@ -1853,6 +1859,37 @@ namespace gamescope
                 nNewOverlayVisibleCount,
                 m_bOverlayShown    ? "true" : "false",
                 m_bSceneAppVisible ? "true" : "false" );
+
+            // SteamVR can fail to grant a launching app overlay input focus,
+            // which would otherwise leave the previous connector current. Only
+            // defer to a holder SteamVR's grant actually points at. Every
+            // caller holds m_mutActiveConnectors, which keeps the holder alive
+            // across the plane lookup.
+            if ( bVisible )
+            {
+                COpenVRConnector *pKeyboardConnector = m_pBackend->m_pKeyboardFocusConnector.load();
+                COpenVRConnector *pMouseConnector = m_pBackend->m_pMouseFocusConnector.load();
+
+                bool bTakeKeyboard = !pKeyboardConnector || pKeyboardConnector == this ||
+                    !pKeyboardConnector->GetPlaneByOverlayHandle( g_FocusedVROverlayKeyboard.load() );
+                bool bTakeMouse = !pMouseConnector || pMouseConnector == this ||
+                    !pMouseConnector->GetPlaneByOverlayHandle( g_FocusedVROverlayMouse.load() );
+
+                bool bChanged = false;
+                if ( bTakeKeyboard )
+                    bChanged |= m_pBackend->m_pKeyboardFocusConnector.exchange( this ) != this;
+                if ( bTakeMouse )
+                    bChanged |= m_pBackend->m_pMouseFocusConnector.exchange( this ) != this;
+
+                if ( bChanged )
+                {
+                    openvr_log.debugf( "Changing keyboard and mouse focus connector to %p", this );
+                    update_connector_display_info_wl( NULL );
+
+                    MakeFocusDirty();
+                    nudge_steamcompmgr();
+                }
+            }
         }
     }
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -925,6 +925,16 @@ static gamescope::ConCommand cc_debug_force_repaint( "debug_force_repaint", "For
 	hasRepaint = true;
 });
 
+// The main loop dumps this on the steamcompmgr thread, which owns the
+// focus state and the X connections.
+static std::atomic<bool> g_bPendingFocusInfo = { false };
+
+static gamescope::ConCommand cc_focus_info( "focus_info", "Dump debug info about the focus state",
+[]( std::span<std::string_view> args )
+{
+	g_bPendingFocusInfo = true;
+});
+
 unsigned long	damageSequence = 0;
 
 uint64_t		cursorHideTime = 10'000ul * 1'000'000ul;
@@ -4166,6 +4176,63 @@ steamcompmgr_xdg_determine_and_apply_focus( const std::vector< steamcompmgr_win_
 }
 
 uint32_t g_focusedBaseAppId = 0;
+
+static void
+DumpFocusInfo()
+{
+	global_focus_t *pFocus = GetCurrentFocus();
+	if ( !pFocus )
+		return;
+
+	auto dump_win = []( const char *pszRole, steamcompmgr_win_t *w )
+	{
+		if ( w )
+			focus_log.infof( "%s: 0x%x (%s) appID=%u", pszRole, w->id(), w->debug_name(), w->appID );
+		else
+			focus_log.infof( "%s: none", pszRole );
+	};
+
+	dump_win( "Global focus window", pFocus->focusWindow );
+	dump_win( "Global input focus window", pFocus->inputFocusWindow );
+	dump_win( "Global keyboard focus window", pFocus->keyboardFocusWindow );
+	dump_win( "Global override window", pFocus->overrideWindow );
+	dump_win( "Global overlay window", pFocus->overlayWindow );
+
+	// Only the current connector's focus gets published to Steam, so dump
+	// every connector's focus next to the current key.
+	gamescope::IBackendConnector *pCurrentConnector = GetBackend()->GetCurrentConnector();
+	gamescope::VirtualConnectorKey_t ulCurrentKey = pCurrentConnector ? pCurrentConnector->GetVirtualConnectorKey() : 0;
+	std::string_view svStrategy = gamescope::VirtualConnectorStrategyToString( gamescope::cv_backend_virtual_connector_strategy );
+	focus_log.infof( "Virtual connector strategy: %.*s, current key: 0x%" PRIx64,
+		(int)svStrategy.size(), svStrategy.data(), ulCurrentKey );
+
+	for ( auto &[ ulKey, focus ] : g_VirtualConnectorFocuses )
+	{
+		steamcompmgr_win_t *w = focus.focusWindow;
+		focus_log.infof( "  Connector 0x%" PRIx64 "%s: focus window %s appID=%u", ulKey,
+			ulKey == ulCurrentKey ? " (current)" : "",
+			w ? w->debug_name() : "none", w ? w->appID : 0 );
+	}
+
+	xwayland_ctx_t *root_ctx = wlserver_get_xwayland_server( 0 )->ctx.get();
+	focus_log.infof( "Focused app property: %u", get_prop( root_ctx, root_ctx->root, root_ctx->atoms.gamescopeFocusedAppAtom, 0 ) );
+	focus_log.infof( "Focused window property: 0x%x", get_prop( root_ctx, root_ctx->root, root_ctx->atoms.gamescopeFocusedWindowAtom, 0 ) );
+
+	gamescope_xwayland_server_t *server = NULL;
+	for ( size_t i = 0; ( server = wlserver_get_xwayland_server( i ) ); i++ )
+	{
+		xwayland_ctx_t *ctx = server->ctx.get();
+		Window realFocus = None;
+		int nRevertMode = 0;
+		XGetInputFocus( ctx->dpy, &realFocus, &nRevertMode );
+		steamcompmgr_win_t *realWin = find_win( ctx, realFocus );
+		focus_log.infof( "Server %zu keyboard focus: 0x%lx (%s) revert=%d wanted=0x%lx", i,
+			realFocus, realWin ? realWin->debug_name() : "untracked", nRevertMode, ctx->currentKeyboardFocusWindow );
+		dump_win( "  Focus window", ctx->focus.focusWindow );
+		dump_win( "  Input focus window", ctx->focus.inputFocusWindow );
+		dump_win( "  Override window", ctx->focus.overrideWindow );
+	}
+}
 
 static void
 determine_and_apply_focus( global_focus_t *pFocus )
@@ -8976,6 +9043,9 @@ steamcompmgr_main(int argc, char **argv)
 				hasRepaint = true;
 			}
 		}
+
+		if ( g_bPendingFocusInfo.exchange( false ) )
+			DumpFocusInfo();
 
 		// XXX(misyl): This is bad! We shouldnt change the upscaler like this at all!!!
 		// We should move this to business logic in paint_window or something!

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3253,6 +3253,17 @@ get_prop(xwayland_ctx_t *ctx, Window win, Atom prop, unsigned int def, bool *fou
 								 &n, &left, &data);
 	if (result == Success && data != NULL)
 	{
+		// A zero-element property still hands back an allocation, so we would read uninitialized memory.
+		if ( n < 1 )
+		{
+			XFree((void *) data);
+			if ( found != nullptr )
+			{
+				*found = false;
+			}
+			return def;
+		}
+
 		unsigned int i;
 		memcpy(&i, data, sizeof(unsigned int));
 		XFree((void *) data);

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4575,7 +4575,9 @@ determine_and_apply_focus( global_focus_t *pFocus )
 	{
 		focusedWindow = (unsigned long)pFocus->focusWindow->id();
 		focusedBaseAppId = pFocus->focusWindow->appID;
-		focusedAppId = pFocus->inputFocusWindow->appID;
+		// A focus window does not guarantee an input focus window.
+		if ( pFocus->inputFocusWindow )
+			focusedAppId = pFocus->inputFocusWindow->appID;
 		focused_display = get_win_display_name(pFocus->focusWindow);
 		sdFocusWindow_pid = pFocus->focusWindow->pid;
 	}

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -3983,7 +3983,10 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 
 		if ( !ctx->focus.overrideWindow || ctx->focus.overrideWindow != keyboardFocusWin )
 		{
-			XSetInputFocus(ctx->dpy, keyboardFocusWin->xwayland().id, RevertToNone, CurrentTime);
+			// Retargeting the toplevel would unfocus CEF's browser subwindow.
+			// A subwindow reverts to its parent so it can't strand focus on None.
+			int nRevertMode = keyboardFocusWindow == keyboardFocusWin->xwayland().id ? RevertToNone : RevertToParent;
+			XSetInputFocus(ctx->dpy, keyboardFocusWindow, nRevertMode, CurrentTime);
 
 			// wine >= 10.0 treats _NET_ACTIVE_WINDOW as foreground, so it must track real keyboard focus.
 			Window activeWindow = keyboardFocusWin->xwayland().id;
@@ -7776,7 +7779,9 @@ void xwayland_ctx_t::Dispatch()
 
 	if ( bSetFocus )
 	{
-		XSetInputFocus(ctx->dpy, ctx->currentKeyboardFocusWindow, RevertToNone, CurrentTime);
+		// A subwindow reverts to its parent so it can't strand focus on None.
+		bool bToplevel = find_win( ctx, ctx->currentKeyboardFocusWindow, false ) != nullptr;
+		XSetInputFocus(ctx->dpy, ctx->currentKeyboardFocusWindow, bToplevel ? RevertToNone : RevertToParent, CurrentTime);
 	}
 }
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -7679,8 +7679,9 @@ void xwayland_ctx_t::Dispatch()
 			{
 				steamcompmgr_win_t * w = find_win( ctx, ev.xfocus.window );
 
-				// If focus escaped the current desired keyboard focus window, check where it went
-				if ( w && w->xwayland().id == ctx->currentKeyboardFocusWindow )
+				// If focus escaped the current desired keyboard focus window, check where it went.
+				// The desired window may be a preserved subwindow, so also match it directly.
+				if ( w && ( ev.xfocus.window == ctx->currentKeyboardFocusWindow || w->xwayland().id == ctx->currentKeyboardFocusWindow ) )
 				{
 					Window newKeyboardFocus = None;
 					int nRevertMode = 0;
@@ -7691,9 +7692,9 @@ void xwayland_ctx_t::Dispatch()
 
 					if ( kbw )
 					{
-						if ( kbw->xwayland().id == ctx->currentKeyboardFocusWindow )
+						if ( kbw == find_win( ctx, ctx->currentKeyboardFocusWindow ) )
 						{
-							// focus went to a child, this is fine, make note of it in case we need to fix it
+							// focus stayed within the same toplevel, keep track of it
 							ctx->currentKeyboardFocusWindow = newKeyboardFocus;
 						}
 						else
@@ -7701,6 +7702,11 @@ void xwayland_ctx_t::Dispatch()
 							// focus went elsewhere, correct it
 							bSetFocus = true;
 						}
+					}
+					else if ( newKeyboardFocus == None )
+					{
+						// focus dropped to None, take it back
+						bSetFocus = true;
 					}
 				}
 


### PR DESCRIPTION
At startup, the breathing focus ring on the Steam home screen sometimes doesn't appear, and keyboard input goes nowhere. Flipping to a dialog and back fixes it. Whether it happens depends on startup timing, which made it unbisectable.

After adding a focus_info debug command, it showed that Steam's CEF takes input on a subwindow inside the toplevel, and focuses it with XSetInputFocus(RevertToParent). Since b471a05d, gamescope tracks that subwindow so no-op focus rerolls don't yank focus away from it, but the XSetInputFocus call itself still targeted the toplevel. When the focus apply path re-fires during startup churn after CEF has focused its subwindow, focus moves back to the toplevel. CEF sees FocusOut on its browser window, considers the context unfocused, and stops drawing the ring. Gamescope's bookkeeping already records the subwindow as focused, so it never re-applies, and the state sticks until something forces a new focus change.

Broken state info dump:

```
[gamescope] [Info]  focus: Server 0 keyboard focus: 0x1e00035 (Steam Big Picture Mode) revert=0 wanted=0x1400006
[gamescope] [Info]  focus:   Focus window: 0x1e00035 (Steam Big Picture Mode) appID=769
[gamescope] [Info]  focus:   Input focus window: 0x1e00035 (Steam Big Picture Mode) appID=769
[gamescope] [Info]  focus:   Override window: none
```

Working state with focus ring dump:

```
[gamescope] [Info]  focus: Server 0 keyboard focus: 0x1400006 (Steam Big Picture Mode) revert=2 wanted=0x1400006
[gamescope] [Info]  focus:   Focus window: 0x1e00035 (Steam Big Picture Mode) appID=769
[gamescope] [Info]  focus:   Input focus window: 0x1e00035 (Steam Big Picture Mode) appID=769
[gamescope] [Info]  focus:   Override window: none
```

To repro the original bug, the easiest way to do so is just continuously run a loop of `gamescope -e --xwayland-count 2 -- steam -steamdeck -steamos3 -steampal -gamepadui` and then if the focus ring appears after Steam loads, kill gamescope and run the command again. Usually within 5-10 tries you can hit this bug, but I've had it take up to 15 tries before. This series has survived 75 restarts here so far with nested gamescope, I'll verify on DRM backend tomorrow. 