### PR TITLE
Fix gamescope crash during Steam startup in Wayland backend

### DIFF
--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -147,10 +147,16 @@ namespace gamescope
         uint32_t uFractionalScale;
     };
 
-    inline WaylandPlaneState ClipPlane( const WaylandPlaneState &state )
+    inline std::optional<WaylandPlaneState> ClipPlane( const WaylandPlaneState &state )
     {
         int32_t nClippedDstWidth  = std::min<int32_t>( g_nOutputWidth,  state.nDstWidth  + state.nDestX ) - state.nDestX;
         int32_t nClippedDstHeight = std::min<int32_t>( g_nOutputHeight, state.nDstHeight + state.nDestY ) - state.nDestY;
+
+        // A plane that starts past the edge of the output clips away to nothing.
+        // Viewport source and destination sizes must be positive, so present no buffer at all.
+        if ( nClippedDstWidth <= 0 || nClippedDstHeight <= 0 )
+            return std::nullopt;
+
         double flClippedSrcWidth  = state.flSrcWidth  * ( nClippedDstWidth  / double( state.nDstWidth ) );
         double flClippedSrcHeight = state.flSrcHeight * ( nClippedDstHeight / double( state.nDstHeight ) );
 

--- a/src/Backends/WaylandBackend.cpp
+++ b/src/Backends/WaylandBackend.cpp
@@ -2821,6 +2821,25 @@ namespace gamescope
         return true;
     }
 
+    // The display connection is dead by the time we get here, so say why before we take the process with us.
+    static void LogDisplayError( const char *pszWhat, wl_display *pDisplay )
+    {
+        int nError = wl_display_get_error( pDisplay );
+
+        if ( nError == EPROTO )
+        {
+            const wl_interface *pInterface = nullptr;
+            uint32_t uId = 0;
+            uint32_t uCode = wl_display_get_protocol_error( pDisplay, &pInterface, &uId );
+
+            xdg_log.errorf( "%s: protocol error %u on %s@%u", pszWhat, uCode, pInterface ? pInterface->name : "<unknown>", uId );
+        }
+        else
+        {
+            xdg_log.errorf( "%s: %s", pszWhat, strerror( nError ) );
+        }
+    }
+
     void CWaylandInputThread::ThreadFunc()
     {
         m_bInitted.wait( false );
@@ -2831,6 +2850,7 @@ namespace gamescope
         int nFD = wl_display_get_fd( m_pBackend->GetDisplay() );
         if ( nFD < 0 )
         {
+            xdg_log.errorf( "Couldn't get Wayland display fd for input thread." );
             abort();
         }
 
@@ -2842,6 +2862,7 @@ namespace gamescope
         {
             if ( ( nRet = wl_display_dispatch_queue_pending( m_pBackend->GetDisplay(), m_pQueue ) ) < 0 )
             {
+                LogDisplayError( "Failed to dispatch input thread queue", m_pBackend->GetDisplay() );
                 abort();
             }
 
@@ -2850,6 +2871,7 @@ namespace gamescope
                 if ( errno == EAGAIN || errno == EINTR )
                     continue;
 
+                LogDisplayError( "Failed to prepare read of input thread queue", m_pBackend->GetDisplay() );
                 abort();
             }
 
@@ -2857,7 +2879,10 @@ namespace gamescope
             {
                 wl_display_cancel_read( m_pBackend->GetDisplay() );
                 if ( nRet < 0 )
+                {
+                    xdg_log.errorf_errno( "Input thread poll failed" );
                     abort();
+                }
 
                 assert( nRet == 0 );
                 continue;
@@ -2865,6 +2890,7 @@ namespace gamescope
 
             if ( ( nRet = wl_display_read_events( m_pBackend->GetDisplay() ) ) < 0 )
             {
+                LogDisplayError( "Failed to read events on input thread", m_pBackend->GetDisplay() );
                 abort();
             }
         }


### PR DESCRIPTION
Fixes a crash when moving a mouse cursor during Steam start-up in a nested Wayland session on KWin.