### PR TITLE
BufferMemo: do not assert when a destroyed buffer still has texture r…

### DIFF
--- a/src/BufferMemo.cpp
+++ b/src/BufferMemo.cpp
@@ -31,7 +31,10 @@ namespace gamescope
 
     void CBufferMemo::OnBufferDestroyed( void *pUserData )
     {
-        assert( m_pVulkanTexture->GetRefCount() == 0 );
+        // A pending render command buffer can still reference the texture and keep it alive, so just drop our private reference here.
+        if ( m_pVulkanTexture->GetRefCount() != 0 )
+            memo_log.debugf( "Buffer destroyed with %u live texture references, unmemoizing anyway", m_pVulkanTexture->GetRefCount() );
+
         m_pMemoizer->UnmemoizeBuffer( m_pBuffer );
     }
 


### PR DESCRIPTION
…eferences

When a client commits a new frame, wlroots frees the previous buffer and emits its destroy signal on the wlserver thread. A pending render command buffer on the steamcompmgr thread can still hold a public reference to that buffer's texture until it is garbage collected, so OnBufferDestroyed runs with a non-zero reference count and aborts.

That outstanding reference keeps the texture and its imported memory alive on its own, so unmemoizing the buffer here is safe. Drop the assert and unmemoize unconditionally.