### PR TITLE
rendervulkan: read capture back through a buffer on NVIDIA

### DIFF
--- a/src/pipewire.cpp
+++ b/src/pipewire.cpp
@@ -34,6 +34,9 @@ static uint32_t s_nCaptureHeight;
 static uint32_t s_nOutputWidth;
 static uint32_t s_nOutputHeight;
 
+// Readback mode the current SHM buffers were created with, -1 = no SHM buffers
+static int s_nNegotiatedReadback = -1;
+
 static void destroy_buffer(struct pipewire_buffer *buffer) {
 	assert(buffer->buffer == nullptr);
 
@@ -285,7 +288,9 @@ static void dispatch_nudge(struct pipewire_state *state, int fd)
 		s_nOutputHeight = g_nOutputHeight;
 		calculate_capture_size();
 	}
-	if (s_nCaptureWidth != state->video_info.size.width || s_nCaptureHeight != state->video_info.size.height) {
+	bool bReadbackChanged = s_nNegotiatedReadback >= 0 &&
+		s_nNegotiatedReadback != (int)vulkan_capture_prefers_readback();
+	if (s_nCaptureWidth != state->video_info.size.width || s_nCaptureHeight != state->video_info.size.height || bReadbackChanged) {
 		pwr_log.debugf("renegotiating stream params (size: %dx%d)", s_nCaptureWidth, s_nCaptureHeight);
 
 		uint8_t buf[4096];
@@ -294,6 +299,9 @@ static void dispatch_nudge(struct pipewire_state *state, int fd)
 		int ret = pw_stream_update_params(state->stream, format_params.data(), format_params.size());
 		if (ret < 0) {
 			pwr_log.errorf("pw_stream_update_params failed");
+		} else if (bReadbackChanged) {
+			// One attempt per readback flip, the peer may keep the current buffers
+			s_nNegotiatedReadback = (int)vulkan_capture_prefers_readback();
 		}
 	}
 
@@ -504,14 +512,23 @@ static void stream_handle_add_buffer(void *user_data, struct pw_buffer *pw_buffe
 
 	buffer->texture = new CVulkanTexture();
 	CVulkanTexture::createFlags screenshotImageFlags;
-	screenshotImageFlags.bMappable = true;
 	screenshotImageFlags.bTransferDst = true;
 	screenshotImageFlags.bStorage = true;
-	if (is_dmabuf || drmFormat == DRM_FORMAT_NV12)
+	if (!is_dmabuf && vulkan_capture_prefers_readback())
 	{
-		screenshotImageFlags.bExportable = true;
-		screenshotImageFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire
+		screenshotImageFlags.bReadback = true;
 	}
+	else
+	{
+		screenshotImageFlags.bMappable = true;
+		if (is_dmabuf || drmFormat == DRM_FORMAT_NV12)
+		{
+			screenshotImageFlags.bExportable = true;
+			screenshotImageFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire
+		}
+	}
+	if (!is_dmabuf)
+		s_nNegotiatedReadback = screenshotImageFlags.bReadback;
 	bool bImageInitSuccess = buffer->texture->BInit( s_nCaptureWidth, s_nCaptureHeight, 1u, drmFormat, screenshotImageFlags );
 	if ( !bImageInitSuccess )
 	{
@@ -595,6 +612,7 @@ static void stream_handle_remove_buffer(void *data, struct pw_buffer *pw_buffer)
 {
 	struct pipewire_buffer *buffer = (struct pipewire_buffer *) pw_buffer->user_data;
 
+	s_nNegotiatedReadback = -1;
 	buffer->buffer = nullptr;
 
 	if (!buffer->copying) {

--- a/src/rendervulkan.cpp
+++ b/src/rendervulkan.cpp
@@ -422,6 +422,7 @@ bool CVulkanDevice::selectPhysDev(VkSurfaceKHR surface)
 
 	VkPhysicalDeviceProperties props;
 	vk.GetPhysicalDeviceProperties( m_physDev, &props );
+	m_vendorID = props.vendorID;
 	vk_log.infof( "selecting physical device '%s': queue family %x (general queue family %x)", props.deviceName, m_queueFamily, m_generalQueueFamily );
 
 	return true;
@@ -1823,6 +1824,68 @@ void CVulkanCmdBuffer::copyImage(gamescope::Rc<CVulkanTexture> src, gamescope::R
 	m_textureRefs.emplace_back(std::move(dst));
 }
 
+void CVulkanCmdBuffer::copyImageToReadback(gamescope::Rc<CVulkanTexture> src)
+{
+	assert(src->isReadback());
+	prepareSrcImage(src.get());
+	insertBarrier();
+
+	if (src->isYcbcr())
+	{
+		VkBufferImageCopy regions[2] = {
+			{
+				.bufferOffset = src->lumaOffset(),
+				.bufferRowLength = src->lumaRowPitch(),
+				.imageSubresource = {
+					.aspectMask = VK_IMAGE_ASPECT_PLANE_0_BIT,
+					.layerCount = 1
+				},
+				.imageExtent = {
+					.width = src->width(),
+					.height = src->height(),
+					.depth = 1
+				},
+			},
+			{
+				.bufferOffset = src->chromaOffset(),
+				// bufferRowLength is in texels and chroma texels are 2 bytes wide.
+				.bufferRowLength = src->chromaRowPitch() / 2,
+				.imageSubresource = {
+					.aspectMask = VK_IMAGE_ASPECT_PLANE_1_BIT,
+					.layerCount = 1
+				},
+				.imageExtent = {
+					.width = (src->width() + 1) / 2,
+					.height = (src->height() + 1) / 2,
+					.depth = 1
+				},
+			},
+		};
+
+		m_device->vk.CmdCopyImageToBuffer(m_cmdBuffer, src->vkImage(), VK_IMAGE_LAYOUT_GENERAL, src->readbackBuffer(), 2, regions);
+	}
+	else
+	{
+		VkBufferImageCopy region = {
+			.bufferOffset = 0,
+			.bufferRowLength = src->rowPitch() / DRMFormatGetBPP(src->drmFormat()),
+			.imageSubresource = {
+				.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+				.layerCount = 1
+			},
+			.imageExtent = {
+				.width = src->width(),
+				.height = src->height(),
+				.depth = 1
+			},
+		};
+
+		m_device->vk.CmdCopyImageToBuffer(m_cmdBuffer, src->vkImage(), VK_IMAGE_LAYOUT_GENERAL, src->readbackBuffer(), 1, &region);
+	}
+
+	m_textureRefs.emplace_back(std::move(src));
+}
+
 void CVulkanCmdBuffer::copyBufferToImage(VkBuffer buffer, VkDeviceSize offset, uint32_t stride, gamescope::Rc<CVulkanTexture> dst)
 {
 	prepareDestImage(dst.get());
@@ -2051,6 +2114,11 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 	if ( flags.bFlippable == true )
 	{
 		flags.bExportable = true;
+	}
+
+	if ( flags.bReadback == true )
+	{
+		flags.bTransferSrc = true;
 	}
 
 	if ( flags.bTransferSrc == true )
@@ -2589,6 +2657,77 @@ bool CVulkanTexture::BInit( uint32_t width, uint32_t height, uint32_t depth, uin
 			m_pMappedData = (uint8_t*)pData;
 		}
 	}
+
+	if ( flags.bReadback )
+	{
+		VkDeviceSize readbackSize;
+		if ( isYcbcr() )
+		{
+			m_lumaOffset = 0;
+			m_lumaPitch = width;
+			m_chromaOffset = width * height;
+			m_chromaPitch = ((width + 1) / 2) * 2;
+			readbackSize = VkDeviceSize(width) * height + VkDeviceSize(m_chromaPitch) * ((height + 1) / 2);
+		}
+		else
+		{
+			m_unRowPitch = width * DRMFormatGetBPP( drmFormat );
+			readbackSize = VkDeviceSize(m_unRowPitch) * height;
+		}
+
+		VkBufferCreateInfo bufferCreateInfo = {
+			.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+			.size = readbackSize,
+			.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+			.sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+		};
+		res = g_device.vk.CreateBuffer( g_device.device(), &bufferCreateInfo, nullptr, &m_vkReadbackBuffer );
+		if ( res != VK_SUCCESS )
+		{
+			vk_errorf( res, "vkCreateBuffer failed for readback buffer" );
+			return false;
+		}
+
+		VkMemoryRequirements bufMemRequirements;
+		g_device.vk.GetBufferMemoryRequirements( g_device.device(), m_vkReadbackBuffer, &bufMemRequirements );
+
+		int32_t memTypeIndex = g_device.findMemoryType( VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, bufMemRequirements.memoryTypeBits );
+		if ( memTypeIndex == -1 )
+			memTypeIndex = g_device.findMemoryType( VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, bufMemRequirements.memoryTypeBits );
+		if ( memTypeIndex == -1 )
+		{
+			vk_log.errorf( "findMemoryType failed for readback buffer" );
+			return false;
+		}
+
+		VkMemoryAllocateInfo readbackAllocInfo = {
+			.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+			.allocationSize = bufMemRequirements.size,
+			.memoryTypeIndex = uint32_t(memTypeIndex),
+		};
+		res = g_device.vk.AllocateMemory( g_device.device(), &readbackAllocInfo, nullptr, &m_vkReadbackMemory );
+		if ( res != VK_SUCCESS )
+		{
+			vk_errorf( res, "vkAllocateMemory failed for readback buffer" );
+			return false;
+		}
+
+		res = g_device.vk.BindBufferMemory( g_device.device(), m_vkReadbackBuffer, m_vkReadbackMemory, 0 );
+		if ( res != VK_SUCCESS )
+		{
+			vk_errorf( res, "vkBindBufferMemory failed for readback buffer" );
+			return false;
+		}
+
+		void *pData = nullptr;
+		res = g_device.vk.MapMemory( g_device.device(), m_vkReadbackMemory, 0, VK_WHOLE_SIZE, 0, &pData );
+		if ( res != VK_SUCCESS )
+		{
+			vk_errorf( res, "vkMapMemory failed for readback buffer" );
+			return false;
+		}
+		m_pMappedData = (uint8_t*)pData;
+	}
 	
 	m_bInitialized = true;
 	
@@ -2688,6 +2827,21 @@ CVulkanTexture::CVulkanTexture( void )
 CVulkanTexture::~CVulkanTexture( void )
 {
 	wlr_dmabuf_attributes_finish( &m_dmabuf );
+
+	if ( m_vkReadbackBuffer != VK_NULL_HANDLE )
+	{
+		g_device.vk.DestroyBuffer( g_device.device(), m_vkReadbackBuffer, nullptr );
+		m_vkReadbackBuffer = VK_NULL_HANDLE;
+
+		if ( m_pMappedData != nullptr )
+		{
+			g_device.vk.UnmapMemory( g_device.device(), m_vkReadbackMemory );
+			m_pMappedData = nullptr;
+		}
+
+		g_device.vk.FreeMemory( g_device.device(), m_vkReadbackMemory, nullptr );
+		m_vkReadbackMemory = VK_NULL_HANDLE;
+	}
 
 	if ( m_pMappedData != nullptr && m_vkImageMemory )
 	{
@@ -3623,7 +3777,7 @@ void vulkan_garbage_collect( void )
 	g_device.garbageCollect();
 }
 
-static gamescope::Rc<CVulkanTexture> acquire_pooled_texture( auto& pool, uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace )
+static gamescope::Rc<CVulkanTexture> acquire_pooled_texture( auto& pool, uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace, bool bDeviceLocal = false )
 {
 	for (auto& pTexture : pool)
 	{
@@ -3631,7 +3785,8 @@ static gamescope::Rc<CVulkanTexture> acquire_pooled_texture( auto& pool, uint32_
 		if (pTexture && pTexture->GetRefCount() == 0 &&
 			(width != pTexture->width() ||
 			 height != pTexture->height() ||
-			 drmFormat != pTexture->drmFormat()))
+			 drmFormat != pTexture->drmFormat() ||
+			 bDeviceLocal != (pTexture->mappedData() == nullptr)))
 		{
 			pTexture = nullptr;
 		}
@@ -3641,13 +3796,16 @@ static gamescope::Rc<CVulkanTexture> acquire_pooled_texture( auto& pool, uint32_
 			pTexture = new CVulkanTexture();
 
 			CVulkanTexture::createFlags textureFlags;
-			textureFlags.bMappable = true;
 			textureFlags.bTransferDst = true;
 			textureFlags.bStorage = true;
 			textureFlags.bSampled = true; // required for RGB-to-NV12 shader to sample this texture
-			if (exportable || drmFormat == DRM_FORMAT_NV12) {
-				textureFlags.bExportable = true;
-				textureFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire
+			if ( !bDeviceLocal )
+			{
+				textureFlags.bMappable = true;
+				if (exportable || drmFormat == DRM_FORMAT_NV12) {
+					textureFlags.bExportable = true;
+					textureFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire
+				}
 			}
 
 			bool bSuccess = pTexture->BInit( width, height, 1u, drmFormat, textureFlags );
@@ -3659,7 +3817,8 @@ static gamescope::Rc<CVulkanTexture> acquire_pooled_texture( auto& pool, uint32_
 		if (pTexture->GetRefCount() != 0 ||
 			width != pTexture->width() ||
 			height != pTexture->height() ||
-			drmFormat != pTexture->drmFormat())
+			drmFormat != pTexture->drmFormat() ||
+			bDeviceLocal != (pTexture->mappedData() == nullptr))
 			continue;
 
 		return pTexture.get();
@@ -3676,9 +3835,9 @@ gamescope::Rc<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, 
 	return texture;
 }
 
-gamescope::Rc<CVulkanTexture> vulkan_acquire_capture_texture(uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace)
+gamescope::Rc<CVulkanTexture> vulkan_acquire_capture_texture(uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace, bool bDeviceLocal)
 {
-	auto texture = acquire_pooled_texture(g_output.pCaptureTextures, width, height, exportable, drmFormat, colorspace);
+	auto texture = acquire_pooled_texture(g_output.pCaptureTextures, width, height, exportable, drmFormat, colorspace, bDeviceLocal);
 	if (!texture)
 		vk_log.errorf("Unable to acquire capture texture. Out of textures.");
 	return texture;
@@ -3690,14 +3849,14 @@ uint32_t vulkan_get_rgb10_capture_format( void )
 {
 	static uint32_t s_uFormat = []()
 	{
-		// Pooled capture textures are mappable, hence linear-tiled.
+		// Check both tilings, direct capture textures are linear and readback ones optimal
 		VkFormatProperties props;
 		g_device.vk.GetPhysicalDeviceFormatProperties( g_device.physDev(), VK_FORMAT_A2R10G10B10_UNORM_PACK32, &props );
 		constexpr VkFormatFeatureFlags uNeeded = VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
-		if ( ( props.linearTilingFeatures & uNeeded ) == uNeeded )
+		if ( ( props.linearTilingFeatures & props.optimalTilingFeatures & uNeeded ) == uNeeded )
 			return DRM_FORMAT_XRGB2101010;
 
-		vk_log.infof( "XRGB2101010 lacks linear storage/sampled support, capturing as XBGR2101010" );
+		vk_log.infof( "XRGB2101010 lacks storage/sampled support, capturing as XBGR2101010" );
 		return DRM_FORMAT_XBGR2101010;
 	}();
 	return s_uFormat;
@@ -3974,6 +4133,9 @@ std::optional<uint64_t> vulkan_screenshot( const struct FrameInfo_t *frameInfo, 
 
 	cmdBuffer->dispatch(div_roundup(currentOutputWidth, pixelsPerGroup), div_roundup(currentOutputHeight, pixelsPerGroup));
 
+	if ( pScreenshotTexture->isReadback() )
+		cmdBuffer->copyImageToReadback(pScreenshotTexture);
+
 	if ( pYUVOutTexture != nullptr )
 	{
 		float scale = (float)pScreenshotTexture->width() / pYUVOutTexture->width();
@@ -4003,10 +4165,26 @@ std::optional<uint64_t> vulkan_screenshot( const struct FrameInfo_t *frameInfo, 
 		const int dispatchSize = pixelsPerGroup * 2;
 
 		cmdBuffer->dispatch(div_roundup(pYUVOutTexture->width(), dispatchSize), div_roundup(pYUVOutTexture->height(), dispatchSize));
+
+		if ( pYUVOutTexture->isReadback() )
+			cmdBuffer->copyImageToReadback(pYUVOutTexture);
 	}
 
 	uint64_t sequence = g_device.submit(std::move(cmdBuffer));
 	return sequence;
+}
+
+gamescope::ConVar<int> cv_capture_readback{ "capture_readback", -1,
+	"Keep PipeWire capture images device-local and read back through a buffer. "
+	"-1 = auto (NVIDIA), 0 = never, 1 = always" };
+
+bool vulkan_capture_prefers_readback( void )
+{
+	if ( cv_capture_readback >= 0 )
+		return cv_capture_readback != 0;
+	// NVIDIA maps host-visible memory GPU-uncached on both the proprietary
+	// driver and NVK, so shader stores to it become uncoalesced PCIe writes
+	return g_device.vendorID() == 0x10de; /* NVIDIA */
 }
 
 extern std::string g_reshade_effect;
@@ -4235,6 +4413,9 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 
 			cmdBuffer->dispatch(div_roundup(pPipewireTexture->width(), dispatchSize), div_roundup(pPipewireTexture->height(), dispatchSize));
 		}
+
+		if ( pPipewireTexture->isReadback() )
+			cmdBuffer->copyImageToReadback(pPipewireTexture);
 	}
 
 	uint64_t sequence = g_device.submit(std::move(cmdBuffer));

--- a/src/rendervulkan.hpp
+++ b/src/rendervulkan.hpp
@@ -142,6 +142,7 @@ public:
 			bExportable = false;
 			bOutputImage = false;
 			bColorAttachment = false;
+			bReadback = false;
 			imageType = VK_IMAGE_TYPE_2D;
 		}
 
@@ -155,6 +156,9 @@ public:
 		bool bExportable : 1;
 		bool bOutputImage : 1;
 		bool bColorAttachment : 1;
+		// Device-local image with a host-visible readback buffer. mappedData()
+		// and the plane offsets/pitches describe the buffer.
+		bool bReadback : 1;
 		VkImageType imageType;
 	};
 
@@ -191,6 +195,9 @@ public:
 	inline uint32_t lumaRowPitch() const { return m_lumaPitch; }
 	inline uint32_t chromaOffset() const { return m_chromaOffset; }
 	inline uint32_t chromaRowPitch() const { return m_chromaPitch; }
+
+	inline bool isReadback() const { return m_vkReadbackBuffer != VK_NULL_HANDLE; }
+	inline VkBuffer readbackBuffer() const { return m_vkReadbackBuffer; }
 
 	inline EStreamColorspace streamColorspace() const { return m_streamColorspace; }
 	inline void setStreamColorspace(EStreamColorspace colorspace) { m_streamColorspace = colorspace; }
@@ -232,6 +239,9 @@ private:
 
 	uint32_t m_unRowPitch = 0;
 	VkDeviceSize m_size = 0;
+
+	VkBuffer m_vkReadbackBuffer = VK_NULL_HANDLE;
+	VkDeviceMemory m_vkReadbackMemory = VK_NULL_HANDLE;
 
 	uint32_t m_lumaOffset = 0;
 	uint32_t m_lumaPitch = 0;
@@ -413,7 +423,8 @@ std::optional<uint64_t> vulkan_composite( struct FrameInfo_t *frameInfo, gamesco
 void vulkan_wait( uint64_t ulSeqNo, bool bReset );
 gamescope::Rc<CVulkanTexture> vulkan_get_last_output_image( bool partial, bool defer );
 gamescope::Rc<CVulkanTexture> vulkan_acquire_screenshot_texture(uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace = k_EStreamColorspace_Unknown);
-gamescope::Rc<CVulkanTexture> vulkan_acquire_capture_texture(uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace = k_EStreamColorspace_Unknown);
+gamescope::Rc<CVulkanTexture> vulkan_acquire_capture_texture(uint32_t width, uint32_t height, bool exportable, uint32_t drmFormat, EStreamColorspace colorspace = k_EStreamColorspace_Unknown, bool bDeviceLocal = false);
+bool vulkan_capture_prefers_readback(void);
 uint32_t vulkan_get_rgb10_capture_format( void );
 
 void vulkan_present_to_window( void );
@@ -685,6 +696,7 @@ static inline uint32_t div_roundup(uint32_t x, uint32_t y)
 	VK_FUNC(CmdBindPipeline) \
 	VK_FUNC(CmdClearColorImage) \
 	VK_FUNC(CmdCopyBufferToImage) \
+	VK_FUNC(CmdCopyImageToBuffer) \
 	VK_FUNC(CmdCopyImage) \
 	VK_FUNC(CmdDispatch) \
 	VK_FUNC(CmdDraw) \
@@ -808,6 +820,7 @@ public:
 	inline bool hasDrmPrimaryDevId() {return m_bHasDrmPrimaryDevId;}
 	inline dev_t primaryDevId() {return m_drmPrimaryDevId;}
 	inline bool supportsFp16() {return m_bSupportsFp16;}
+	inline uint32_t vendorID() {return m_vendorID;}
 	inline std::vector<VkExtensionProperties>& supportedExtensions() {return m_supportedExts;}
 
 	inline std::pair<void *, uint32_t> uploadBufferData(uint32_t size)
@@ -865,6 +878,7 @@ protected:
 
 	uint32_t m_queueFamily = -1;
 	uint32_t m_generalQueueFamily = -1;
+	uint32_t m_vendorID = 0;
 
 	int m_drmRendererFd = -1;
 	dev_t m_drmPrimaryDevId = 0;
@@ -950,6 +964,7 @@ public:
 	void bindPipeline(VkPipeline pipeline);
 	void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1);
 	void copyImage(gamescope::Rc<CVulkanTexture> src, gamescope::Rc<CVulkanTexture> dst);
+	void copyImageToReadback(gamescope::Rc<CVulkanTexture> src);
 	void copyBufferToImage(VkBuffer buffer, VkDeviceSize offset, uint32_t stride, gamescope::Rc<CVulkanTexture> dst);
 
 

--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -2422,7 +2422,7 @@ static void paint_pipewire()
 	}
 
 	gamescope::Rc<CVulkanTexture> pRGBTexture = s_pPipewireBuffer->texture->isYcbcr()
-		? vulkan_acquire_capture_texture( uWidth, uHeight, false, vulkan_get_rgb10_capture_format() )
+		? vulkan_acquire_capture_texture( uWidth, uHeight, false, vulkan_get_rgb10_capture_format(), k_EStreamColorspace_Unknown, vulkan_capture_prefers_readback() )
 		: gamescope::Rc<CVulkanTexture>{ s_pPipewireBuffer->texture };
 
 	gamescope::Rc<CVulkanTexture> pYUVTexture = s_pPipewireBuffer->texture->isYcbcr() ? s_pPipewireBuffer->texture : nullptr;


### PR DESCRIPTION
On NVIDIA, the capture path's RGB->NV12 shader stores into the host-visible linear PipeWire texture go out at a few hundred MB/s, so one 5120x2160 frame takes ~65ms regardless of GPU clocks. paint_pipewire blocks on that work in the compositor thread, capping the whole session at ~15fps whenever recording or Remote Play is active.

Keep capture images device-local and move them into a host-visible buffer with the copy engine. Both the proprietary driver and NVK map host-visible system memory GPU-uncached, so shader stores bypass the GPU L2 and cross PCIe as individual snooped transactions that nothing coalesces. The copy engine moves the same data in large bursts and does not share the problem. Key on the vendor ID since the behavior is common to both drivers, and this fix results in a >10x speedup for the capture path on my 5090.