### PR TITLE
Steam overlay stutter fix

### DIFF
--- a/src/Utils/Process.cpp
+++ b/src/Utils/Process.cpp
@@ -269,6 +269,36 @@ namespace gamescope::Process
         }
     }
 
+    void RemoveSteamOverlayFromPreload()
+    {
+        const char *pszCurrentPreload = getenv( "LD_PRELOAD" );
+        if ( !pszCurrentPreload )
+            return;
+
+        std::vector<std::string_view> svLibraries = Split( pszCurrentPreload, " :" );
+        std::erase_if( svLibraries, []( std::string_view svPreload )
+        {
+            return svPreload.find( "gameoverlayrenderer.so" ) != std::string_view::npos;
+        });
+
+        std::string sNewPreload;
+        bool bFirst = true;
+        for ( std::string_view svLibrary : svLibraries )
+        {
+            if ( !bFirst )
+            {
+                sNewPreload.append( ":" );
+            }
+            bFirst = false;
+            sNewPreload.append( svLibrary );
+        }
+
+        if ( !sNewPreload.empty() )
+            setenv( "LD_PRELOAD", sNewPreload.c_str(), 1 );
+        else
+            unsetenv( "LD_PRELOAD" );
+    }
+
     pid_t SpawnProcess( char **argv, std::function<void()> fnPreambleInChild, bool bDoubleFork )
     {
         // Create a pipe for the child to return the grandchild's

--- a/src/Utils/Process.cpp
+++ b/src/Utils/Process.cpp
@@ -299,6 +299,53 @@ namespace gamescope::Process
             unsetenv( "LD_PRELOAD" );
     }
 
+    // Doubles as the guard that stops us from ever exec'ing twice.
+    static constexpr const char *k_pszStashedOverlayPreload = "GAMESCOPE_STEAM_OVERLAY_LD_PRELOAD";
+
+    void RestartWithoutSteamOverlay( char **argv )
+    {
+        if ( getenv( k_pszStashedOverlayPreload ) )
+            return;
+
+        const char *pszPreload = getenv( "LD_PRELOAD" );
+        if ( !pszPreload || std::string_view( pszPreload ).find( "gameoverlayrenderer.so" ) == std::string_view::npos )
+            return;
+
+        // A pointer from getenv does not survive setenv, so keep our own copy.
+        std::string sPreload = pszPreload;
+
+        if ( setenv( k_pszStashedOverlayPreload, sPreload.c_str(), 1 ) != 0 )
+        {
+            s_ProcessLog.errorf_errno( "Failed to stash the Steam overlay, keeping it loaded" );
+            return;
+        }
+        RemoveSteamOverlayFromPreload();
+
+        s_ProcessLog.infof( "Restarting ourselves to drop the Steam overlay from LD_PRELOAD." );
+        execv( "/proc/self/exe", argv );
+
+        // Still here, so put everything back and carry on with the overlay loaded.
+        s_ProcessLog.errorf_errno( "Failed to restart without the Steam overlay" );
+        setenv( "LD_PRELOAD", sPreload.c_str(), 1 );
+        unsetenv( k_pszStashedOverlayPreload );
+    }
+
+    bool RestoreSteamOverlayPreload()
+    {
+        const char *pszStashedPreload = getenv( k_pszStashedOverlayPreload );
+        if ( !pszStashedPreload )
+            return false;
+
+        std::string sPreload = pszStashedPreload;
+        if ( setenv( "LD_PRELOAD", sPreload.c_str(), 1 ) != 0 )
+            s_ProcessLog.errorf_errno( "Failed to pass the Steam overlay through to the application" );
+        else
+            s_ProcessLog.infof( "Passing the Steam overlay through to the application." );
+
+        unsetenv( k_pszStashedOverlayPreload );
+        return true;
+    }
+
     pid_t SpawnProcess( char **argv, std::function<void()> fnPreambleInChild, bool bDoubleFork )
     {
         // Create a pipe for the child to return the grandchild's

--- a/src/Utils/Process.h
+++ b/src/Utils/Process.h
@@ -31,6 +31,8 @@ namespace gamescope::Process
 
     void CloseAllFds( std::span<int> nExcludedFds );
 
+    void RemoveSteamOverlayFromPreload();
+
     pid_t SpawnProcess( char **argv, std::function<void()> fnPreambleInChild = nullptr, bool bDoubleFork = false );
     pid_t SpawnProcessInWatchdog( char **argv, bool bRespawn = false, std::function<void()> fnPreambleInChild = nullptr );
 

--- a/src/Utils/Process.h
+++ b/src/Utils/Process.h
@@ -33,6 +33,14 @@ namespace gamescope::Process
 
     void RemoveSteamOverlayFromPreload();
 
+    // Stashes the LD_PRELOAD we were launched with so a child that can draw the overlay
+    // gets handed it instead. Does nothing if we have no overlay or have already done this.
+    void RestartWithoutSteamOverlay( char **argv );
+
+    // Puts a stashed Steam overlay back into LD_PRELOAD for our children to inherit.
+    // Returns whether there was anything stashed to put back.
+    bool RestoreSteamOverlayPreload();
+
     pid_t SpawnProcess( char **argv, std::function<void()> fnPreambleInChild = nullptr, bool bDoubleFork = false );
     pid_t SpawnProcessInWatchdog( char **argv, bool bRespawn = false, std::function<void()> fnPreambleInChild = nullptr );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -445,6 +445,16 @@ static enum gamescope::GamescopeBackend parse_backend_name(const char *str)
 	}
 }
 
