### PR TITLE
wlserver: Add missing cleanup for wayland surfaces

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8099,6 +8099,8 @@ void steamcompmgr_check_xdg(bool vblank, uint64_t vblank_idx)
 				pFocus->overrideWindow = nullptr;
 			if (pFocus->fadeWindow && pFocus->fadeWindow->type == steamcompmgr_win_type_t::XDG)
 				pFocus->fadeWindow = nullptr;
+			if (pFocus->keyboardFocusWindow && pFocus->keyboardFocusWindow->type == steamcompmgr_win_type_t::XDG)
+				pFocus->keyboardFocusWindow = nullptr;
 		}
 		g_steamcompmgr_xdg_wins = wlserver_get_xdg_shell_windows();
 		MakeFocusDirty();

--- a/src/wlserver.cpp
+++ b/src/wlserver.cpp
@@ -580,6 +580,26 @@ static void handle_wl_surface_commit( struct wl_listener *l, void *data )
 	xwayland_surface_commit(surf->wlr);
 }
 
+static void wlserver_xdg_surface_info_finish( struct wlserver_xdg_surface_info *info )
+{
+	{
+		std::unique_lock lock( g_wlserver_xdg_shell_windows_lock );
+		std::erase_if( wlserver.xdg_wins,
+			[=]( auto win ) { return win.get() == info->win; } );
+	}
+	wlserver.xdg_dirty = true;
+	info->win = nullptr;
+
+	info->xdg_surface = nullptr;
+	info->main_surface = nullptr;
+	info->layer_surface = nullptr;
+	info->mapped = false;
+
+	wl_list_remove( &info->map.link );
+	wl_list_remove( &info->unmap.link );
+	wl_list_remove( &info->destroy.link );
+}
+
 static void handle_wl_surface_destroy( struct wl_listener *l, void *data )
 {
 	wlserver_wl_surface_info *surf = wl_container_of( l, surf, destroy );
@@ -594,6 +614,12 @@ static void handle_wl_surface_destroy( struct wl_listener *l, void *data )
 		// wl_list_remove leaves stuff in a weird state, so we need to call
 		// this to re-init the list to avoid a crash.
 		wlserver_x11_surface_info_init(x11_surface, x11_surface->xwayland_server, x11_surface->x11_id);
+	}
+
+	if ( surf->xdg_surface )
+	{
+		wlserver_xdg_surface_info_finish( surf->xdg_surface );
+		surf->xdg_surface = nullptr;
 	}
 
 	if ( surf->wlr == wlserver.mouse_focus_surface )
@@ -1871,28 +1897,20 @@ static void waylandy_surface_destroy(struct wl_listener *listener, void *data) {
 	struct wlserver_xdg_surface_info* info =
 		wl_container_of(listener, info, destroy);
 
-	wlserver_wl_surface_info *wlserver_surface = get_wl_surface_info(info->main_surface);
-	if (!wlserver_surface)
-	{
-		wl_log.infof("No base surface info. (destroy)");
-		return;
+	wlserver_wl_surface_info *wlserver_surface = nullptr;
+
+	if (info->main_surface) {
+		if (wlserver.kb_focus_surface == info->main_surface)
+			wlserver.kb_focus_surface = nullptr;
+		if (wlserver.mouse_focus_surface == info->main_surface)
+			wlserver.mouse_focus_surface = nullptr;
+		wlserver_surface = get_wl_surface_info(info->main_surface);
 	}
 
-	{
-		std::unique_lock lock(g_wlserver_xdg_shell_windows_lock);
-		std::erase_if(wlserver.xdg_wins, [=](auto win) { return win.get() == info->win; });
-	}
-	info->main_surface = nullptr;
-	info->win = nullptr;
-	info->xdg_surface = nullptr;
-	info->layer_surface = nullptr;
-	info->mapped = false;
+	wlserver_xdg_surface_info_finish( info );
 
-	wl_list_remove(&info->map.link);
-	wl_list_remove(&info->unmap.link);
-	wl_list_remove(&info->destroy.link);
-
-	wlserver_surface->xdg_surface = nullptr;
+	if (wlserver_surface)
+		wlserver_surface->xdg_surface = nullptr;
 }
 
 void xdg_toplevel_new(struct wl_listener *listener, void *data)
@@ -2340,13 +2358,23 @@ void wlserver_keyboardfocus( struct wlr_surface *surface, bool bConstrain )
 	assert( wlserver_is_lock_held() );
 
 	if (wlserver.kb_focus_surface != surface) {
-		auto old_wl_surf = get_wl_surface_info( wlserver.kb_focus_surface );
-		if (old_wl_surf && old_wl_surf->xdg_surface && old_wl_surf->xdg_surface->xdg_surface && old_wl_surf->xdg_surface->xdg_surface->toplevel)
-			wlr_xdg_toplevel_set_activated(old_wl_surf->xdg_surface->xdg_surface->toplevel, false);
+		if ( wlserver.kb_focus_surface ) {
+			auto wl_surf = get_wl_surface_info( wlserver.kb_focus_surface );
+			if ( wl_surf && wl_surf->xdg_surface ) {
+				auto old_xdg = wlr_xdg_surface_try_from_wlr_surface( wlserver.kb_focus_surface );
+				if ( old_xdg && old_xdg->toplevel )
+					wlr_xdg_toplevel_set_activated( old_xdg->toplevel, false );
+			}
+		}
 
-		auto new_wl_surf = get_wl_surface_info( surface );
-		if (new_wl_surf && new_wl_surf->xdg_surface && new_wl_surf->xdg_surface->xdg_surface && new_wl_surf->xdg_surface->xdg_surface->toplevel)
-			wlr_xdg_toplevel_set_activated(new_wl_surf->xdg_surface->xdg_surface->toplevel, true);
+		if ( surface ) {
+			auto wl_surf = get_wl_surface_info( surface );
+			if ( wl_surf && wl_surf->xdg_surface ) {
+				auto new_xdg = wlr_xdg_surface_try_from_wlr_surface( surface );
+				if ( new_xdg && new_xdg->toplevel )
+					wlr_xdg_toplevel_set_activated( new_xdg->toplevel, true );
+			}
+		}
 	}
 
 	assert( wlserver.wlr.virtual_keyboard_device != nullptr );


### PR DESCRIPTION
A few surface lifecycle related fixes that I found while working on a bigger PR for `wlr_subcompositor`.

- Clean XDG surface when underlying wl_surface is destroyed
- Guard against null main_surface
- Check union type for wlr_xdg_surface::toplevel
- Clear keyboard focus for destroyed XDG windows