### PR TITLE
drm: put the cursor plane behind a drm_cursor_plane convar

### DIFF
--- a/src/Backends/DRMBackend.cpp
+++ b/src/Backends/DRMBackend.cpp
@@ -55,12 +55,11 @@
 
 #include "gamescope-control-protocol.h"
 
-static constexpr bool k_bUseCursorPlane = false;
-
 extern int g_nPreferredOutputWidth;
 extern int g_nPreferredOutputHeight;
 
 gamescope::ConVar<bool> cv_drm_single_plane_optimizations( "drm_single_plane_optimizations", true, "Whether or not to enable optimizations for single plane usage." );
+gamescope::ConVar<bool> cv_drm_cursor_plane( "drm_cursor_plane", false, "Scan out the cursor with the DRM cursor plane instead of forcing composition while a cursor is visible. Known driver issues on AMDGPU." );
 
 gamescope::ConVar<bool> cv_drm_debug_disable_shaper_and_3dlut( "drm_debug_disable_shaper_and_3dlut", false, "Shaper + 3DLUT chicken bit. (Force disable/DEFAULT, no logic change)" );
 gamescope::ConVar<bool> cv_drm_debug_disable_degamma_tf( "drm_debug_disable_degamma_tf", false, "Degamma chicken bit. (Forces DEGAMMA_TF to DEFAULT, does not affect other logic)" );
@@ -3605,7 +3604,7 @@ namespace gamescope
 			bNeedsFullComposite |= pFrameInfo->useNISLayer0;
 			bNeedsFullComposite |= pFrameInfo->blurLayer0;
 			bNeedsFullComposite |= bNeedsCompositeFromFilter;
-			bNeedsFullComposite |= !k_bUseCursorPlane && bDrewCursor;
+			bNeedsFullComposite |= !cv_drm_cursor_plane && bDrewCursor;
 			bNeedsFullComposite |= g_bColorSliderInUse;
 			bNeedsFullComposite |= pFrameInfo->bFadingOut;
 			bNeedsFullComposite |= !g_reshade_effect.empty();
@@ -3986,7 +3985,7 @@ namespace gamescope
 
 		virtual glm::uvec2 CursorSurfaceSize( glm::uvec2 uvecSize ) const override
 		{
-			if ( !k_bUseCursorPlane )
+			if ( !cv_drm_cursor_plane )
 				return uvecSize;
 
 			return glm::uvec2{ g_DRM.cursor_width, g_DRM.cursor_height };


### PR DESCRIPTION
Addresses the cursor show/hide stutter in #1056.

With the cursor plane hardcoded off, any visible hardware cursor forces a full composition, and the scanout <-> composite transitions at cursor show/hide drop frames.

Measured on the embedded DRM backend (Intel i915, UHD 620, 1080p60, 60fps client, per-frame instrumentation):

- Every cursor **show** missed exactly one vblank: a 33.3 ms frame delta at each of 15/15 transitions. The first composited frame takes 21.7 ms median wakeup-to-flip against a ~7.3 ms scanout-sized budget; the GPU compose alone is 15.6 ms cold vs 8.2 ms steady (idle-GPU clock ramp), and the vblank timer only learns about compositing one frame late (`UpdateWasCompositing` is called during Present).
- Cursor **hide** on i915 costs nothing extra, the longer first scanout frame is pure flip-wait. The hide-side hitches reported on Deck are presumably the AMDGPU plane-programming cost stacked on this.
- With the cursor plane enabled: 30+ show/hide cycles, direct scanout throughout, p99 frame delta 16.91 ms, zero dropped frames. It also avoids the composite scaling blur while a cursor is visible, reported later in that thread.

The change replaces the `k_bUseCursorPlane` constant with a `drm_cursor_plane` convar, default **off** = no behavior change.

Testers can enable it with `gamescopectl drm_cursor_plane 1` or from a config script (`gamescope.convars.drm_cursor_plane.value = true`).

Would be great to get Deck/AMDGPU testing behind this convar to see where the driver issues stand today.