+static enum gamescope::GamescopeBackend auto_select_backend()
+{
+	if ( getenv( "WAYLAND_DISPLAY" ) != NULL )
+		return gamescope::GamescopeBackend::Wayland;
+	else if ( getenv( "DISPLAY" ) != NULL )
+		return gamescope::GamescopeBackend::SDL;
+	else
+		return gamescope::GamescopeBackend::DRM;
+}
+
 static int parse_integer(const char *str, const char *optionName)
 {
 	auto result = gamescope::Parse<int>(str);
@@ -718,8 +728,6 @@ int main(int argc, char **argv)
 
 	gamescope::GamescopeBackend eCurrentBackend = gamescope::GamescopeBackend::Auto;
 
-	gamescope::PrintVersion();
-
 	int o;
 	int opt_index = -1;
 	while ((o = getopt_long(argc, argv, gamescope_optstring, gamescope_options, &opt_index)) != -1)
@@ -776,10 +784,11 @@ int main(int argc, char **argv)
 			case 0: // long options without a short option
 				opt_name = gamescope_options[opt_index].name;
 				if (strcmp(opt_name, "help") == 0) {
+					gamescope::PrintVersion();
 					fprintf(stderr, "%s", usage);
 					return 0;
 				} else if (strcmp(opt_name, "version") == 0) {
-					// We always print the version to stderr anyway.
+					gamescope::PrintVersion();
 					return 0;
 				} else if (strcmp(opt_name, "debug-layers") == 0) {
 					g_bDebugLayers = true;
@@ -849,6 +858,17 @@ int main(int argc, char **argv)
 				return 1;
 		}
 	}
