### PR TITLE
steamcompmgr: stop nudging the focus window

### DIFF
--- a/src/steamcompmgr.cpp
+++ b/src/steamcompmgr.cpp
@@ -4022,14 +4022,6 @@ void xwayland_ctx_t::DetermineAndApplyFocus( const std::vector< steamcompmgr_win
 	if ( ctx->list[0].xwayland().id != inputFocus->xwayland().id )
 		inputFocus->Raise();
 
-	if (!ctx->focus.focusWindow->nudged)
-	{
-		Rect rect = ctx->focus.focusWindow->GetGeometry();
-		XMoveWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, rect.nX + 1, rect.nY + 1);
-		XMoveWindow(ctx->dpy, ctx->focus.focusWindow->xwayland().id, rect.nX, rect.nY);
-		ctx->focus.focusWindow->nudged = true;
-	}
-
 	// X confines the pointer to the screen, so a screen-sized focus window only
 	// sees all of it at the origin. Place it there once, a client that moves it
 	// afterwards keeps its position. Oversized windows stay put, clients centre
@@ -5229,7 +5221,6 @@ add_win(xwayland_ctx_t *ctx, Window id, Window prev, unsigned long sequence)
 	new_win->skipPager = false;
 	new_win->requestedWidth = 0;
 	new_win->requestedHeight = 0;
-	new_win->nudged = false;
 	new_win->placed = false;
 	new_win->ignoreOverrideRedirect = false;
 

--- a/src/steamcompmgr_shared.hpp
+++ b/src/steamcompmgr_shared.hpp
@@ -150,7 +150,6 @@ struct steamcompmgr_win_t {
 
 	bool bHasHadNonSRGBColorSpace = false;
 
-	bool nudged = false;
 	bool placed = false;
 	bool ignoreOverrideRedirect = false;
 


### PR DESCRIPTION
The nudge dates back to the first commit and was half of a pair. It moved a newly focused window off its position so that the snap on the next line would move it back to (0, 0). a563226d431d dropped that snap so windows keep the position they ask for, and 33f3776918b8 turned the nudge into a round trip on the client's own position so it no longer parks windows on (1, 1). The only thing it still forces is undoing a client configure that is in flight when we nudge, and the round trip is two real moves that the client sees.

Wine turns each of them into a WM_MOVE. League of Evil (491060) stops its sound on WM_MOVE and only resumes it on WM_EXITSIZEMOVE, which never arrives because the window is not being dragged, so the game runs silent until the player changes the resolution in its options.

Drop the nudge, and with it the last placement gamescope imposes on a window smaller than the screen.