### PR TITLE
subprojects: Bump wlroots to 0.20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           pacman-key --init
           pacman -Syu --noconfirm
-          pacman -S --noconfirm git meson clang glslang libcap wlroots0.19 \
+          pacman -S --noconfirm git meson clang glslang libcap wlroots0.20 \
             sdl2 vulkan-headers libx11 libxmu libxcomposite libxrender libxres \
             libxtst libxkbcommon libdrm libinput wayland-protocols benchmark \
             xorg-xwayland pipewire cmake \

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,8 +25,8 @@ pixman_dep = dependency('pixman-1')
 udev_dep = dependency('libudev')
 
 wlroots_dep = dependency(
-  'wlroots-0.19',
-  version: ['>= 0.19.0', '< 0.20.0'],
+  'wlroots-0.20',
+  version: ['>= 0.20.0', '< 0.21.0'],
   fallback: 'wlroots',
   default_options: ['default_library=static', 'examples=false', 'xwayland=enabled', 'backends=libinput', 'renderers=[]', 'allocators=[]', 'session=enabled'],
 )


### PR DESCRIPTION
wlroots 0.19 was removed from Arch Linux on 2026-08-15 (https://gitlab.archlinux.org/archlinux/packaging/state/-/commit/bb93f52d3df)