+
+	// Steam preloads its overlay into us, but only the SDL backend can draw it.
+	// A ConVar or script override comes too late to unload it.
+	gamescope::GamescopeBackend eLaunchBackend = eCurrentBackend;
+	if ( eLaunchBackend == gamescope::GamescopeBackend::Auto )
+		eLaunchBackend = auto_select_backend();
+	if ( eLaunchBackend != gamescope::GamescopeBackend::SDL )
+		gamescope::Process::RestartWithoutSteamOverlay( argv );
+
+	// Print this after the re-exec, so we only announce ourselves once.
+	gamescope::PrintVersion();
 
 	if ( gamescope::Process::HasCapSysNice() )
 	{
@@ -922,12 +942,7 @@ int main(int argc, char **argv)
 
 	if ( eCurrentBackend == gamescope::GamescopeBackend::Auto )
 	{
-		if ( g_pOriginalWaylandDisplay != NULL )
-			eCurrentBackend = gamescope::GamescopeBackend::Wayland;
-		else if ( g_pOriginalDisplay != NULL )
-			eCurrentBackend = gamescope::GamescopeBackend::SDL;
-		else
-			eCurrentBackend = gamescope::GamescopeBackend::DRM;
+		eCurrentBackend = auto_select_backend();
 	}
 
 	if ( g_pOriginalWaylandDisplay != NULL )

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8247,48 +8247,15 @@ static gamescope::ConVar<std::string> cv_mouse_relative_filter_appids( "mouse_re
 
 void LaunchNestedChildren( char **ppPrimaryChildArgv )
 {
-	std::string sNewPreload;
-	{
-		const char *pszCurrentPreload = getenv( "LD_PRELOAD" );
-		if ( pszCurrentPreload && *pszCurrentPreload )
-		{
-			// Remove gameoverlayrenderer.so from the child if Gamescope
-			// is running with a window + Vulkan swapchain (eg. SDL2 backend)
-			if ( GetBackend()->UsesVulkanSwapchain() )
-			{
-				std::vector<std::string_view> svLibraries = gamescope::Split( pszCurrentPreload, " :" );
-				std::erase_if( svLibraries, []( std::string_view svPreload )
-				{
-					return svPreload.find( "gameoverlayrenderer.so" ) != std::string_view::npos;
-				});
-
-				bool bFirst = true;
-				for ( std::string_view svLibrary : svLibraries )
-				{
-					if ( !bFirst )
-					{
-						sNewPreload.append( ":" );
-					}
-					bFirst = false;
-					sNewPreload.append( svLibrary );
-				}
-			}
-			else
-			{
-				sNewPreload = pszCurrentPreload;
-			}
-		}
-	}
-
 	// We could just run this inside the child process,
 	// but we might as well just run it here at this point.
 	// and affect all future child processes, without needing
 	// a pre-amble inside of them.
 	{
-		if ( !sNewPreload.empty() )
-			setenv( "LD_PRELOAD", sNewPreload.c_str(), 1 );
-		else
-			unsetenv( "LD_PRELOAD" );
+		// Remove gameoverlayrenderer.so from the child if Gamescope
+		// is running with a window + Vulkan swapchain (eg. SDL2 backend)
+		if ( GetBackend()->UsesVulkanSwapchain() )
+			gamescope::Process::RemoveSteamOverlayFromPreload();
 
 		unsetenv( "ENABLE_VKBASALT" );
 		// Enable Gamescope WSI by default for nested.

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8251,9 +8251,8 @@ void LaunchNestedChildren( char **ppPrimaryChildArgv )
 	// but we might as well just run it here at this point.
 	// and affect all future child processes.
 	{
-		// Remove gameoverlayrenderer.so from the child if Gamescope
-		// is running with a window + Vulkan swapchain (eg. SDL2 backend)
-		if ( GetBackend()->UsesVulkanSwapchain() )
+		// We draw the overlay ourselves when we present with a swapchain, otherwise the game does.
+		if ( !gamescope::Process::RestoreSteamOverlayPreload() && GetBackend()->UsesVulkanSwapchain() )
 			gamescope::Process::RemoveSteamOverlayFromPreload();
 
 		unsetenv( "ENABLE_VKBASALT" );

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -8249,8 +8249,7 @@ void LaunchNestedChildren( char **ppPrimaryChildArgv )
 {
 	// We could just run this inside the child process,
 	// but we might as well just run it here at this point.
-	// and affect all future child processes, without needing
-	// a pre-amble inside of them.
+	// and affect all future child processes.
 	{
 		// Remove gameoverlayrenderer.so from the child if Gamescope
 		// is running with a window + Vulkan swapchain (eg. SDL2 backend)
@@ -8293,7 +8292,8 @@ void LaunchNestedChildren( char **ppPrimaryChildArgv )
 	if ( g_bLaunchMangoapp )
 	{
 		char *ppMangoappArgv[] = { (char *)"mangoapp", NULL };
-		gamescope::Process::SpawnProcessInWatchdog( ppMangoappArgv, true );
+		// The Steam overlay would latch onto mangoapp's own swapchain as if it were the game.
+		gamescope::Process::SpawnProcessInWatchdog( ppMangoappArgv, true, gamescope::Process::RemoveSteamOverlayFromPreload );
 	}
 }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,11 +6,12 @@ foreach src : gamescope_core_src + ['Script/Script.cpp', 'convar_script.cpp']
 	unittest_src += srcdir / src
 endforeach
 
-test_convar = executable(
-	'test_convar',
-	unittest_src + ['test_convar.cpp'],
+gamescope_tests = executable(
+	'gamescope_tests',
+	unittest_src + ['test_convar.cpp', 'test_process.cpp'],
 	include_directories: [srcdir, sol2_include],
 	dependencies: [catch2_dep, luajit_dep, cap_dep, drm_dep, glm_dep, wlroots_dep],
 	cpp_args: gamescope_cpp_args,
 )
-test('convar', test_convar)
+test('convar', gamescope_tests, args: ['[convar]'])
+test('process', gamescope_tests, args: ['[process]'])

--- a/tests/test_process.cpp
+++ b/tests/test_process.cpp
@@ -1,0 +1,68 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <stdlib.h>
+
+#include <string>
+
+#include "Utils/Process.h"
+
+// Keep in sync with k_pszStashedOverlayPreload in Process.cpp.
+static constexpr const char *k_pszStashedOverlayPreload = "GAMESCOPE_STEAM_OVERLAY_LD_PRELOAD";
+
+static const char *k_pszOverlay = "/home/user/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so";
+
+static std::string GetEnv( const char *pszName )
+{
+	const char *pszValue = getenv( pszName );
+	REQUIRE( pszValue != nullptr );
+	return pszValue;
+}
+
+TEST_CASE("RemoveSteamOverlayFromPreload", "[process]") {
+	SECTION("does nothing when LD_PRELOAD is unset") {
+		unsetenv( "LD_PRELOAD" );
+		gamescope::Process::RemoveSteamOverlayFromPreload();
+		REQUIRE( getenv( "LD_PRELOAD" ) == nullptr );
+	}
+
+	SECTION("unsets LD_PRELOAD when the overlay is the only entry") {
+		setenv( "LD_PRELOAD", k_pszOverlay, 1 );
+		gamescope::Process::RemoveSteamOverlayFromPreload();
+		REQUIRE( getenv( "LD_PRELOAD" ) == nullptr );
+	}
+
+	SECTION("removes the overlay and keeps the other entries") {
+		setenv( "LD_PRELOAD", ( std::string{ "libfirst.so:" } + k_pszOverlay + ":liblast.so" ).c_str(), 1 );
+		gamescope::Process::RemoveSteamOverlayFromPreload();
+		REQUIRE( GetEnv( "LD_PRELOAD" ) == "libfirst.so:liblast.so" );
+	}
+
+	SECTION("handles space-separated lists") {
+		setenv( "LD_PRELOAD", ( std::string{ "libfirst.so " } + k_pszOverlay ).c_str(), 1 );
+		gamescope::Process::RemoveSteamOverlayFromPreload();
+		REQUIRE( GetEnv( "LD_PRELOAD" ) == "libfirst.so" );
+	}
+
+	SECTION("leaves the other entries alone when the overlay is absent") {
+		setenv( "LD_PRELOAD", "libfirst.so:liblast.so", 1 );
+		gamescope::Process::RemoveSteamOverlayFromPreload();
+		REQUIRE( GetEnv( "LD_PRELOAD" ) == "libfirst.so:liblast.so" );
+	}
+}
+
+TEST_CASE("RestoreSteamOverlayPreload", "[process]") {
+	SECTION("reports when there is nothing stashed") {
+		unsetenv( k_pszStashedOverlayPreload );
+		setenv( "LD_PRELOAD", "libuntouched.so", 1 );
+		REQUIRE( gamescope::Process::RestoreSteamOverlayPreload() == false );
+		REQUIRE( GetEnv( "LD_PRELOAD" ) == "libuntouched.so" );
+	}
+
+	SECTION("puts the stashed preload back and consumes the stash") {
+		setenv( k_pszStashedOverlayPreload, k_pszOverlay, 1 );
+		unsetenv( "LD_PRELOAD" );
+		REQUIRE( gamescope::Process::RestoreSteamOverlayPreload() == true );
+		REQUIRE( GetEnv( "LD_PRELOAD" ) == k_pszOverlay );
+		REQUIRE( getenv( k_pszStashedOverlayPreload ) == nullptr );
+	}
+}


### PR DESCRIPTION
Works around severe stutter after ~25 minutes playing S.T.A.L.K.E.R. 2: Heart of Chornobyl with `gamescope --hdr-enabled --mangoapp -h 2160 -w 5120 -f --force-grab-cursor --adaptive-sync -- %command%` with the Steam Overlay enabled, nested on a KDE Wayland session.

I confirmed Steam Recording, Steam Input, and Remote Play all still work, as well as loading the Vulkan validation layer in front of gamescope or a game. I also tested Renderdoc capture for running a game inside of gamescope, and it was still able to be enabled. 